### PR TITLE
Prepare paper-pptx 0.1.0 PyPI release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     tags:
       # Publish on any tag starting with a `v`, e.g., v1.2.3
@@ -27,11 +26,15 @@ jobs:
         run: uv python install 3.13
       - name: Build
         run: uv build
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          package_version="$(uv run --isolated --no-project python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          test "${GITHUB_REF_NAME}" = "v${package_version}"
       # Check that basic features work and we didn't miss to include crucial files
       - name: Smoke test (wheel)
         run: uv run --isolated --no-project --with dist/*.whl python -c "import pptx; print(pptx.__paper_version__)"
       - name: Smoke test (source distribution)
         run: uv run --isolated --no-project --with dist/*.tar.gz python -c "import pptx; print(pptx.__paper_version__)"
       - name: Publish
-        if: ${{ vars.PUBLISH_ENABLED == 'true' }}
         run: uv publish

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ compatibility.
 
 ## Installation
 
-This repository is private for now and publication to PyPI is gated. Install from Git:
+Install from PyPI:
 
 ```bash
-pip install "paper-pptx @ git+https://github.com/The-LLM-Data-Company/paper-pptx.git@main"
+pip install paper-pptx
 ```
 
 Verify the install:


### PR DESCRIPTION
## Summary
- make releases tag-only and publish without the obsolete repository-variable gate
- reject tags that do not match the package version
- update installation instructions for the production PyPI package

## Verification
- built wheel and source distribution
- installed the wheel in an isolated environment
- verified `pptx.__paper_version__ == "0.1.0"` and upstream `pptx.__version__ == "1.0.2"`
- validated workflow YAML and tag/version guard