### PR TITLE
Release paper-pptx 0.1.2: practical hardening

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,17 @@
 Release History
 ---------------
 
-paper-pptx 0.1.1 (unreleased)
+paper-pptx 0.1.2 (2026-07-12)
+++++++++++++++++++++++++++++++++
+
+- Make failed multi-part edits restore the original live object graph and package bytes.
+- Reject stale targets, shared mutable chart data, unsafe relationship aliases, and foreign
+  source-package ownership before mutation.
+- Preserve document-wide identities during cloning and composition.
+- Correct field, line-break, inherited-formatting, and exact-package diff reporting.
+- Make ordinary path and seekable-stream saves refusal-atomic.
+
+paper-pptx 0.1.1 (2026-07-11)
 ++++++++++++++++++++++++++++++++
 
 - Add bounded, unambiguous ZIP intake and atomic ordinary path saves.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ preserves the millions of existing snippets and model priors that use
 
 - GitHub repository / PyPI distribution: **`paper-pptx`**
 - Python import: **`pptx`**
-- Fork sentinel: `pptx.__paper_version__ = "0.1.1"`
+- Fork sentinel: `pptx.__paper_version__ = "0.1.2"`
 - Upstream base: python-pptx `v1.0.2` (git tag `paper-base`)
 
 New upstream releases are merged, never rebased, so the fork retains its history and

--- a/hardening_proposal.md
+++ b/hardening_proposal.md
@@ -1,0 +1,132 @@
+# paper-pptx Practical Hardening Proposal
+
+## Objective
+
+Harden the operations that professionals rely on when editing an existing presentation: replace content, modify structure, compose decks, inspect the result, and save it without damaging unrelated content.
+
+This proposal is intentionally narrow. It includes only failures that can produce a wrong deck, an incomplete rollback, a misleading result, or an invalid package during practical use. It does not attempt to reject every theoretically malformed XML shape or defend every unsupported manipulation of private internals.
+
+## Release standard
+
+For the operations covered here, `paper-pptx` should meet three requirements:
+
+1. Validate the complete operation before changing the presentation.
+2. On refusal, restore the original live object graph as well as the serialized package.
+3. On success, preserve unrelated presentation content and report the change accurately.
+
+## Proposed work
+
+### 1. Make failed edits genuinely atomic
+
+Some multi-part operations can fail after changing XML elements, relationships, or binary part data. Restoring only serialized bytes is insufficient because callers may continue using existing `Presentation`, slide, shape, chart, or table objects after the refusal.
+
+Implement one transaction boundary for public mutators that:
+
+- captures every XML tree, relationship collection, and mutable binary part involved in the operation;
+- performs candidate-package validation without mutating the candidate or the live presentation;
+- restores the original live objects and cached proxies when validation or serialization fails; and
+- supports nested operations without taking a stale snapshot or partially committing an inner operation.
+
+This is the highest-priority item because atomic refusal is part of the package's central contract. A banker or lawyer should be able to catch a typed refusal and continue working with the same in-memory presentation safely.
+
+**Acceptance criteria**
+
+- Injected failures at each mutation and save stage leave both the in-memory presentation and the file on disk unchanged.
+- Existing slide, shape, table, picture, and chart proxies either remain valid or refuse as stale; they never silently edit detached XML.
+- Custom XML and binary parts are restored along with standard PowerPoint parts.
+
+### 2. Protect relationship and shared-part integrity
+
+PowerPoint objects are connected by package relationships. An edit that validates only the visible XML can leave a dangling reference, preserve an unintended alias, or overwrite data shared by another object.
+
+Before picture replacement, chart-data replacement, slide or layout deletion, and related package surgery:
+
+- require relationship IDs in XML and relationship collections to agree;
+- verify that the target part has the expected type and ownership;
+- detect additional relationships that alias the same slide, layout, image, chart, or embedded workbook;
+- refuse in-place replacement when an embedded workbook or other mutable part is shared by another object; and
+- remove relationships only after proving that no surviving XML references them.
+
+This prevents decks that open successfully while a chart points at inconsistent workbook data, an image reference is dangling, or supposedly deleted content remains hidden in the package.
+
+**Acceptance criteria**
+
+- Saving after each supported edit produces no dangling internal relationship.
+- Replacing one chart's data cannot alter another chart through a shared embedded workbook.
+- Deleting a slide or layout either removes its complete owned subgraph or refuses before mutation.
+
+### 3. Reject stale editing targets
+
+Long-running workflows commonly retain references to slides and shapes while other operations restructure the deck. A proxy whose XML node has been replaced or detached must not appear to succeed while changing content that will not be saved.
+
+Add consistent ownership checks to public mutators for slides, layouts, shapes, text frames, tables, pictures, charts, and header/footer objects. The check must prove that the proxy still identifies the active object in the current presentation, not merely that it once belonged to the same package.
+
+**Acceptance criteria**
+
+- Mutating a detached or superseded proxy raises a typed refusal before changing any state.
+- Normal proxies remain usable after unrelated edits.
+- Composition, rebind, clone, and deletion operations explicitly invalidate only the proxies they replace.
+
+### 4. Make inspection and diff results trustworthy
+
+Inspection and verification are decision inputs for automated workflows. Missing inherited formatting, notes, geometry changes, or source-package changes can cause a caller to approve the wrong deck.
+
+Harden the existing inspection and diff APIs so that they:
+
+- resolve effective text and shape properties from the correct placeholder, layout, master, and theme chain;
+- report provenance without silently choosing among ambiguous sources;
+- include supported notes, tables, charts, images, fields, and inherited geometry consistently;
+- compare the actual supplied packages rather than accidentally reusing live or cached state; and
+- refuse malformed or ambiguous structures when a deterministic answer is unavailable.
+
+The goal is not broader reporting. It is that every value already promised by the APIs is complete and dependable enough to drive an automated review step.
+
+**Acceptance criteria**
+
+- Golden fixtures cover inherited formatting, notes, tables, chart data, images, fields, slide movement, layout rebinding, and geometry changes.
+- Repeating inspection or diffing produces deterministic output.
+- Diffing two paths, streams, or live presentations compares those exact inputs and restores stream positions afterward.
+
+### 5. Preserve identity and ownership during deck surgery
+
+Slide cloning, cross-deck import, layout rebinding, and structural deletion touch many related parts. Incorrect identity remapping or incomplete dependency analysis can create duplicate creation IDs, shared mutable content, or references back to the source package.
+
+For these operations:
+
+- inventory the full relationship subgraph before mutation;
+- assign unique document-wide identities to every independently copied object and part;
+- preserve shared immutable media only when the selected policy permits it;
+- ensure copied mutable parts are independent;
+- validate slide, layout, master, notes, comments, charts, and embedded-workbook ownership; and
+- refuse unsupported reconciliation before adding any destination parts.
+
+**Acceptance criteria**
+
+- Imported or cloned slides have no relationship to the source package after the operation.
+- Independently copied parts never receive duplicate document-wide creation IDs.
+- Editing a cloned or imported chart, image, note, or table does not change its source counterpart.
+- A failed compose, clone, rebind, or delete operation leaves the destination byte-identical and its existing proxies usable.
+
+## Verification required for release
+
+The implementation should be delivered as small commits organized by the five workstreams above. Each commit should include a regression test that fails against `v0.1.1` and passes with the fix.
+
+Before release:
+
+- run the complete Paper contract suite and inherited `python-pptx` suite;
+- build the wheel and source distribution from a clean checkout;
+- install the wheel into an empty environment and run the import doctor;
+- exercise representative inspect, replace, clone, compose, diff, refuse, and save workflows;
+- open every resulting fixture with both PowerPoint-compatible package validation and the LibreOffice load smoke; and
+- confirm refusal atomicity for in-memory objects, output paths, and file-like streams.
+
+## Explicitly out of scope
+
+- Exhaustive validation of every malformed OOXML permutation.
+- New authoring features or new public APIs.
+- SmartArt, animation, transition, rendering, or slide-size migration work.
+- Refactors whose only benefit is cleaner internal architecture.
+- Additional refusal cases that require deliberate mutation of private attributes and cannot affect supported public workflows.
+- Documentation, CI, packaging, or install changes unless required to test and ship one of the correctness fixes above.
+
+These exclusions are deliberate. The target is a smaller, reviewable hardening release that materially reduces the chance of silent damage in real presentation workflows.

--- a/src/pptx/_ownership.py
+++ b/src/pptx/_ownership.py
@@ -19,3 +19,49 @@ def require_shape_attached(shape, *, argument: str = "shape") -> None:
         raise TargetNotFoundError(
             "%s is stale: its shape was removed from the presentation" % argument
         )
+    require_part_reachable(shape.part, argument=argument)
+
+
+def require_element_attached(element, part, *, argument: str) -> None:
+    """Refuse an element detached from the active root of its remembered part."""
+    from pptx.errors import TargetNotFoundError
+
+    root = element
+    while root is not None and root.getparent() is not None:
+        root = root.getparent()
+    if root is not getattr(part, "_element", None):
+        raise TargetNotFoundError(
+            "%s is stale: its content was removed from the presentation" % argument
+        )
+    require_part_reachable(part, argument=argument)
+
+
+def require_shape_tree_attached(shapes, *, argument: str = "target shape tree") -> None:
+    """Refuse a shape collection that no longer wraps its part's active tree."""
+    from pptx.errors import TargetNotFoundError
+
+    spTree = getattr(shapes, "_spTree", None)
+    part = shapes.part
+    require_element_attached(spTree, part, argument=argument)
+    live_spTree = part._element.cSld.spTree
+    if spTree is not live_spTree:
+        raise TargetNotFoundError(
+            "%s is stale: it is no longer the part's active shape tree" % argument
+        )
+
+
+def require_part_reachable(part, *, argument: str) -> None:
+    """Refuse a part proxy no longer reachable from its package root."""
+    from pptx.errors import TargetNotFoundError, UnsupportedStructureError
+
+    try:
+        reachable = any(candidate is part for candidate in part.package.iter_parts())
+    except (AssertionError, AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise UnsupportedStructureError(
+            "cannot verify %s ownership because the package relationship graph is broken (%s)"
+            % (argument, exc)
+        ) from exc
+    if not reachable:
+        raise TargetNotFoundError(
+            "%s is stale: its package part is no longer in the presentation" % argument
+        )

--- a/src/pptx/_transaction.py
+++ b/src/pptx/_transaction.py
@@ -486,7 +486,7 @@ class PackageTransaction:
 
     def _validate_candidate(self) -> None:
         """Validate the complete candidate using the ordinary-save output contract."""
-        validation_state = _ValidationReadState(self, snapshot_all_xml=False)
+        validation_state = _ValidationReadState(self)
         self._stage_and_reopen_candidate()
         cleanup_failures = validation_state.restore(force_element_restore=False)
         if cleanup_failures:
@@ -499,13 +499,21 @@ class PackageTransaction:
             )
 
     def _stage_and_reopen_candidate(self) -> None:
-        """Serialize privately and validate the candidate through the ordinary loader."""
+        """Serialize privately and validate through the public presentation loader."""
         from io import BytesIO
+
+        from pptx.api import Presentation
+        from pptx.errors import UnsupportedStructureError
 
         candidate = BytesIO()
         self._package.save(candidate)
         candidate.seek(0)
-        type(self._package).open(candidate)
+        try:
+            Presentation(candidate)
+        except Exception as exc:
+            raise UnsupportedStructureError(
+                "transaction candidate is not a reopenable PowerPoint presentation (%s)" % exc
+            ) from exc
 
     def _validated_reachable_part_dicts(
         self, package_dict: dict

--- a/src/pptx/_transaction.py
+++ b/src/pptx/_transaction.py
@@ -1,0 +1,604 @@
+"""Proxy-preserving rollback for paper-pptx package mutations."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from pptx.opc.package import OpcPackage
+
+
+_ACTIVE_TRANSACTIONS: ContextVar[tuple[object, ...]] = ContextVar(
+    "paper_pptx_active_transactions", default=()
+)
+
+
+class TransactionRollbackError(RuntimeError):
+    """A mutation failed and one or more rollback steps also failed.
+
+    This is deliberately not a ``PaperRefusal``. Once exact restoration cannot be
+    established, callers must treat the package as unsafe rather than interpreting the
+    operation as an atomic refusal.
+    """
+
+    def __init__(
+        self,
+        original_exception: BaseException,
+        failures: Iterable[tuple[str, BaseException]],
+    ):
+        self.original_exception = original_exception
+        self.failures = tuple(failures)
+        details = "; ".join(
+            "%s: %s(%s)" % (label, type(error).__name__, self._safe_message(error))
+            for label, error in self.failures
+        )
+        super().__init__(
+            "package rollback failed after %s: %d restore step(s) failed (%s)"
+            % (
+                type(original_exception).__name__,
+                len(self.failures),
+                details,
+            )
+        )
+
+    @staticmethod
+    def _safe_message(error: BaseException) -> str:
+        """Return an exception message without trusting the exception's formatter."""
+        try:
+            return str(error)
+        except BaseException as formatting_error:
+            return "<unprintable; __str__ raised %s>" % type(formatting_error).__name__
+
+
+class _ElementTreeState:
+    """Original element objects and scalar state for one XML part."""
+
+    def __init__(self, root):
+        from lxml import etree
+
+        self._root = root
+        self._serialized = etree.tostring(root, encoding="UTF-8", standalone=True)
+        self._original_prefixes = tuple(
+            sorted(
+                {
+                    prefix
+                    for element in root.iter()
+                    for prefix in element.nsmap
+                    if prefix is not None
+                }
+            )
+        )
+        self._records = tuple(
+            (
+                element,
+                element.tag,
+                dict(element.attrib),
+                etree._Element.text.__get__(element),
+                etree._Element.tail.__get__(element),
+                tuple(element),
+            )
+            for element in root.iter()
+        )
+
+    def restore(self) -> None:
+        """Restore the tree using the original nodes so existing proxies stay valid."""
+        from lxml import etree
+
+        original_elements = {record[0] for record in self._records}
+
+        # Detach all current children first. This removes newly-created subtrees and
+        # frees original nodes to be placed back under their original parents.
+        for element, _, _, _, _, _ in self._records:
+            for child in list(element):
+                element.remove(child)
+        for element in original_elements:
+            if element is self._root:
+                continue
+            parent = element.getparent()
+            if parent is not None:
+                parent.remove(element)
+
+        for element, tag, attributes, text, tail, _ in self._records:
+            if isinstance(tag, str) and element.tag != tag:
+                element.tag = tag
+            if dict(element.attrib) != attributes:
+                element.attrib.clear()
+                element.attrib.update(attributes)
+            # Some oxml classes override `.text` with a domain property lacking a
+            # setter. Address the underlying lxml descriptors directly.
+            if etree._Element.text.__get__(element) != text:
+                etree._Element.text.__set__(element, text)
+            if etree._Element.tail.__get__(element) != tail:
+                etree._Element.tail.__set__(element, tail)
+        for element, _, _, _, _, children in self._records:
+            for child in children:
+                element.append(child)
+
+        # lxml retains namespace declarations introduced by a removed namespaced
+        # attribute. Remove only declarations that are now unused, preserving every
+        # prefix that existed before the transaction. Exact verification below remains
+        # authoritative for declarations cleanup cannot restore in place.
+        if self.current_serialized != self._serialized:
+            etree.cleanup_namespaces(
+                self._root, keep_ns_prefixes=self._original_prefixes
+            )
+
+    @property
+    def current_serialized(self) -> bytes:
+        """Current part serialization in the same form used by ``XmlPart.blob``."""
+        from lxml import etree
+
+        return etree.tostring(self._root, encoding="UTF-8", standalone=True)
+
+    @property
+    def is_exact(self) -> bool:
+        """Whether serialization, scalar state, children, and original nodes all match."""
+        if self.current_serialized != self._serialized:
+            return False
+        from lxml import etree
+
+        return all(
+            element.tag == tag
+            and dict(element.attrib) == attributes
+            and etree._Element.text.__get__(element) == text
+            and etree._Element.tail.__get__(element) == tail
+            and tuple(element) == children
+            for element, tag, attributes, text, tail, children in self._records
+        )
+
+
+class _ObjectGraphState:
+    """Mutable state reachable through existing package and caller proxy caches."""
+
+    def __init__(self, roots: Iterable[object]):
+        from lxml import etree
+
+        from pptx.opc.package import OpcPackage, Part
+
+        self._instance_states: list[tuple[object, dict]] = []
+        self._container_states: list[tuple[object, object]] = []
+        seen: set[int] = set()
+        stack = list(roots)
+
+        while stack:
+            value = stack.pop()
+            value_id = id(value)
+            if value_id in seen:
+                continue
+            seen.add(value_id)
+
+            if isinstance(value, (str, bytes, int, float, bool, type(None))):
+                continue
+            if isinstance(value, (OpcPackage, Part, etree._Element)):
+                continue
+            if isinstance(value, bytearray):
+                self._container_states.append((value, bytes(value)))
+                continue
+            if isinstance(value, dict):
+                before = dict(value)
+                self._container_states.append((value, before))
+                stack.extend(before.keys())
+                stack.extend(before.values())
+                continue
+            if isinstance(value, list):
+                before = tuple(value)
+                self._container_states.append((value, before))
+                stack.extend(before)
+                continue
+            if isinstance(value, set):
+                before = set(value)
+                self._container_states.append((value, before))
+                stack.extend(before)
+                continue
+            if isinstance(value, (tuple, frozenset)):
+                stack.extend(value)
+                continue
+
+            # Proxy and collaborator objects in this package use ``__dict__`` for
+            # lazy-property and performance caches. Avoid walking arbitrary user objects.
+            if not type(value).__module__.startswith("pptx.") or not hasattr(value, "__dict__"):
+                continue
+            before = dict(value.__dict__)
+            self._instance_states.append((value, before))
+            stack.extend(before.values())
+
+    def restore(self) -> list[tuple[str, BaseException]]:
+        """Restore every cached instance and container, returning all failures."""
+        failures: list[tuple[str, BaseException]] = []
+        for instance, before in self._instance_states:
+            try:
+                PackageTransaction._restore_instance_dict(instance, before)
+            except BaseException as error:
+                failures.append((self._label("object", instance), error))
+        for container, before in self._container_states:
+            try:
+                self._restore_container(container, before)
+            except BaseException as error:
+                failures.append((self._label("container", container), error))
+        return failures
+
+    @staticmethod
+    def _label(kind: str, value: object) -> str:
+        """Return a stable diagnostic label for one in-memory restore target."""
+        cls = type(value)
+        return "%s %s.%s@0x%x" % (kind, cls.__module__, cls.__qualname__, id(value))
+
+    @staticmethod
+    def _restore_container(container: object, before: object) -> None:
+        """Restore one supported mutable container without replacing its identity."""
+        if isinstance(container, dict):
+            container.clear()
+            container.update(before)
+        elif isinstance(container, (bytearray, list)):
+            container[:] = before
+        else:
+            container.clear()
+            container.update(before)
+
+
+class _ValidationReadState:
+    """Live structural state restored after serialization-only reads.
+
+    Save preflight can materialize lazy caches, and a custom ``XmlPart.blob`` getter can mutate
+    its live element. Capturing both object state and original element nodes allows those read-side
+    effects to be removed without undoing edits made before this snapshot.
+    """
+
+    def __init__(
+        self,
+        transaction: "PackageTransaction",
+        roots: Iterable[object] = (),
+        *,
+        snapshot_all_xml: bool = True,
+    ):
+        from pptx.opc.package import XmlPart
+
+        self._transaction = transaction
+        package = transaction._package
+        self._package_dict = dict(package.__dict__)
+        self._part_states = []
+        graph_roots = list(self._package_dict.values())
+        for part, part_dict in transaction._validated_reachable_part_dicts(
+            self._package_dict
+        ):
+            element_state = (
+                _ElementTreeState(part._element)
+                if isinstance(part, XmlPart)
+                and (snapshot_all_xml or type(part).blob is not XmlPart.blob)
+                else None
+            )
+            part_label = str(part_dict.get("_partname", type(part).__name__))
+            self._part_states.append((part, part_dict, element_state, part_label))
+            graph_roots.extend(part_dict.values())
+        graph_roots.extend(roots)
+        self._object_graph_state = _ObjectGraphState(graph_roots)
+
+    def restore(
+        self, *, force_element_restore: bool = True
+    ) -> list[tuple[str, BaseException]]:
+        """Restore captured live state, returning every cleanup failure."""
+        failures: list[tuple[str, BaseException]] = []
+        failed_xml_state_ids: set[int] = set()
+        for _, _, element_state, part_label in self._part_states:
+            if element_state is None:
+                continue
+            try:
+                if force_element_restore or not element_state.is_exact:
+                    element_state.restore()
+            except BaseException as error:
+                failed_xml_state_ids.add(id(element_state))
+                failures.append(("XML part %s" % part_label, error))
+
+        for part, part_dict, _, part_label in self._part_states:
+            try:
+                PackageTransaction._restore_instance_dict(part, part_dict)
+            except BaseException as error:
+                failures.append(("part %s" % part_label, error))
+        try:
+            PackageTransaction._restore_instance_dict(
+                self._transaction._package, self._package_dict
+            )
+        except BaseException as error:
+            failures.append(("package", error))
+        failures.extend(self._object_graph_state.restore())
+
+        for _, _, element_state, part_label in self._part_states:
+            if element_state is None or id(element_state) in failed_xml_state_ids:
+                continue
+            try:
+                if not element_state.is_exact:
+                    raise RuntimeError("XML serialization or node identity differs after restore")
+            except BaseException as error:
+                failures.append(("XML part %s" % part_label, error))
+        return failures
+
+
+class PackageTransaction:
+    """Restore a package's original live graph if the guarded operation raises."""
+
+    def __init__(self, package: "OpcPackage", *roots: object):
+        self._package = package
+        self._roots = tuple(roots)
+        self._package_dict = {}
+        self._part_states = []
+        self._object_graph_state = None
+        self._context_token = None
+        self._is_outermost = False
+
+        # Preserve constructor-time refusal for malformed relationships and signatures without
+        # freezing rollback state before the context is actually entered.
+        self._validated_reachable_part_dicts(dict(package.__dict__))
+
+    def __enter__(self) -> "PackageTransaction":
+        if self._context_token is not None:
+            raise RuntimeError("PackageTransaction cannot be entered more than once")
+        self._capture_entry_snapshot()
+        active = _ACTIVE_TRANSACTIONS.get()
+        self._is_outermost = not any(
+            transaction._package is self._package
+            for transaction in active
+            if isinstance(transaction, PackageTransaction)
+        )
+        self._context_token = _ACTIVE_TRANSACTIONS.set(active + (self,))
+        return self
+
+    def _capture_entry_snapshot(self) -> None:
+        """Capture rollback state at context entry and reverse blob-getter read effects."""
+        from pptx.opc.package import XmlPart
+
+        state = _ValidationReadState(self, self._roots)
+        payloads = []
+        try:
+            for part, _, element_state, _ in state._part_states:
+                payloads.append(
+                    element_state._serialized
+                    if element_state is not None and type(part).blob is XmlPart.blob
+                    else bytes(part.blob)
+                )
+        except BaseException as error:
+            cleanup_failures = state.restore(force_element_restore=False)
+            if cleanup_failures:
+                raise TransactionRollbackError(error, cleanup_failures) from error
+            raise
+
+        cleanup_failures = state.restore(force_element_restore=False)
+        if cleanup_failures:
+            snapshot_error = RuntimeError(
+                "transaction snapshot serialization changed live state and cleanup failed"
+            )
+            raise TransactionRollbackError(snapshot_error, cleanup_failures) from snapshot_error
+
+        self._package_dict = state._package_dict
+        self._part_states = [
+            (part, part_dict, element_state, payload, part_label)
+            for (part, part_dict, element_state, part_label), payload in zip(
+                state._part_states, payloads
+            )
+        ]
+        self._object_graph_state = state._object_graph_state
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        token = self._context_token
+        if token is None:
+            raise RuntimeError("PackageTransaction exited without being entered")
+        active = _ACTIVE_TRANSACTIONS.get()
+        if not active or active[-1] is not self:
+            raise RuntimeError("PackageTransaction contexts exited out of order")
+        try:
+            if exc_type is not None:
+                assert exc_value is not None
+                self._rollback(exc_value)
+                return False
+            if not self._is_outermost:
+                return False
+            try:
+                self._validate_candidate()
+            except BaseException as validation_error:
+                self._rollback(validation_error)
+                raise
+            return False
+        finally:
+            _ACTIVE_TRANSACTIONS.reset(token)
+            self._context_token = None
+
+    def _rollback(self, original_exception: BaseException) -> None:
+        """Restore the pre-transaction graph or raise a loud rollback failure."""
+        assert self._object_graph_state is not None
+        failures: list[tuple[str, BaseException]] = []
+        failed_xml_state_ids: set[int] = set()
+
+        # Restore every independent state even when an earlier target is hostile. A
+        # partial best effort is still valuable, but it is never presented as atomic.
+        for _, _, element_state, _, part_label in self._part_states:
+            if element_state is None:
+                continue
+            try:
+                element_state.restore()
+            except BaseException as error:
+                failed_xml_state_ids.add(id(element_state))
+                failures.append(("XML part %s" % part_label, error))
+
+        for part, part_dict, _, _, part_label in self._part_states:
+            try:
+                self._restore_instance_dict(part, part_dict)
+            except BaseException as error:
+                failures.append(("part %s" % part_label, error))
+
+        try:
+            self._restore_instance_dict(self._package, self._package_dict)
+        except BaseException as error:
+            failures.append(("package", error))
+
+        failures.extend(self._object_graph_state.restore())
+        for part, _, element_state, expected_payload, part_label in self._part_states:
+            if element_state is not None:
+                if id(element_state) in failed_xml_state_ids:
+                    continue
+                try:
+                    if not element_state.is_exact:
+                        raise RuntimeError("XML serialization differs after rollback")
+                    restored_payload = bytes(part.blob)
+                    if restored_payload != expected_payload:
+                        raise RuntimeError(
+                            "XML payload differs after rollback (%d bytes before, %d after)"
+                            % (len(expected_payload), len(restored_payload))
+                        )
+                except BaseException as error:
+                    failures.append(("XML part %s" % part_label, error))
+                finally:
+                    # A custom blob getter can itself mutate the live element. Restore the
+                    # original nodes again after observing its save-visible payload.
+                    try:
+                        element_state.restore()
+                        if not element_state.is_exact:
+                            raise RuntimeError(
+                                "XML serialization or node identity differs after payload "
+                                "verification"
+                            )
+                    except BaseException as error:
+                        failures.append(("XML part %s" % part_label, error))
+                continue
+            try:
+                restored_payload = bytes(part.blob)
+                if restored_payload != expected_payload:
+                    raise RuntimeError(
+                        "binary payload differs after rollback (%d bytes before, %d after)"
+                        % (len(expected_payload), len(restored_payload))
+                    )
+            except BaseException as error:
+                failures.append(("binary part %s" % part_label, error))
+
+        # Payload getters can also materialize caches or mutate supported collaborators. Remove
+        # those verification-only effects before deciding whether rollback was exact.
+        for part, part_dict, _, _, part_label in self._part_states:
+            try:
+                self._restore_instance_dict(part, part_dict)
+            except BaseException as error:
+                failures.append(("part %s after payload verification" % part_label, error))
+        try:
+            self._restore_instance_dict(self._package, self._package_dict)
+        except BaseException as error:
+            failures.append(("package after payload verification", error))
+        failures.extend(self._object_graph_state.restore())
+        if failures:
+            raise TransactionRollbackError(original_exception, failures) from original_exception
+
+    def _validate_candidate(self) -> None:
+        """Validate the complete candidate using the ordinary-save output contract."""
+        validation_state = _ValidationReadState(self, snapshot_all_xml=False)
+        self._stage_and_reopen_candidate()
+        cleanup_failures = validation_state.restore(force_element_restore=False)
+        if cleanup_failures:
+            raise RuntimeError(
+                "candidate validation changed live package state and cleanup failed (%s)"
+                % "; ".join(
+                    "%s: %s" % (label, type(error).__name__)
+                    for label, error in cleanup_failures
+                )
+            )
+
+    def _stage_and_reopen_candidate(self) -> None:
+        """Serialize privately and validate the candidate through the ordinary loader."""
+        from io import BytesIO
+
+        candidate = BytesIO()
+        self._package.save(candidate)
+        candidate.seek(0)
+        type(self._package).open(candidate)
+
+    def _validated_reachable_part_dicts(
+        self, package_dict: dict
+    ) -> list[tuple[object, dict]]:
+        """Return reachable part states after raw graph and signature validation."""
+        from pptx.errors import UnsupportedStructureError
+        from pptx.opc.constants import CONTENT_TYPE as CT
+
+        signature_content_types = {
+            CT.OPC_DIGITAL_SIGNATURE_CERTIFICATE,
+            CT.OPC_DIGITAL_SIGNATURE_ORIGIN,
+            CT.OPC_DIGITAL_SIGNATURE_XMLSIGNATURE,
+        }
+        part_states = []
+        seen_part_ids: set[int] = set()
+        pending = list(self._internal_targets(package_dict))
+        while pending:
+            part = pending.pop()
+            part_id = id(part)
+            if part_id in seen_part_ids:
+                continue
+            seen_part_ids.add(part_id)
+            part_dict = dict(part.__dict__)
+            if part_dict.get("_content_type") in signature_content_types:
+                raise UnsupportedStructureError(
+                    "mutating a digitally signed presentation would invalidate its OPC "
+                    "signature; remove or re-sign it with a signature-aware tool first"
+                )
+            part_states.append((part, part_dict))
+            pending.extend(self._internal_targets(part_dict))
+        return part_states
+
+    def _internal_targets(self, owner_state: dict) -> list[object]:
+        """Return internal target parts without evaluating any lazy properties."""
+        from pptx.errors import RelationshipPolicyError, UnsupportedStructureError
+        from pptx.opc.constants import RELATIONSHIP_TARGET_MODE as RTM
+        from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+        from pptx.opc.package import Part
+
+        targets = []
+        seen_relationship_collections: set[int] = set()
+        for key in ("_rels", "rels"):
+            relationships = owner_state.get(key)
+            if relationships is None or id(relationships) in seen_relationship_collections:
+                continue
+            seen_relationship_collections.add(id(relationships))
+            relationship_map = getattr(relationships, "__dict__", {}).get("_rels")
+            if relationship_map is None:
+                continue
+            if not isinstance(relationship_map, dict):
+                raise RelationshipPolicyError(
+                    "relationship collection on %s is malformed"
+                    % owner_state.get("_partname", "/")
+                )
+            for relationship in relationship_map.values():
+                relationship_state = getattr(relationship, "__dict__", {})
+                if relationship_state.get("_reltype") in {RT.ORIGIN, RT.SIGNATURE}:
+                    raise UnsupportedStructureError(
+                        "mutating a digitally signed presentation would invalidate its OPC "
+                        "signature; remove or re-sign it with a signature-aware tool first"
+                    )
+                target_mode = relationship_state.get("_target_mode")
+                if target_mode == RTM.EXTERNAL:
+                    continue
+                if target_mode != RTM.INTERNAL:
+                    raise RelationshipPolicyError(
+                        "relationship %s has invalid target mode %r"
+                        % (relationship_state.get("_rId", "<unknown>"), target_mode)
+                    )
+                target = relationship_state.get("_target")
+                if not isinstance(target, Part):
+                    raise RelationshipPolicyError(
+                        "internal relationship %s targets %s, not a package Part"
+                        % (
+                            relationship_state.get("_rId", "<unknown>"),
+                            type(target).__name__,
+                        )
+                    )
+                target_state = target.__dict__
+                if target_state.get("_package") is not self._package:
+                    raise RelationshipPolicyError(
+                        "internal relationship %s targets part %s owned by another package"
+                        % (
+                            relationship_state.get("_rId", "<unknown>"),
+                            target_state.get("_partname", "<unknown>"),
+                        )
+                    )
+                targets.append(target)
+        return targets
+
+    @staticmethod
+    def _restore_instance_dict(instance, before: dict) -> None:
+        """Restore the exact shallow instance state, including all lazy-cache values."""
+        current = instance.__dict__
+        current.clear()
+        current.update(before)

--- a/src/pptx/_version.py
+++ b/src/pptx/_version.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, distribution
 
-__paper_version__ = "0.1.1"
+__paper_version__ = "0.1.2"
 
 
 def assert_distribution_identity() -> None:

--- a/src/pptx/chart/chart.py
+++ b/src/pptx/chart/chart.py
@@ -71,8 +71,8 @@ _SAFE_REPLACE_CHART_TYPES = frozenset(
 
 
 def _require_chart_attached(chart) -> None:
-    """Refuse a chart proxy detached from its live root or enrolled slide shape."""
-    from pptx.errors import TargetNotFoundError, materialize_slides
+    """Require exactly one reachable graphic-frame reference to this live chart part."""
+    from pptx.errors import TargetNotFoundError, UnsupportedStructureError
     from pptx.opc.constants import RELATIONSHIP_TYPE as RT
     from pptx.oxml.ns import qn
 
@@ -80,18 +80,27 @@ def _require_chart_attached(chart) -> None:
         raise TargetNotFoundError(
             "chart is stale: its XML root is no longer the live chart-part root"
         )
-    presentation = chart.part.package.presentation_part.presentation
-    for slide in materialize_slides(presentation, "replace_data_safe"):
-        for chart_ref in slide.part._element.iter(qn("c:chart")):
+    references = []
+    for owner in chart.part.package.iter_parts():
+        root = getattr(owner, "_element", None)
+        if root is None:
+            continue
+        for chart_ref in root.iter(qn("c:chart")):
             rId = chart_ref.get(qn("r:id"))
-            if not rId or rId not in slide.part.rels:
+            if not rId or rId not in owner.rels:
                 continue
-            rel = slide.part.rels[rId]
+            rel = owner.rels[rId]
             if not rel.is_external and rel.reltype == RT.CHART and rel.target_part is chart.part:
-                return
-    raise TargetNotFoundError(
-        "chart is stale: its chart part is no longer owned by a chart shape on an enrolled slide"
-    )
+                references.append((owner, chart_ref))
+    if not references:
+        raise TargetNotFoundError(
+            "chart is stale: its chart part is no longer referenced by a reachable chart shape"
+        )
+    if len(references) > 1:
+        raise UnsupportedStructureError(
+            "chart part is shared by multiple reachable chart shapes; replacing data would "
+            "silently change every shape that shares it"
+        )
 
 
 def _require_unshared_workbook(chart_part, xlsx_part) -> None:

--- a/src/pptx/chart/chart.py
+++ b/src/pptx/chart/chart.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import math
 from collections.abc import Sequence
 
@@ -69,6 +68,51 @@ _SAFE_REPLACE_CHART_TYPES = frozenset(
         XL_CHART_TYPE.PIE_EXPLODED,
     ]
 )
+
+
+def _require_chart_attached(chart) -> None:
+    """Refuse a chart proxy detached from its live root or enrolled slide shape."""
+    from pptx.errors import TargetNotFoundError, materialize_slides
+    from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+    from pptx.oxml.ns import qn
+
+    if chart._chartSpace is not chart.part._element:
+        raise TargetNotFoundError(
+            "chart is stale: its XML root is no longer the live chart-part root"
+        )
+    presentation = chart.part.package.presentation_part.presentation
+    for slide in materialize_slides(presentation, "replace_data_safe"):
+        for chart_ref in slide.part._element.iter(qn("c:chart")):
+            rId = chart_ref.get(qn("r:id"))
+            if not rId or rId not in slide.part.rels:
+                continue
+            rel = slide.part.rels[rId]
+            if not rel.is_external and rel.reltype == RT.CHART and rel.target_part is chart.part:
+                return
+    raise TargetNotFoundError(
+        "chart is stale: its chart part is no longer owned by a chart shape on an enrolled slide"
+    )
+
+
+def _require_unshared_workbook(chart_part, xlsx_part) -> None:
+    """Refuse mutation of a workbook targeted by another reachable chart part."""
+    if xlsx_part is None:
+        return
+    from pptx.errors import UnsupportedStructureError
+    from pptx.parts.chart import ChartPart
+
+    for part in chart_part.package.iter_parts():
+        if part is chart_part or not isinstance(part, ChartPart):
+            continue
+        rId = part._element.xlsx_part_rId
+        if rId is None or rId not in part.rels:
+            continue
+        rel = part.rels[rId]
+        if not rel.is_external and rel.target_part is xlsx_part:
+            raise UnsupportedStructureError(
+                "chart workbook is shared by another reachable chart; replacing data would "
+                "silently change that chart's workbook"
+            )
 
 
 class Chart(PartElementProxy):
@@ -240,6 +284,8 @@ class Chart(PartElementProxy):
         from pptx.chart.data import CategoryChartData
         from pptx.errors import UnsupportedStructureError
 
+        _require_chart_attached(self)
+
         # -- data validation, complete before any structural probing or mutation --
         categories = list(categories)
         if not categories:
@@ -333,24 +379,15 @@ class Chart(PartElementProxy):
         for name, values in normalized_series:
             chart_data.add_series(name, values)
         xlsx_part = self._workbook.xlsx_part
+        _require_unshared_workbook(self.part, xlsx_part)
         xlsx_blob = chart_data.xlsx_blob if xlsx_part is not None else None
-        chart_snapshot = copy.deepcopy(self._chartSpace)
-        workbook_snapshot = xlsx_part.blob if xlsx_part is not None else None
-        try:
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
             rewriter = SeriesXmlRewriterFactory(self.chart_type, chart_data)
             rewriter.replace_series_data(self._chartSpace)
             if xlsx_blob is not None:
                 self._workbook.update_from_xlsx_blob(xlsx_blob)
-        except BaseException:
-            self._chartSpace.attrib.clear()
-            self._chartSpace.attrib.update(chart_snapshot.attrib)
-            for child in list(self._chartSpace):
-                self._chartSpace.remove(child)
-            for child in chart_snapshot:
-                self._chartSpace.append(copy.deepcopy(child))
-            if xlsx_part is not None:
-                xlsx_part.blob = workbook_snapshot
-            raise
 
     @lazyproperty
     def series(self):

--- a/src/pptx/compose.py
+++ b/src/pptx/compose.py
@@ -33,6 +33,7 @@ import hashlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+from pptx._transaction import PackageTransaction
 from pptx.errors import RelationshipPolicyError, TargetNotFoundError, UnsupportedStructureError
 from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 from pptx.opc.package import XmlPart
@@ -40,6 +41,7 @@ from pptx.oxml import parse_xml
 from pptx.oxml.ns import qn
 from pptx.slideops import (
     _allocate_partname,
+    _CopySession,
     _partname_template,
     _rewrite_r_references,
     _rId_sort_key,
@@ -55,52 +57,12 @@ SCHEMA_NAME = "paper-import-report"
 SCHEMA_VERSION = 1
 
 
-class _ComposeTransaction:
-    """Restore the complete reachable destination graph when composition raises."""
+class _ComposeTransaction(PackageTransaction):
+    """Package transaction rooted at the destination presentation."""
 
     def __init__(self, dest_prs):
-        self._dest_prs = dest_prs
-        self._package = dest_prs.part.package
-        self._parts = list(self._package.iter_parts())
-        self._part_state = []
-        for part in self._parts:
-            payload = copy.deepcopy(part._element) if isinstance(part, XmlPart) else part.blob
-            self._part_state.append((part, payload, dict(part.rels._rels)))
-        self._package_rels = dict(self._package._rels._rels)
-        self._had_cache = hasattr(self._package, "_paper_compose_fingerprints")
-        self._cache = dict(getattr(self._package, "_paper_compose_fingerprints", {}))
+        super().__init__(dest_prs.part.package, dest_prs)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        if exc_type is None:
-            return False
-        for part, payload, rels in self._part_state:
-            if isinstance(part, XmlPart):
-                _restore_xml_element(part._element, payload)
-            else:
-                part.blob = payload
-            part.rels._rels.clear()
-            part.rels._rels.update(rels)
-        self._package._rels._rels.clear()
-        self._package._rels._rels.update(self._package_rels)
-        if self._had_cache:
-            self._package._paper_compose_fingerprints = self._cache
-        elif hasattr(self._package, "_paper_compose_fingerprints"):
-            delattr(self._package, "_paper_compose_fingerprints")
-        return False
-
-
-def _restore_xml_element(target, snapshot) -> None:
-    target.attrib.clear()
-    target.attrib.update(snapshot.attrib)
-    target.text = snapshot.text
-    target.tail = snapshot.tail
-    for child in list(target):
-        target.remove(child)
-    for child in snapshot:
-        target.append(copy.deepcopy(child))
 
 _MODES = ("adopt_theme", "keep_appearance", "bake")
 _MEDIA_RELTYPES = frozenset([RT.IMAGE, RT.MEDIA, RT.VIDEO, RT.AUDIO])
@@ -268,8 +230,7 @@ def _validate_arguments(
         raise ValueError("source_prs must be a Presentation, got %r" % (source_prs,))
     if source_prs.part.package is dest_prs.part.package:
         raise ValueError(
-            "source_prs is this same presentation; same-package duplication is "
-            "Slides.clone's job"
+            "source_prs is this same presentation; same-package duplication is Slides.clone's job"
         )
     from pptx.errors import materialize_slides
 
@@ -292,6 +253,9 @@ def _validate_arguments(
         slide = source_prs.slides[slide]
     elif slide.part.package is not source_prs.part.package:
         raise ValueError("slide does not belong to source_prs")
+    from pptx.slide import _require_layout_enrolled, _require_slide_enrolled
+
+    _require_slide_enrolled(slide, argument="source slide")
     if mode not in _MODES:
         raise ValueError("mode must be one of %s, got %r" % (", ".join(_MODES), mode))
     if position is not None and (
@@ -309,9 +273,7 @@ def _validate_arguments(
         if not isinstance(section, str):
             raise ValueError("section must be a str section name or None")
         if _find_section(dest_prs._element, section) is None:
-            raise TargetNotFoundError(
-                "destination has no section named %r" % (section,)
-            )
+            raise TargetNotFoundError("destination has no section named %r" % (section,))
     if target_layout is not None:
         if mode == "keep_appearance":
             raise ValueError(
@@ -322,15 +284,7 @@ def _validate_arguments(
             raise ValueError("target_layout must be a SlideLayout")
         if target_layout.part.package is not dest_prs.part.package:
             raise ValueError("target_layout must belong to the destination presentation")
-        live_layout_parts = {
-            layout.part
-            for master in dest_prs.slide_masters
-            for layout in master.slide_layouts
-        }
-        if target_layout.part not in live_layout_parts:
-            raise TargetNotFoundError(
-                "target_layout is no longer enrolled in the destination presentation"
-            )
+        _require_layout_enrolled(target_layout, argument="target_layout")
     if mode in ("adopt_theme", "bake") and any(
         True for _ in slide._element.spTree.iterchildren(_MC_ALTERNATE_CONTENT)
     ):
@@ -400,9 +354,7 @@ def _validate_mode_preparation(source_slide, mode, binding):
         return {"before_state": _resolution_state(source_slide)}
 
     slide_phs = [shape for shape in source_slide.shapes if shape.is_placeholder]
-    hf_phs = [
-        shape for shape in slide_phs if shape.element.ph.get("type") in _HF_PH_TYPE_TOKENS
-    ]
+    hf_phs = [shape for shape in slide_phs if shape.element.ph.get("type") in _HF_PH_TYPE_TOKENS]
     content_phs = [shape for shape in slide_phs if shape not in hf_phs]
 
     if mode == "adopt_theme":
@@ -414,17 +366,13 @@ def _validate_mode_preparation(source_slide, mode, binding):
 
     baked_values = {}
     for shape in orphans:
-        if shape.element.findall(
-            ".//{http://schemas.openxmlformats.org/drawingml/2006/main}fld"
-        ):
+        if shape.element.findall(".//{http://schemas.openxmlformats.org/drawingml/2006/main}fld"):
             raise UnsupportedStructureError(
                 "placeholder %r contains a field (a:fld); baking would freeze volatile "
-                "content - import with keep_appearance or remove the field first"
-                % shape.name
+                "content - import with keep_appearance or remove the field first" % shape.name
             )
         geometry = {
-            attribute: getattr(shape, attribute)
-            for attribute in ("left", "top", "width", "height")
+            attribute: getattr(shape, attribute) for attribute in ("left", "top", "width", "height")
         }
         if any(value is None for value in geometry.values()):
             raise UnsupportedStructureError(
@@ -491,13 +439,13 @@ def _resolved_run_values(shape) -> list:
     for p_idx, paragraph in enumerate(shape.text_frame.paragraphs):
         for r_idx, run in enumerate(paragraph.runs):
             effective = run.effective_font()
-            unsafe_name = any(
-                "non-Latin" in step.detail for step in effective.name.provenance
+            unsafe_name = any("non-Latin" in step.detail for step in effective.name.provenance)
+            unsafe_color = (
+                any(
+                    "unapplied transforms" in step.detail for step in effective.color_rgb.provenance
+                )
+                and effective.color_rgb.bake_color_xml is None
             )
-            unsafe_color = any(
-                "unapplied transforms" in step.detail
-                for step in effective.color_rgb.provenance
-            ) and effective.color_rgb.bake_color_xml is None
             if unsafe_name or unsafe_color:
                 from pptx.errors import UnsupportedStructureError
 
@@ -516,12 +464,16 @@ def _resolved_run_values(shape) -> list:
                 values["color_xml"] = effective.color_rgb.bake_color_xml
             for facet in ("bold", "italic"):
                 facet_value = getattr(effective, facet)
-                if facet_value is not None and facet_value.resolved and (
-                    facet_value.value is not None
+                if (
+                    facet_value is not None
+                    and facet_value.resolved
+                    and (facet_value.value is not None)
                 ):
                     values[facet] = facet_value.value
-            if effective.underline is not None and effective.underline.resolved and (
-                effective.underline.value is not None
+            if (
+                effective.underline is not None
+                and effective.underline.resolved
+                and (effective.underline.value is not None)
             ):
                 values["underline"] = effective.underline.value
             if values:
@@ -545,9 +497,7 @@ def _resolve_layout_binding(dest_prs, source_slide, mode, target_layout) -> _Lay
     if target_layout is not None:
         return _LayoutBinding(target_layout, "explicit")
     source_layout = source_slide.slide_layout
-    dest_layouts = [
-        layout for master in dest_prs.slide_masters for layout in master.slide_layouts
-    ]
+    dest_layouts = [layout for master in dest_prs.slide_masters for layout in master.slide_layouts]
     source_name = source_layout.name
     if source_name:
         for layout in dest_layouts:
@@ -579,7 +529,7 @@ def _perform_import(
     dest_package = dest_prs.part.package
     before_partnames = {str(part.partname) for part in dest_package.iter_parts()}
     reused: "List[str]" = []
-    allocated = _ImportSession()
+    allocated = _ImportSession(dest_package, source_slide.part.package)
 
     # -- keep_appearance: the support chain first (fingerprint-deduped) ------------------
     if mode == "keep_appearance":
@@ -596,6 +546,7 @@ def _perform_import(
         dest_package,
         copy.deepcopy(source_slide.part._element),
     )
+    allocated.remap(source_slide.part, new_slide_part)
     rId_mapping: "Dict[str, str]" = {}
     comments_dropped = 0
     notes_copied = False
@@ -635,9 +586,7 @@ def _perform_import(
     baked_names: "List[str]" = []
     dropped_names: "List[str]" = []
     if mode in ("adopt_theme", "bake"):
-        baked_names, dropped_names = _reconcile_copied_placeholders(
-            new_slide_part, mode, prep
-        )
+        baked_names, dropped_names = _reconcile_copied_placeholders(new_slide_part, mode, prep)
     new_slide_part.relate_to(dest_layout_part, RT.SLIDE_LAYOUT)
 
     # -- enroll in the destination slide sequence ------------------------------------------
@@ -651,9 +600,7 @@ def _perform_import(
         sldIdLst.sldId_lst[final_position].addprevious(sldId)
     new_slide_id = int(sldId.get("id"))
 
-    enrolled_section = _enroll_in_section(
-        dest_prs._element, new_slide_id, final_position, section
-    )
+    enrolled_section = _enroll_in_section(dest_prs._element, new_slide_id, final_position, section)
 
     # -- report ----------------------------------------------------------------------------
     after_state = _resolution_state(new_slide_part.slide)
@@ -719,9 +666,7 @@ def _reconcile_copied_placeholders(new_slide_part, mode, prep):
                 if "italic" in values:
                     run.font.italic = values["italic"]
                 if "underline" in values:
-                    run.font.underline = MSO_TEXT_UNDERLINE_TYPE.from_xml(
-                        values["underline"]
-                    )
+                    run.font.underline = MSO_TEXT_UNDERLINE_TYPE.from_xml(values["underline"])
         if shape.is_placeholder and shape.shape_id in prep["orphan_ids"]:
             baked_names.append(shape.name)
             ph = shape.element.ph
@@ -738,7 +683,7 @@ def _reconcile_copied_placeholders(new_slide_part, mode, prep):
 # --------------------------------------------------------------- support-part transplant
 
 
-class _ImportSession(set):
+class _ImportSession(_CopySession):
     """The partname-allocation set for one import call, plus the parts it created.
 
     Behaves as the plain `allocated` set the shared `_allocate_partname` machinery
@@ -747,8 +692,8 @@ class _ImportSession(set):
     reachable (the new slide is enrolled only at the end of the import).
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, dest_package, source_package):
+        super().__init__(dest_package, tuple(source_package.iter_parts()))
         self.created_parts = []
 
 
@@ -823,15 +768,14 @@ def _import_support_part(dest_package, part, allocated, reused):
     if hit is not None:
         reused.append(str(hit.partname))
         return hit
-    partname = _allocate_partname(
-        dest_package, _partname_template(str(part.partname)), allocated
-    )
+    partname = _allocate_partname(dest_package, _partname_template(str(part.partname)), allocated)
     if isinstance(part, XmlPart):
         new_part = type(part)(
             partname, part.content_type, dest_package, copy.deepcopy(part._element)
         )
     else:
         new_part = type(part)(partname, part.content_type, dest_package, part.blob)
+    allocated.remap(part, new_part)
     rId_mapping = {}
     for rId in sorted(part.rels, key=_rId_sort_key):
         rel = part.rels[rId]
@@ -918,14 +862,13 @@ def _import_diagram_part(dest_package, dgm_part, allocated, reused):
 
 
 def _import_leaf_into(dest_package, part, allocated):
-    partname = _allocate_partname(
-        dest_package, _partname_template(str(part.partname)), allocated
-    )
+    partname = _allocate_partname(dest_package, _partname_template(str(part.partname)), allocated)
     if isinstance(part, XmlPart):
-        return type(part)(
-            partname, part.content_type, dest_package, copy.deepcopy(part._element)
-        )
-    return type(part)(partname, part.content_type, dest_package, part.blob)
+        copied = type(part)(partname, part.content_type, dest_package, copy.deepcopy(part._element))
+    else:
+        copied = type(part)(partname, part.content_type, dest_package, part.blob)
+    allocated.remap(part, copied)
+    return copied
 
 
 def _transplant_layout_chain(dest_prs, source_layout, allocated, reused):
@@ -959,9 +902,7 @@ def _transplant_layout_chain(dest_prs, source_layout, allocated, reused):
     # -- enroll the layout in the transplanted master (via the oxml id-list machinery)
     master_rId = dest_master_part.relate_to(new_layout, RT.SLIDE_LAYOUT)
     sldLayoutIdLst = dest_master_part._element.get_or_add_sldLayoutIdLst()
-    sldLayoutIdLst._add_sldLayoutId(
-        rId=master_rId, id=_next_layout_or_master_id(dest_prs)
-    )
+    sldLayoutIdLst._add_sldLayoutId(rId=master_rId, id=_next_layout_or_master_id(dest_prs))
 
     cache[layout_fingerprint] = new_layout
     if hasattr(allocated, "created_parts"):
@@ -1009,9 +950,7 @@ def _transplant_master(dest_prs, source_master, allocated, reused):
     # -- enroll the master in the destination presentation (via the oxml machinery)
     pres_rId = dest_prs.part.relate_to(new_master, RT.SLIDE_MASTER)
     sldMasterIdLst = dest_prs._element.get_or_add_sldMasterIdLst()
-    sldMasterIdLst._add_sldMasterId(
-        rId=pres_rId, id=_next_layout_or_master_id(dest_prs)
-    )
+    sldMasterIdLst._add_sldMasterId(rId=pres_rId, id=_next_layout_or_master_id(dest_prs))
 
     cache[master_fingerprint] = new_master
     if hasattr(allocated, "created_parts"):
@@ -1047,9 +986,7 @@ def _enroll_in_section(presentation_elm, new_slide_id, final_position, section_n
     Returns the name of the section actually enrolled in (None when the destination has
     no sections) so the report can carry the real disposition, not the argument.
     """
-    sections = presentation_elm.findall(
-        ".//{%s}sectionLst/{%s}section" % (_P14_NS, _P14_NS)
-    )
+    sections = presentation_elm.findall(".//{%s}sectionLst/{%s}section" % (_P14_NS, _P14_NS))
     if not sections:
         return None
     if section_name is not None:
@@ -1071,9 +1008,7 @@ def _enroll_in_section(presentation_elm, new_slide_id, final_position, section_n
         for section in sections:
             for entry in section.findall(".//{%s}sldId" % _P14_NS):
                 if entry.get("id") == preceding_id:
-                    new_entry = entry.makeelement(
-                        "{%s}sldId" % _P14_NS, {"id": str(new_slide_id)}
-                    )
+                    new_entry = entry.makeelement("{%s}sldId" % _P14_NS, {"id": str(new_slide_id)})
                     entry.addnext(new_entry)
                     return section.get("name")
     first_sldIdLst = sections[0].find("{%s}sldIdLst" % _P14_NS)

--- a/src/pptx/compose.py
+++ b/src/pptx/compose.py
@@ -304,7 +304,9 @@ def _validated_transplant_plan(source_part, notes: bool):
         rel = source_part.rels[rId]
         if rel.is_external:
             plan.append((rId, "external", rel))
-        elif rel.reltype == RT.SLIDE_LAYOUT:
+            continue
+        _owned_source_target(source_part, rel, "slide import")
+        if rel.reltype == RT.SLIDE_LAYOUT:
             plan.append((rId, "layout", rel))
         elif rel.reltype in _MEDIA_RELTYPES:
             plan.append((rId, "media", rel))  # -- cross-package media ALWAYS copies
@@ -338,6 +340,7 @@ def _validate_dgm_rels(dgm_part) -> None:
     for rel in dgm_part.rels.values():
         if rel.is_external:
             continue
+        _owned_source_target(dgm_part, rel, "diagram import")
         if rel.reltype not in _MEDIA_RELTYPES:
             raise RelationshipPolicyError(
                 "SmartArt part %s has relationship type import does not support: %s"
@@ -414,6 +417,7 @@ def _validate_support_chain(source_layout) -> None:
         for rel in part.rels.values():
             if rel.is_external:
                 continue
+            _owned_source_target(part, rel, "support-chain import")
             if rel.reltype not in allowed:
                 raise RelationshipPolicyError(
                     "support part %s has relationship type import does not support: %s"
@@ -421,11 +425,29 @@ def _validate_support_chain(source_layout) -> None:
                 )
     theme_part = master_part.part_related_by(RT.THEME)
     for rel in theme_part.rels.values():
+        if not rel.is_external:
+            _owned_source_target(theme_part, rel, "theme import")
         if not rel.is_external and rel.reltype not in _MEDIA_RELTYPES:
             raise RelationshipPolicyError(
                 "theme part %s has relationship type import does not support: %s"
                 % (theme_part.partname, rel.reltype)
             )
+
+
+def _owned_source_target(owner_part, rel, context: str):
+    """Return an internal target only when it belongs to the source package."""
+    try:
+        target = rel.target_part
+    except (AssertionError, AttributeError, TypeError, ValueError) as exc:
+        raise RelationshipPolicyError(
+            "%s relationship %s has an invalid internal target" % (context, rel.rId)
+        ) from exc
+    if target.package is not owner_part.package:
+        raise RelationshipPolicyError(
+            "%s relationship %s targets a part owned by another package"
+            % (context, rel.rId)
+        )
+    return target
 
 
 def _resolved_run_values(shape) -> list:

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -283,7 +283,6 @@ def _package_changes(source_a, prs_a, source_b, prs_b) -> tuple:
 
 def _source_package_map(source, prs, label: str) -> dict:
     """Read a path/stream package exactly; serialize only Presentation proxies."""
-    from pptx.errors import UnsupportedStructureError
     from pptx.package import _read_zip_map, _read_zip_map_from_bytes
     from pptx.presentation import Presentation as _PresentationProxy
 
@@ -297,14 +296,41 @@ def _source_package_map(source, prs, label: str) -> dict:
     position = source.tell()
     try:
         source.seek(0)
-        data = source.read()
-        if not isinstance(data, bytes):
-            raise UnsupportedStructureError(
-                "diff_decks refused: %s input stream must return bytes" % label
-            )
+        data = _read_stream_package_bytes(source, label)
         return _read_zip_map_from_bytes(data, "%s input" % label)
     finally:
         source.seek(position)
+
+
+def _read_stream_package_bytes(source, label: str) -> bytes:
+    """Read a package stream in bounded chunks with typed I/O failures."""
+    from pptx._zipguard import MAX_COMPRESSED_BYTES
+    from pptx.errors import PackageLimitError, UnsupportedStructureError
+
+    chunks = []
+    total = 0
+    try:
+        while True:
+            chunk = source.read(min(1024 * 1024, MAX_COMPRESSED_BYTES - total + 1))
+            if not isinstance(chunk, bytes):
+                raise UnsupportedStructureError(
+                    "diff_decks refused: %s input stream must return bytes" % label
+                )
+            if not chunk:
+                return b"".join(chunks)
+            total += len(chunk)
+            if total > MAX_COMPRESSED_BYTES:
+                raise PackageLimitError(
+                    "diff_decks refused: %s input stream exceeds the compressed package limit"
+                    % label
+                )
+            chunks.append(chunk)
+    except (PackageLimitError, UnsupportedStructureError):
+        raise
+    except (OSError, TypeError, ValueError) as exc:
+        raise UnsupportedStructureError(
+            "diff_decks refused: cannot read %s input stream (%s)" % (label, exc)
+        ) from exc
 
 
 def _open_deck(source):
@@ -568,8 +594,8 @@ def _diff_text(slide_a, slide_b) -> "List[dict]":
         block_b = blocks_b.get(key)
         text_a = block_a.text if block_a is not None else None
         text_b = block_b.text if block_b is not None else None
-        fields_a = block_a.fields if block_a is not None else ()
-        fields_b = block_b.fields if block_b is not None else ()
+        fields_a = _field_markers(block_a)
+        fields_b = _field_markers(block_b)
         if text_a != text_b or fields_a != fields_b:
             reference = block_b if block_b is not None else block_a
             change = {
@@ -580,10 +606,30 @@ def _diff_text(slide_a, slide_b) -> "List[dict]":
                 "after": text_b,
             }
             if fields_a != fields_b:
-                change["field_types_before"] = list(fields_a)
-                change["field_types_after"] = list(fields_b)
+                change["field_types_before"] = [field_type for _, field_type in fields_a]
+                change["field_types_after"] = [field_type for _, field_type in fields_b]
+                change["fields_before"] = [
+                    {"offset": offset, "type": field_type} for offset, field_type in fields_a
+                ]
+                change["fields_after"] = [
+                    {"offset": offset, "type": field_type} for offset, field_type in fields_b
+                ]
             changes.append(change)
     return changes
+
+
+def _field_markers(block) -> tuple:
+    """Return field types positioned in visible literal text, independent of run splitting."""
+    if block is None:
+        return ()
+    offset = 0
+    markers = []
+    for run in block.runs:
+        if run.field_type is not None:
+            markers.append((offset, run.field_type))
+        else:
+            offset += len(run.text)
+    return tuple(markers)
 
 
 def _notes_text(slide) -> "Optional[str]":

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -457,7 +457,8 @@ def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
         from pptx.rebind import _resolution_state, _shifts_between
 
         effective_shifts = _shifts_between(
-            _resolution_state(slide_a), _resolution_state(slide_b)
+            _resolution_state(slide_a, align_by_content=True),
+            _resolution_state(slide_b, align_by_content=True),
         )
 
     return SlideChange(

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
@@ -158,66 +159,152 @@ def diff_decks(path_a, path_b, *, detail: str = "structure") -> DeckDiff:
         )
     from pptx.errors import materialize_slides
 
-    prs_a = _open_deck(path_a)
-    prs_b = _open_deck(path_b)
-    package_changes = _package_changes(prs_a, prs_b)
+    stream_positions = _stream_positions(path_a, path_b)
+    try:
+        prs_a = _open_deck(path_a)
+        prs_b = _open_deck(path_b)
+        package_changes = _package_changes(path_a, prs_a, path_b, prs_b)
 
-    order_a = [(slide.slide_id, slide) for slide in materialize_slides(prs_a, "diff_decks")]
-    order_b = [(slide.slide_id, slide) for slide in materialize_slides(prs_b, "diff_decks")]
-    ids_a = [slide_id for slide_id, _ in order_a]
-    ids_b = [slide_id for slide_id, _ in order_b]
-    position_a = {slide_id: index for index, (slide_id, _) in enumerate(order_a)}
-    position_b = {slide_id: index for index, (slide_id, _) in enumerate(order_b)}
-    common = set(ids_a) & set(ids_b)
+        order_a = [(slide.slide_id, slide) for slide in materialize_slides(prs_a, "diff_decks")]
+        order_b = [(slide.slide_id, slide) for slide in materialize_slides(prs_b, "diff_decks")]
+        ids_a = [slide_id for slide_id, _ in order_a]
+        ids_b = [slide_id for slide_id, _ in order_b]
+        position_a = {slide_id: index for index, (slide_id, _) in enumerate(order_a)}
+        position_b = {slide_id: index for index, (slide_id, _) in enumerate(order_b)}
+        common = set(ids_a) & set(ids_b)
 
-    slides_added = tuple(
-        SlideRef(slide_id, position_b[slide_id], _title_of(slide))
-        for slide_id, slide in order_b
-        if slide_id not in common
-    )
-    slides_removed = tuple(
-        SlideRef(slide_id, position_a[slide_id], _title_of(slide))
-        for slide_id, slide in order_a
-        if slide_id not in common
-    )
+        slides_added = tuple(
+            SlideRef(slide_id, position_b[slide_id], _title_of(slide))
+            for slide_id, slide in order_b
+            if slide_id not in common
+        )
+        slides_removed = tuple(
+            SlideRef(slide_id, position_a[slide_id], _title_of(slide))
+            for slide_id, slide in order_a
+            if slide_id not in common
+        )
 
-    common_a = [slide_id for slide_id in ids_a if slide_id in common]
-    common_b = [slide_id for slide_id in ids_b if slide_id in common]
-    stationary = _longest_common_subsequence(common_a, common_b)
-    slides_moved = tuple(
-        MovedSlide(slide_id, position_a[slide_id], position_b[slide_id])
-        for slide_id in common_b  # -- destination order, deterministic
-        if slide_id not in stationary
-    )
+        common_a = [slide_id for slide_id in ids_a if slide_id in common]
+        common_b = [slide_id for slide_id in ids_b if slide_id in common]
+        stationary = _longest_common_subsequence(common_a, common_b)
+        slides_moved = tuple(
+            MovedSlide(slide_id, position_a[slide_id], position_b[slide_id])
+            for slide_id in common_b  # -- destination order, deterministic
+            if slide_id not in stationary
+        )
 
-    slide_a_by_id = dict(order_a)
-    slide_b_by_id = dict(order_b)
-    changes = []
-    for slide_id in common_b:
-        change = _diff_slide(slide_id, slide_a_by_id[slide_id], slide_b_by_id[slide_id], detail)
-        if not change.is_empty:
-            changes.append(change)
+        slide_a_by_id = dict(order_a)
+        slide_b_by_id = dict(order_b)
+        changes = []
+        for slide_id in common_b:
+            change = _diff_slide(
+                slide_id, slide_a_by_id[slide_id], slide_b_by_id[slide_id], detail
+            )
+            if not change.is_empty:
+                changes.append(change)
 
-    return DeckDiff(
-        detail=detail,
-        slides_added=slides_added,
-        slides_removed=slides_removed,
-        slides_moved=slides_moved,
-        slide_changes=tuple(changes),
-        package_changes=package_changes,
-    )
+        return DeckDiff(
+            detail=detail,
+            slides_added=slides_added,
+            slides_removed=slides_removed,
+            slides_moved=slides_moved,
+            slide_changes=tuple(changes),
+            package_changes=package_changes,
+        )
+    finally:
+        _restore_stream_positions(stream_positions)
 
 
-def _package_changes(prs_a, prs_b) -> tuple:
-    """Return semantic package deltas for the serialized in-memory presentations."""
-    from pptx.package import _diff_maps, _read_zip_map_from_bytes
+def _stream_positions(*sources):
+    """Capture supported stream positions so diffing is observationally read-only."""
+    from pptx.errors import UnsupportedStructureError
+    from pptx.presentation import Presentation as _PresentationProxy
 
-    buffers = []
-    for prs in (prs_a, prs_b):
+    positions = []
+    seen = set()
+    for source in sources:
+        if isinstance(source, (_PresentationProxy, str, bytes, os.PathLike)):
+            continue
+        if id(source) in seen:
+            continue
+        seen.add(id(source))
+        if not hasattr(source, "read"):
+            raise UnsupportedStructureError(
+                "diff_decks refused: inputs must be paths, Presentation objects, or "
+                "seekable binary streams"
+            )
+        try:
+            if hasattr(source, "seekable") and not source.seekable():
+                raise OSError("stream reports that it is not seekable")
+            position = source.tell()
+            if type(position) is not int or position < 0:
+                raise UnsupportedStructureError(
+                    "diff_decks refused: stream tell() must return a nonnegative integer"
+                )
+            source.seek(position)
+        except UnsupportedStructureError:
+            raise
+        except (AttributeError, OSError, TypeError, ValueError) as exc:
+            raise UnsupportedStructureError(
+                "diff_decks refused: non-seekable input streams are unsupported (%s)" % exc
+            ) from exc
+        positions.append((source, position))
+    return tuple(positions)
+
+
+def _restore_stream_positions(stream_positions) -> None:
+    """Attempt every stream restore before reporting an aggregate typed failure."""
+    from pptx.errors import UnsupportedStructureError
+
+    failures = []
+    for index, (stream, position) in enumerate(stream_positions):
+        try:
+            stream.seek(position)
+            if stream.tell() != position:
+                raise OSError("stream did not restore to %d" % position)
+        except Exception as exc:  # noqa: BLE001 - aggregate all restore failures
+            failures.append((index, exc))
+    if failures:
+        index, exc = failures[0]
+        raise UnsupportedStructureError(
+            "diff_decks could not restore %d input stream position(s); first failure was "
+            "input %d (%s)" % (len(failures), index, type(exc).__name__)
+        ) from exc
+
+
+def _package_changes(source_a, prs_a, source_b, prs_b) -> tuple:
+    """Return semantic deltas from the exact supplied packages when recoverable."""
+    from pptx.package import _diff_maps
+
+    map_a = _source_package_map(source_a, prs_a, "before")
+    map_b = _source_package_map(source_b, prs_b, "after")
+    return _diff_maps(map_a, map_b, "before", "after").deltas
+
+
+def _source_package_map(source, prs, label: str) -> dict:
+    """Read a path/stream package exactly; serialize only Presentation proxies."""
+    from pptx.errors import UnsupportedStructureError
+    from pptx.package import _read_zip_map, _read_zip_map_from_bytes
+    from pptx.presentation import Presentation as _PresentationProxy
+
+    if isinstance(source, _PresentationProxy):
         buffer = io.BytesIO()
         prs.save(buffer)
-        buffers.append(_read_zip_map_from_bytes(buffer.getvalue(), "diff_decks input"))
-    return _diff_maps(buffers[0], buffers[1], "before", "after").deltas
+        return _read_zip_map_from_bytes(buffer.getvalue(), "%s normalized input" % label)
+    if isinstance(source, (str, bytes, os.PathLike)):
+        return _read_zip_map(os.fspath(source))
+
+    position = source.tell()
+    try:
+        source.seek(0)
+        data = source.read()
+        if not isinstance(data, bytes):
+            raise UnsupportedStructureError(
+                "diff_decks refused: %s input stream must return bytes" % label
+            )
+        return _read_zip_map_from_bytes(data, "%s input" % label)
+    finally:
+        source.seek(position)
 
 
 def _open_deck(source):
@@ -481,26 +568,25 @@ def _diff_text(slide_a, slide_b) -> "List[dict]":
         block_b = blocks_b.get(key)
         text_a = block_a.text if block_a is not None else None
         text_b = block_b.text if block_b is not None else None
-        if text_a != text_b:
+        fields_a = block_a.fields if block_a is not None else ()
+        fields_b = block_b.fields if block_b is not None else ()
+        if text_a != text_b or fields_a != fields_b:
             reference = block_b if block_b is not None else block_a
-            changes.append(
-                {
-                    "shape_id": key[0],
-                    "shape_name": reference.shape_name,
-                    "block_ordinal": key[1],
-                    "before": text_a,
-                    "after": text_b,
-                }
-            )
+            change = {
+                "shape_id": key[0],
+                "shape_name": reference.shape_name,
+                "block_ordinal": key[1],
+                "before": text_a,
+                "after": text_b,
+            }
+            if fields_a != fields_b:
+                change["field_types_before"] = list(fields_a)
+                change["field_types_after"] = list(fields_b)
+            changes.append(change)
     return changes
 
 
 def _notes_text(slide) -> "Optional[str]":
-    from pptx.errors import UnsupportedStructureError
-
     if not slide.has_notes_slide:
         return None
-    try:
-        return slide.read_notes_text()
-    except UnsupportedStructureError:  # pragma: no cover - notes part without a body
-        return None
+    return slide.read_notes_text()

--- a/src/pptx/edit.py
+++ b/src/pptx/edit.py
@@ -285,10 +285,14 @@ def _block_paragraph(prs, anchor: BlockAnchor):
 
 def _paragraph_text(p) -> str:
     """Concatenated `a:r` run text of `p` — same definition `inspect_text` hashes."""
-    return "".join(
-        (r.find(qn("a:t")).text or "") if r.find(qn("a:t")) is not None else ""
-        for r in p.findall(qn("a:r"))
-    )
+    pieces = []
+    for child in p:
+        if child.tag == qn("a:r"):
+            text = child.find(qn("a:t"))
+            pieces.append((text.text or "") if text is not None else "")
+        elif child.tag == qn("a:br"):
+            pieces.append("\v")
+    return "".join(pieces)
 
 
 def _replace_in_paragraph(p, find: str, replace: str) -> int:

--- a/src/pptx/edit.py
+++ b/src/pptx/edit.py
@@ -69,20 +69,23 @@ def replace_text(
     `ReplaceResult(0)`, not a refusal. Validation completes before the first write.
     """
     _validate_find_replace(find, replace)
-    # -- validate-fully-then-mutate (§1.3): materialize the COMPLETE traversal first, so any
-    # -- traversal refusal (depth guard, unsupported markup) fires before the first write —
-    # -- a refusal must never leave earlier blocks already rewritten
-    plan = _materialize_blocks(prs, include_notes)
-    total = 0
-    touched: List[BlockAnchor] = []
-    for partname, block_index, p in plan:
-        count = _replace_in_paragraph(p, find, replace)
-        if count:
-            total += count
-            touched.append(
-                BlockAnchor(partname, block_index, content_hash(_paragraph_text(p)))
-            )
-    return ReplaceResult(total, tuple(touched))
+    _require_presentation_root(prs)
+    from pptx._transaction import PackageTransaction
+
+    with PackageTransaction(prs.part.package, prs):
+        # -- validate-fully-then-mutate (§1.3): materialize the COMPLETE traversal first,
+        # -- so any traversal refusal fires before the first write.
+        plan = _materialize_blocks(prs, include_notes)
+        total = 0
+        touched: List[BlockAnchor] = []
+        for partname, block_index, p in plan:
+            count = _replace_in_paragraph(p, find, replace)
+            if count:
+                total += count
+                touched.append(
+                    BlockAnchor(partname, block_index, content_hash(_paragraph_text(p)))
+                )
+        return ReplaceResult(total, tuple(touched))
 
 
 def replace_text_at(
@@ -98,31 +101,35 @@ def replace_text_at(
     _validate_find_replace(find, replace)
     if not isinstance(anchor, BlockAnchor):
         raise ValueError("anchor must be a BlockAnchor, got %r" % (anchor,))
-    p = _block_paragraph(prs, anchor)
-    current_text = _paragraph_text(p)
-    current_hash = content_hash(current_text)
-    if current_hash != anchor.content_hash:
-        raise StaleAnchorError(
-            "anchor is stale: block %d of %s now hashes %s (anchor says %s); the document"
-            " changed since the anchor was produced — use pptx.edit.refind() to recover"
-            % (anchor.block_index, anchor.part, current_hash, anchor.content_hash)
+    _require_presentation_root(prs)
+    from pptx._transaction import PackageTransaction
+
+    with PackageTransaction(prs.part.package, prs):
+        p = _block_paragraph(prs, anchor)
+        current_text = _paragraph_text(p)
+        current_hash = content_hash(current_text)
+        if current_hash != anchor.content_hash:
+            raise StaleAnchorError(
+                "anchor is stale: block %d of %s now hashes %s (anchor says %s); the document"
+                " changed since the anchor was produced — use pptx.edit.refind() to recover"
+                % (anchor.block_index, anchor.part, current_hash, anchor.content_hash)
+            )
+        if find not in current_text:
+            raise TargetNotFoundError(
+                "%r does not occur in the anchored block (text %r)" % (find, current_text)
+            )
+        count = _replace_in_paragraph(p, find, replace)
+        if count == 0:
+            # -- `find` appears in the hash-text but every occurrence crosses a field or
+            # -- line-break boundary, which matches never do.
+            raise TargetNotFoundError(
+                "%r occurs in the anchored block only across a field or line-break boundary;"
+                " matches never cross a:fld/a:br" % (find,)
+            )
+        return ReplaceResult(
+            count,
+            (BlockAnchor(anchor.part, anchor.block_index, content_hash(_paragraph_text(p))),),
         )
-    if find not in current_text:
-        raise TargetNotFoundError(
-            "%r does not occur in the anchored block (text %r)" % (find, current_text)
-        )
-    count = _replace_in_paragraph(p, find, replace)
-    if count == 0:
-        # -- `find` appears in the hash-text but every occurrence crosses a field or
-        # -- line-break boundary, which matches never do: refuse rather than return a
-        # -- success-shaped zero (§1.5)
-        raise TargetNotFoundError(
-            "%r occurs in the anchored block only across a field or line-break boundary;"
-            " matches never cross a:fld/a:br" % (find,)
-        )
-    return ReplaceResult(
-        count, (BlockAnchor(anchor.part, anchor.block_index, content_hash(_paragraph_text(p))),)
-    )
 
 
 def refind(prs: "Presentation", anchor: BlockAnchor) -> BlockAnchor:
@@ -140,7 +147,7 @@ def refind(prs: "Presentation", anchor: BlockAnchor) -> BlockAnchor:
             continue
         block_index = 0
         for kind, _, txBody, _, _ in iter_text_bodies(spTree):
-            if kind == "alternate-content":
+            if txBody is None:
                 block_index += 1  # -- occupies an index but is never hash-matchable
                 continue
             for p in txBody.findall(qn("a:p")):
@@ -166,6 +173,14 @@ def refind(prs: "Presentation", anchor: BlockAnchor) -> BlockAnchor:
 
 
 # ------------------------------------------------------------------------------- internals
+
+
+def _require_presentation_root(prs) -> None:
+    """Refuse a retained Presentation proxy whose root has been replaced."""
+    if getattr(prs, "_element", None) is not getattr(prs.part, "_element", None):
+        raise TargetNotFoundError(
+            "presentation is stale: its XML root is no longer the live package root"
+        )
 
 
 def _validate_find_replace(find, replace) -> None:
@@ -224,6 +239,9 @@ def _materialize_blocks(prs, include_notes):
                     " guarantee every occurrence is reached inside markup-compatibility"
                     " branches (inspect_text reports these as blind regions)" % partname
                 )
+            if txBody is None:
+                block_index += 1
+                continue
             for p in txBody.findall(qn("a:p")):
                 plan.append((partname, block_index, p))
                 block_index += 1
@@ -241,11 +259,16 @@ def _block_paragraph(prs, anchor: BlockAnchor):
             continue
         block_index = 0
         for kind, _, txBody, _, _ in iter_text_bodies(spTree):
-            if kind == "alternate-content":
+            if txBody is None:
                 if block_index == anchor.block_index:
+                    detail = (
+                        "mc:AlternateContent (a blind region)"
+                        if kind == "alternate-content"
+                        else "%s (a blind graphic region)" % kind
+                    )
                     raise UnsupportedStructureError(
-                        "the anchored block is mc:AlternateContent (a blind region);"
-                        " markup-compatibility content is not editable in v0.1"
+                        "the anchored block is %s; this content is not editable in v0.1"
+                        % detail
                     )
                 block_index += 1
                 continue

--- a/src/pptx/hf.py
+++ b/src/pptx/hf.py
@@ -68,6 +68,9 @@ def apply_presentation_footers(
     now: "Optional[datetime]" = None,
 ) -> None:
     """Apply the complete footer state to every slide (the dialog's "Apply to All")."""
+    from pptx._ownership import require_element_attached
+
+    require_element_attached(prs._element, prs.part, argument="presentation")
     _validate_arguments(footer, slide_number, date_format, fixed_date, now)
     if not isinstance(skip_title_slides, bool):
         raise ValueError("skip_title_slides must be True or False")
@@ -87,11 +90,16 @@ def apply_presentation_footers(
         if not all_off:
             _validate_slide_furniture(slide, footer, slide_number, date_format, fixed_date)
 
-    for slide, number, all_off in plans:
-        if all_off:
-            _apply_to_slide(slide, number, None, False, None, None, now)
-        else:
-            _apply_to_slide(slide, number, footer, slide_number, date_format, fixed_date, now)
+    from pptx._transaction import PackageTransaction
+
+    with PackageTransaction(prs.part.package, prs, *(slide for slide, _, _ in plans)):
+        for slide, number, all_off in plans:
+            if all_off:
+                _apply_to_slide(slide, number, None, False, None, None, now)
+            else:
+                _apply_to_slide(
+                    slide, number, footer, slide_number, date_format, fixed_date, now
+                )
 
 
 def apply_slide_footers(
@@ -104,11 +112,17 @@ def apply_slide_footers(
     now: "Optional[datetime]" = None,
 ) -> None:
     """Apply the complete footer state to one slide (the dialog's per-slide "Apply")."""
+    from pptx._ownership import require_element_attached
+
+    require_element_attached(slide._element, slide.part, argument="slide")
     _validate_arguments(footer, slide_number, date_format, fixed_date, now)
     prs = slide.part.package.presentation_part.presentation
     number = _first_slide_number(prs) + prs.slides.index(slide)
     _validate_slide_furniture(slide, footer, slide_number, date_format, fixed_date)
-    _apply_to_slide(slide, number, footer, slide_number, date_format, fixed_date, now)
+    from pptx._transaction import PackageTransaction
+
+    with PackageTransaction(slide.part.package, slide):
+        _apply_to_slide(slide, number, footer, slide_number, date_format, fixed_date, now)
 
 
 # ------------------------------------------------------------------------------ validation

--- a/src/pptx/inspect.py
+++ b/src/pptx/inspect.py
@@ -171,9 +171,13 @@ class BlockAnchor:
 class InspectedRun:
     text: str
     font: EffectiveFont
+    field_type: Optional[str] = None
 
     def to_dict(self) -> dict:
-        return {"text": self.text, "font": self.font.to_dict()}
+        payload = {"text": self.text, "font": self.font.to_dict()}
+        if self.field_type is not None:
+            payload["field_type"] = self.field_type
+        return payload
 
 
 @dataclass(frozen=True)
@@ -661,6 +665,12 @@ def _iter_container(container_elm, group_path):
         elif child.tag == qn("p:graphicFrame"):
             tbl = child.find(".//%s" % qn("a:tbl"))
             if tbl is None:
+                kind = (
+                    "chart"
+                    if child.find(".//%s" % qn("c:chart")) is not None
+                    else "graphic-frame"
+                )
+                yield kind, child, None, group_path, _cNvPr_name(child)
                 continue
             frame_name = _cNvPr_name(child)
             for row_index, tr in enumerate(tbl.findall(qn("a:tr"))):
@@ -674,7 +684,7 @@ def _iter_container(container_elm, group_path):
 def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
     """Append TextBlocks for every text body under `spTree` (see iter_text_bodies)."""
     for kind, owner, txBody, path, cell_detail in iter_text_bodies(spTree):
-        if kind == "alternate-content":
+        if kind in ("alternate-content", "chart", "graphic-frame"):
             cNvPr = owner.find(".//%s" % qn("p:cNvPr"))
             blocks.append(
                 TextBlock(
@@ -685,8 +695,8 @@ def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
                     level=0,
                     text="",
                     runs=(),
-                    container="alternate-content",
-                    container_detail="/".join(path) if path else None,
+                    container=kind,
+                    container_detail=cell_detail or ("/".join(path) if path else None),
                     blind=True,
                 )
             )
@@ -694,8 +704,13 @@ def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
         if kind == "table-cell":
             for p in txBody.findall(qn("a:p")):
                 runs = tuple(
-                    InspectedRun(_run_text(r), _blind_font("table-cell"))
-                    for r in p.findall(qn("a:r"))
+                    InspectedRun(
+                        "" if item.tag == qn("a:fld") else _run_text(item),
+                        _blind_font("table-cell"),
+                        (item.get("type") or "") if item.tag == qn("a:fld") else None,
+                    )
+                    for item in p
+                    if item.tag in (qn("a:r"), qn("a:fld"))
                 )
                 _append_block(
                     blocks, partname, owner, p, runs, None, "table-cell", cell_detail, True
@@ -708,8 +723,13 @@ def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
             container_detail = "/".join(path) if path else None
             for p in txBody.findall(qn("a:p")):
                 runs = tuple(
-                    InspectedRun(_run_text(r), resolver.effective_font(r, owner))
-                    for r in p.findall(qn("a:r"))
+                    InspectedRun(
+                        "" if item.tag == qn("a:fld") else _run_text(item),
+                        resolver.effective_font(item, owner),
+                        (item.get("type") or "") if item.tag == qn("a:fld") else None,
+                    )
+                    for item in p
+                    if item.tag in (qn("a:r"), qn("a:fld"))
                 )
                 _append_block(
                     blocks, partname, owner, p, runs, placeholder_type, kind,
@@ -720,13 +740,13 @@ def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
 def _append_block(
     blocks, partname, shape_elm, p, runs, placeholder_type, container, container_detail, blind
 ) -> None:
-    text = "".join(inspected.text for inspected in runs)
+    text = "".join(inspected.text for inspected in runs if inspected.field_type is None)
     pPr = p.find(qn("a:pPr"))
     level = int(pPr.get("lvl", "0")) if pPr is not None else 0
     cNvPr = shape_elm.find(".//%s" % qn("p:cNvPr"))
     # -- fields (a:fld) are recognized by type but excluded from text/hash: their display
     # -- text is volatile (PowerPoint re-renders it), so hashing it would rot anchors
-    fields = tuple(fld.get("type") or "" for fld in p.findall(qn("a:fld")))
+    fields = tuple(run.field_type for run in runs if run.field_type is not None)
     blocks.append(
         TextBlock(
             anchor=BlockAnchor(partname, len(blocks), content_hash(text)),
@@ -806,7 +826,7 @@ class _FontResolver(object):
         chain = list(self._chain(r, p, sp, level))
         return EffectiveFont(
             size=self._resolve_size(chain),
-            name=self._resolve_name(chain, _run_text(r)),
+            name=self._resolve_name(chain, "" if r.tag == qn("a:fld") else _run_text(r)),
             color_rgb=self._resolve_color(chain, sp),
             bold=self._resolve_flag(chain, "b", "bold"),
             italic=self._resolve_flag(chain, "i", "italic"),
@@ -850,22 +870,15 @@ class _FontResolver(object):
 
     def _placeholder_chain(self, sp, level):
         idx, ph_type = sp.ph_idx, sp.ph_type
-        layout_ph = self._layout.placeholders.get(idx=idx)
-        if layout_ph is None:
-            layout_ph = next(
-                (ph for ph in self._layout.placeholders if ph.element.ph_type == ph_type),
-                None,
-            )
+        layout_ph = self._layout_placeholder(idx, ph_type)
         yield (
             "layout placeholder lstStyle lvl%d" % (level + 1),
             str(self._layout.part.partname),
             self._ph_lstStyle_defRPr(layout_ph, level),
         )
 
-        master_ph_type = (
-            PP_PLACEHOLDER.TITLE if ph_type in _TITLE_FAMILY else PP_PLACEHOLDER.BODY
-        )
-        master_ph = self._master.placeholders.get(master_ph_type)
+        master_ph_type = self._master_placeholder_type(ph_type)
+        master_ph = self._master_placeholder(master_ph_type)
         yield (
             "master placeholder lstStyle lvl%d" % (level + 1),
             str(self._master.part.partname),
@@ -892,25 +905,14 @@ class _FontResolver(object):
         ph = sp.find(qn("p:nvSpPr") + "/" + qn("p:nvPr") + "/" + qn("p:ph"))
         if ph is not None:
             idx, ph_type = sp.ph_idx, sp.ph_type
-            layout_ph = self._layout.placeholders.get(idx=idx)
-            if layout_ph is None:
-                layout_ph = next(
-                    (
-                        candidate
-                        for candidate in self._layout.placeholders
-                        if candidate.element.ph_type == ph_type
-                    ),
-                    None,
-                )
+            layout_ph = self._layout_placeholder(idx, ph_type)
             yield (
                 "layout placeholder lstStyle lvl%d" % (level + 1),
                 str(self._layout.part.partname),
                 self._ph_lstStyle_pPr(layout_ph, level),
             )
-            master_ph_type = (
-                PP_PLACEHOLDER.TITLE if ph_type in _TITLE_FAMILY else PP_PLACEHOLDER.BODY
-            )
-            master_ph = self._master.placeholders.get(master_ph_type)
+            master_ph_type = self._master_placeholder_type(ph_type)
+            master_ph = self._master_placeholder(master_ph_type)
             yield (
                 "master placeholder lstStyle lvl%d" % (level + 1),
                 str(self._master.part.partname),
@@ -1131,6 +1133,72 @@ class _FontResolver(object):
         if ph_type in _BODY_FAMILY:
             return "bodyStyle", txStyles.bodyStyle if txStyles is not None else None
         return "otherStyle", txStyles.otherStyle if txStyles is not None else None
+
+    def _layout_placeholder(self, idx, ph_type):
+        """Return only the exact-idx layout placeholder used by PowerPoint inheritance."""
+        if idx == 4294967295:
+            return None
+        matches = [
+            placeholder
+            for placeholder in self._layout.placeholders
+            if placeholder.element.ph_idx == idx
+        ]
+        if len(matches) > 1:
+            def inheritance_type(placeholder_type):
+                if placeholder_type in _TITLE_FAMILY:
+                    return "title"
+                if placeholder_type in _BODY_FAMILY:
+                    return "body"
+                return placeholder_type
+
+            typed_matches = [
+                placeholder
+                for placeholder in matches
+                if inheritance_type(placeholder.element.ph_type)
+                == inheritance_type(ph_type)
+            ]
+            if len(typed_matches) == 1:
+                matches = typed_matches
+        if len(matches) > 1:
+            raise UnsupportedStructureError(
+                "layout %s has %d placeholders with idx %d; effective formatting "
+                "inheritance is ambiguous"
+                % (self._layout.part.partname, len(matches), idx)
+            )
+        if matches:
+            return matches[0]
+        raise UnsupportedStructureError(
+            "slide placeholder idx %d (type %s) has no layout placeholder with the same "
+            "idx; PowerPoint placeholder inheritance requires an exact idx match"
+            % (idx, ph_type.name)
+        )
+
+    def _master_placeholder(self, ph_type):
+        matches = [
+            placeholder
+            for placeholder in self._master.placeholders
+            if placeholder.element.ph_type == ph_type
+        ]
+        if len(matches) > 1:
+            raise UnsupportedStructureError(
+                "slide master %s has %d placeholders of type %s; effective formatting "
+                "inheritance is ambiguous"
+                % (self._master.part.partname, len(matches), ph_type.name)
+            )
+        return matches[0] if matches else None
+
+    @staticmethod
+    def _master_placeholder_type(ph_type):
+        if ph_type in _TITLE_FAMILY:
+            return PP_PLACEHOLDER.TITLE
+        if ph_type in (
+            PP_PLACEHOLDER.DATE,
+            PP_PLACEHOLDER.FOOTER,
+            PP_PLACEHOLDER.HEADER,
+            PP_PLACEHOLDER.SLIDE_NUMBER,
+        ):
+            return ph_type
+        return PP_PLACEHOLDER.BODY
 
     @staticmethod
     def _ph_lstStyle_defRPr(placeholder_proxy, level):

--- a/src/pptx/inspect.py
+++ b/src/pptx/inspect.py
@@ -705,12 +705,18 @@ def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
             for p in txBody.findall(qn("a:p")):
                 runs = tuple(
                     InspectedRun(
-                        "" if item.tag == qn("a:fld") else _run_text(item),
+                        (
+                            ""
+                            if item.tag == qn("a:fld")
+                            else "\v"
+                            if item.tag == qn("a:br")
+                            else _run_text(item)
+                        ),
                         _blind_font("table-cell"),
                         (item.get("type") or "") if item.tag == qn("a:fld") else None,
                     )
                     for item in p
-                    if item.tag in (qn("a:r"), qn("a:fld"))
+                    if item.tag in (qn("a:r"), qn("a:fld"), qn("a:br"))
                 )
                 _append_block(
                     blocks, partname, owner, p, runs, None, "table-cell", cell_detail, True
@@ -724,12 +730,18 @@ def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
             for p in txBody.findall(qn("a:p")):
                 runs = tuple(
                     InspectedRun(
-                        "" if item.tag == qn("a:fld") else _run_text(item),
+                        (
+                            ""
+                            if item.tag == qn("a:fld")
+                            else "\v"
+                            if item.tag == qn("a:br")
+                            else _run_text(item)
+                        ),
                         resolver.effective_font(item, owner),
                         (item.get("type") or "") if item.tag == qn("a:fld") else None,
                     )
                     for item in p
-                    if item.tag in (qn("a:r"), qn("a:fld"))
+                    if item.tag in (qn("a:r"), qn("a:fld"), qn("a:br"))
                 )
                 _append_block(
                     blocks, partname, owner, p, runs, placeholder_type, kind,
@@ -1056,7 +1068,7 @@ class _FontResolver(object):
             ]
         schemeClr = style_ref.find(qn("a:schemeClr"))
         if schemeClr is not None:
-            resolved = self._resolve_scheme_color(schemeClr.get("val"), [])
+            resolved = self._resolve_scheme_color(schemeClr.get("val"), [], partname)
             rgb = resolved.value if resolved.resolved else None
             return rgb, [
                 ProvenanceStep(
@@ -1093,13 +1105,13 @@ class _FontResolver(object):
                 )
             )
             if len(schemeClr):
-                base = self._resolve_scheme_color(schemeClr.get("val"), steps)
+                base = self._resolve_scheme_color(schemeClr.get("val"), steps, partname)
                 if not base.resolved or base.value is None:
                     return base
                 return self._transformed_color_value(
                     schemeClr, str(base.value), list(base.provenance)
                 )
-            return self._resolve_scheme_color(schemeClr.get("val"), steps)
+            return self._resolve_scheme_color(schemeClr.get("val"), steps, partname)
         steps.append(
             ProvenanceStep(
                 label,
@@ -1382,13 +1394,13 @@ class _FontResolver(object):
                     )
                 )
                 if len(schemeClr):
-                    base = self._resolve_scheme_color(schemeClr.get("val"), steps)
+                    base = self._resolve_scheme_color(schemeClr.get("val"), steps, partname)
                     if not base.resolved or base.value is None:
                         return base
                     return self._transformed_color_value(
                         schemeClr, str(base.value), list(base.provenance)
                     )
-                return self._resolve_scheme_color(schemeClr.get("val"), steps)
+                return self._resolve_scheme_color(schemeClr.get("val"), steps, partname)
             steps.append(
                 ProvenanceStep(
                     label,
@@ -1403,8 +1415,8 @@ class _FontResolver(object):
             return EffectiveValue(None, None, False, tuple(steps))
         return EffectiveValue(None, None, False, tuple(steps))
 
-    def _resolve_scheme_color(self, token, steps) -> EffectiveValue:
-        slot, map_step = self._map_scheme_token(token)
+    def _resolve_scheme_color(self, token, steps, source_partname) -> EffectiveValue:
+        slot, map_step = self._map_scheme_token(token, source_partname)
         steps.append(map_step)
         if slot is None:
             return EffectiveValue(None, None, False, tuple(steps))
@@ -1448,9 +1460,9 @@ class _FontResolver(object):
         )
         return EffectiveValue(rgb, None, rgb is not None, tuple(steps))
 
-    def _map_scheme_token(self, token):
+    def _map_scheme_token(self, token, source_partname):
         """Return (theme-slot, ProvenanceStep) for schemeClr `token`."""
-        override = self._clrMapOvr_mapping()
+        override = self._clrMapOvr_mapping(source_partname)
         if override is not None:
             mapping, source_label, source_part = override
         else:
@@ -1473,9 +1485,21 @@ class _FontResolver(object):
             source_label, source_part, "unmappable scheme color token %r" % token, False
         )
 
-    def _clrMapOvr_mapping(self):
-        """Return (mapping, label, partname) from the slide's clrMapOvr, or None to defer."""
-        clrMapOvr = self._slide_part._element.find(qn("p:clrMapOvr"))
+    def _clrMapOvr_mapping(self, source_partname):
+        """Return the color-map override belonging to the property source part."""
+        layout_partname = str(self._layout.part.partname)
+        master_partname = str(self._master.part.partname)
+        if source_partname == master_partname:
+            return None
+        if source_partname == layout_partname:
+            root = self._layout._element
+            label = "layout clrMapOvr"
+            partname = layout_partname
+        else:
+            root = self._slide_part._element
+            label = "slide clrMapOvr"
+            partname = str(self._slide_part.partname)
+        clrMapOvr = root.find(qn("p:clrMapOvr"))
         if clrMapOvr is None:
             return None
         overrideClrMapping = clrMapOvr.find(qn("a:overrideClrMapping"))
@@ -1483,8 +1507,8 @@ class _FontResolver(object):
             return None  # -- a:masterClrMapping (or empty): defer to the master's clrMap
         return (
             dict(overrideClrMapping.attrib),
-            "slide clrMapOvr",
-            str(self._slide_part.partname),
+            label,
+            partname,
         )
 
     # ------------------------------------------------------------------------- helpers

--- a/src/pptx/opc/package.py
+++ b/src/pptx/opc/package.py
@@ -172,6 +172,7 @@ class OpcPackage(_RelatableMixin):
             PackageWriter.write(staged, self._rels, parts)
             staged.seek(0)
 
+            original_position = None
             try:
                 original_position = stream.tell()
                 stream.seek(0, os.SEEK_END)
@@ -186,13 +187,26 @@ class OpcPackage(_RelatableMixin):
                     raise OSError("could not snapshot complete destination stream")
                 truncate = stream.truncate
                 stream.seek(0)
-            except PackageLimitError:
+            except BaseException as setup_error:
+                if original_position is not None:
+                    try:
+                        stream.seek(original_position)
+                        if stream.tell() != original_position:
+                            raise OSError("destination stream did not restore its position")
+                    except BaseException as restore_error:
+                        raise RuntimeError(
+                            "package stream setup failed and the original position could not "
+                            "be restored"
+                        ) from restore_error
+                if isinstance(setup_error, PackageLimitError):
+                    raise
+                if isinstance(setup_error, (AttributeError, OSError, TypeError, ValueError)):
+                    raise UnsupportedStructureError(
+                        "saving to a stream requires readable, seekable, truncatable "
+                        "binary I/O (%s)"
+                        % setup_error
+                    ) from setup_error
                 raise
-            except (AttributeError, OSError, TypeError, ValueError) as exc:
-                raise UnsupportedStructureError(
-                    "saving to a stream requires readable, seekable, truncatable binary I/O (%s)"
-                    % exc
-                ) from exc
 
             try:
                 while True:

--- a/src/pptx/opc/package.py
+++ b/src/pptx/opc/package.py
@@ -161,7 +161,62 @@ class OpcPackage(_RelatableMixin):
         if isinstance(pkg_file, (str, os.PathLike)):
             self._save_path_atomically(os.fspath(pkg_file), parts)
             return
-        PackageWriter.write(pkg_file, self._rels, parts)
+        self._save_stream_atomically(pkg_file, parts)
+
+    def _save_stream_atomically(self, stream: IO[bytes], parts: tuple[Part, ...]) -> None:
+        """Stage output and restore a seekable destination if publishing fails."""
+        from pptx._zipguard import MAX_COMPRESSED_BYTES
+        from pptx.errors import PackageLimitError, UnsupportedStructureError
+
+        with tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024, mode="w+b") as staged:
+            PackageWriter.write(staged, self._rels, parts)
+            staged.seek(0)
+
+            try:
+                original_position = stream.tell()
+                stream.seek(0, os.SEEK_END)
+                original_size = stream.tell()
+                if original_size > MAX_COMPRESSED_BYTES:
+                    raise PackageLimitError(
+                        "existing package destination stream exceeds the compressed package limit"
+                    )
+                stream.seek(0)
+                original = stream.read(original_size)
+                if not isinstance(original, bytes) or len(original) != original_size:
+                    raise OSError("could not snapshot complete destination stream")
+                truncate = stream.truncate
+                stream.seek(0)
+            except PackageLimitError:
+                raise
+            except (AttributeError, OSError, TypeError, ValueError) as exc:
+                raise UnsupportedStructureError(
+                    "saving to a stream requires readable, seekable, truncatable binary I/O (%s)"
+                    % exc
+                ) from exc
+
+            try:
+                while True:
+                    chunk = staged.read(64 * 1024)
+                    if not chunk:
+                        break
+                    written = stream.write(chunk)
+                    if written is not None and written != len(chunk):
+                        raise OSError("destination stream performed a short write")
+                truncate()
+            except BaseException as publish_error:
+                try:
+                    stream.seek(0)
+                    written = stream.write(original)
+                    if written is not None and written != len(original):
+                        raise OSError("destination stream performed a short restore write")
+                    truncate()
+                    stream.seek(original_position)
+                except BaseException as restore_error:
+                    raise RuntimeError(
+                        "package stream write failed and the original destination could not "
+                        "be restored"
+                    ) from restore_error
+                raise publish_error
 
     def _save_path_atomically(self, path: str, parts: tuple[Part, ...]) -> None:
         """Serialize beside `path` and replace it only after a complete successful write."""

--- a/src/pptx/rebind.py
+++ b/src/pptx/rebind.py
@@ -391,12 +391,16 @@ def _resolution_state(slide, *, align_by_content: bool = False):
     for block in inspect_text(slide).blocks:
         ordinal = block_ordinals.get(block.shape_id, 0)
         block_ordinals[block.shape_id] = ordinal + 1
-        runs = [run for run in block.runs if run.text != "\v"]
+        indexed_runs = [
+            (run_index, run)
+            for run_index, run in enumerate(block.runs)
+            if run.text != "\v"
+        ]
         identities = [
             ("field", run.field_type) if run.field_type is not None else ("text", run.text)
-            for run in runs
+            for _, run in indexed_runs
         ]
-        for run_index, (run, identity) in enumerate(zip(runs, identities)):
+        for (run_index, run), identity in zip(indexed_runs, identities):
             if align_by_content and (not identity[1] or identities.count(identity) != 1):
                 continue
             font = run.font

--- a/src/pptx/rebind.py
+++ b/src/pptx/rebind.py
@@ -122,8 +122,7 @@ class RebindReport:
             "target_layout": self.target_layout,
             "target_layout_name": self.target_layout_name,
             "placeholder_map_used": [
-                {"source_idx": src, "target_idx": tgt}
-                for src, tgt in self.placeholder_map_used
+                {"source_idx": src, "target_idx": tgt} for src, tgt in self.placeholder_map_used
             ],
             "baked_orphans": list(self.baked_orphans),
             "run_shifts": [shift.to_dict() for shift in self.run_shifts],
@@ -138,7 +137,12 @@ def rebind_layout(
     orphan_policy: str = "refuse",
 ) -> RebindReport:
     """Rebind `slide` to `target_layout`; return the required shift report."""
-    from pptx.slide import SlideLayout
+    from pptx._transaction import PackageTransaction
+    from pptx.slide import (
+        SlideLayout,
+        _require_layout_enrolled,
+        _require_slide_enrolled,
+    )
 
     if not isinstance(target_layout, SlideLayout):
         raise ValueError("target_layout must be a SlideLayout, got %r" % (target_layout,))
@@ -149,7 +153,23 @@ def rebind_layout(
         )
     if orphan_policy not in ("refuse", "bake"):
         raise ValueError("orphan_policy must be 'refuse' or 'bake', got %r" % (orphan_policy,))
+    _require_slide_enrolled(slide)
+    _require_layout_enrolled(target_layout)
+    with PackageTransaction(slide.part.package, slide, target_layout):
+        return _rebind_layout_impl(
+            slide,
+            target_layout,
+            placeholder_map=placeholder_map,
+            orphan_policy=orphan_policy,
+        )
+
+
+def _rebind_layout_impl(slide, target_layout, *, placeholder_map, orphan_policy) -> RebindReport:
+    """Perform a rebind inside the caller's package transaction."""
     source_layout = slide.slide_layout
+    from pptx.slide import _require_layout_enrolled
+
+    _require_layout_enrolled(source_layout, argument="source layout")
     if target_layout.part is source_layout.part:
         raise ValueError("target_layout is already this slide's layout")
     if any(True for _ in slide._element.spTree.iterchildren(_MC_ALTERNATE_CONTENT)):
@@ -185,8 +205,7 @@ def rebind_layout(
                 "volatile content - remove the placeholder or map it explicitly" % shape.name
             )
         if any(
-            getattr(shape, attribute) is None
-            for attribute in ("left", "top", "width", "height")
+            getattr(shape, attribute) is None for attribute in ("left", "top", "width", "height")
         ):
             raise UnsupportedStructureError(
                 "placeholder %r has no resolvable geometry (no a:xfrm anywhere in its "
@@ -199,10 +218,13 @@ def rebind_layout(
                     unsafe_name = any(
                         "non-Latin" in step.detail for step in effective.name.provenance
                     )
-                    unsafe_color = any(
-                        "unapplied transforms" in step.detail
-                        for step in effective.color_rgb.provenance
-                    ) and effective.color_rgb.bake_color_xml is None
+                    unsafe_color = (
+                        any(
+                            "unapplied transforms" in step.detail
+                            for step in effective.color_rgb.provenance
+                        )
+                        and effective.color_rgb.bake_color_xml is None
+                    )
                     if unsafe_name or unsafe_color:
                         raise UnsupportedStructureError(
                             "placeholder %r has unresolved text formatting; baking would "
@@ -321,9 +343,7 @@ def _compute_mapping(slide_phs, target_layout, placeholder_map):
     for shape in unmatched:
         source_idx = shape.element.ph_idx
         exact = slot_by_idx.get(source_idx)
-        if exact is not None and exact[0] == shape.element.ph_type and (
-            source_idx not in claimed
-        ):
+        if exact is not None and exact[0] == shape.element.ph_type and (source_idx not in claimed):
             mapping[source_idx] = exact
             claimed.add(source_idx)
         else:
@@ -332,9 +352,7 @@ def _compute_mapping(slide_phs, target_layout, placeholder_map):
     unmatched, still_unmatched = still_unmatched, []
     for shape in unmatched:
         source_type = shape.element.ph_type
-        same_type = [
-            slot for slot in slots if slot[0] == source_type and slot[1] not in claimed
-        ]
+        same_type = [slot for slot in slots if slot[0] == source_type and slot[1] not in claimed]
         if same_type:
             mapping[shape.element.ph_idx] = same_type[0]
             claimed.add(same_type[0][1])
@@ -414,8 +432,7 @@ def _bake_placeholder(shape) -> None:
     # -- before writing ANY: writing `left` creates an a:off whose y defaults to 0, which
     # -- a subsequent `top` read would see as a local value, poisoning the inheritance.
     geometry = {
-        attribute: getattr(shape, attribute)
-        for attribute in ("left", "top", "width", "height")
+        attribute: getattr(shape, attribute) for attribute in ("left", "top", "width", "height")
     }
     for attribute, value in geometry.items():
         setattr(shape, attribute, Emu(value))
@@ -449,17 +466,17 @@ def _bake_placeholder(shape) -> None:
                         and effective_value.value is not None
                     ):
                         setattr(run.font, emphasis, effective_value.value)
-                if effective.underline is not None and effective.underline.resolved and (
-                    effective.underline.value is not None
+                if (
+                    effective.underline is not None
+                    and effective.underline.resolved
+                    and (effective.underline.value is not None)
                 ):
                     from pptx.enum.text import MSO_TEXT_UNDERLINE_TYPE
 
                     # -- the resolved value is the raw `u` token ("none", "sng", "dbl",
                     # -- ...); bake the exact token so the style (including "explicitly
                     # -- not underlined") cannot re-resolve under the new layout
-                    run.font.underline = MSO_TEXT_UNDERLINE_TYPE.from_xml(
-                        effective.underline.value
-                    )
+                    run.font.underline = MSO_TEXT_UNDERLINE_TYPE.from_xml(effective.underline.value)
 
     ph = shape.element.ph
     ph.getparent().remove(ph)

--- a/src/pptx/rebind.py
+++ b/src/pptx/rebind.py
@@ -391,7 +391,10 @@ def _resolution_state(slide):
     for block in inspect_text(slide).blocks:
         ordinal = block_ordinals.get(block.shape_id, 0)
         block_ordinals[block.shape_id] = ordinal + 1
-        for run_index, run in enumerate(block.runs):
+        literal_runs = [
+            run for run in block.runs if run.field_type is None and run.text != "\v"
+        ]
+        for run_index, run in enumerate(literal_runs):
             font = run.font
             key = (block.shape_id, ordinal, run_index)
             values = (

--- a/src/pptx/rebind.py
+++ b/src/pptx/rebind.py
@@ -378,7 +378,7 @@ def _compute_mapping(slide_phs, target_layout, placeholder_map):
 # ------------------------------------------------------------------------ resolve and bake
 
 
-def _resolution_state(slide):
+def _resolution_state(slide, *, align_by_content: bool = False):
     """(comparable values, payload) per run, keyed (shape_id, block_ordinal, run_index).
 
     The key is shape-scoped so shapes appearing or disappearing elsewhere on the slide
@@ -391,12 +391,20 @@ def _resolution_state(slide):
     for block in inspect_text(slide).blocks:
         ordinal = block_ordinals.get(block.shape_id, 0)
         block_ordinals[block.shape_id] = ordinal + 1
-        literal_runs = [
-            run for run in block.runs if run.field_type is None and run.text != "\v"
+        runs = [run for run in block.runs if run.text != "\v"]
+        identities = [
+            ("field", run.field_type) if run.field_type is not None else ("text", run.text)
+            for run in runs
         ]
-        for run_index, run in enumerate(literal_runs):
+        for run_index, (run, identity) in enumerate(zip(runs, identities)):
+            if align_by_content and (not identity[1] or identities.count(identity) != 1):
+                continue
             font = run.font
-            key = (block.shape_id, ordinal, run_index)
+            key = (
+                (block.shape_id, ordinal, identity)
+                if align_by_content
+                else (block.shape_id, ordinal, run_index)
+            )
             values = (
                 font.size.value,
                 font.name.value,
@@ -405,22 +413,22 @@ def _resolution_state(slide):
                 font.italic.value if font.italic is not None else None,
                 font.underline.value if font.underline is not None else None,
             )
-            state[key] = (values, run.text, block.anchor.part, font.to_dict())
+            state[key] = (values, run.text, block.anchor.part, font.to_dict(), run_index)
     return state
 
 
 def _shifts_between(before_state, after_state) -> "Tuple[RunShift, ...]":
     shifts = []
     for key in sorted(set(before_state) & set(after_state)):
-        before_values, text, part, before_payload = before_state[key]
-        after_values, _, _, after_payload = after_state[key]
+        before_values, text, part, before_payload, run_index = before_state[key]
+        after_values, _, _, after_payload, _ = after_state[key]
         if before_values != after_values:
             shifts.append(
                 RunShift(
                     part=part,
                     shape_id=key[0],
                     block_ordinal=key[1],
-                    run_index=key[2],
+                    run_index=run_index,
                     text=text,
                     before=before_payload,
                     after=after_payload,

--- a/src/pptx/scrub.py
+++ b/src/pptx/scrub.py
@@ -112,6 +112,35 @@ def scrub_presentation(
     unreachable_media: bool = False,
     embedded_fonts: bool = False,
 ) -> ScrubReport:
+    """Perform the toggled scrub passes as one refusal-atomic operation."""
+    from pptx._transaction import PackageTransaction
+
+    with PackageTransaction(prs.part.package, prs):
+        return _scrub_presentation(
+            prs,
+            notes=notes,
+            comments=comments,
+            metadata=metadata,
+            hidden_slides=hidden_slides,
+            unused_layouts=unused_layouts,
+            unused_masters=unused_masters,
+            unreachable_media=unreachable_media,
+            embedded_fonts=embedded_fonts,
+        )
+
+
+def _scrub_presentation(
+    prs: "Presentation",
+    *,
+    notes: bool = False,
+    comments: bool = False,
+    metadata: bool = False,
+    hidden_slides: bool = False,
+    unused_layouts: bool = False,
+    unused_masters: bool = False,
+    unreachable_media: bool = False,
+    embedded_fonts: bool = False,
+) -> ScrubReport:
     """Perform the toggled scrub passes on `prs` and return the |ScrubReport|."""
     toggles = {
         "notes": notes,

--- a/src/pptx/scrub.py
+++ b/src/pptx/scrub.py
@@ -113,6 +113,26 @@ def scrub_presentation(
     embedded_fonts: bool = False,
 ) -> ScrubReport:
     """Perform the toggled scrub passes as one refusal-atomic operation."""
+    toggles = {
+        "notes": notes,
+        "comments": comments,
+        "metadata": metadata,
+        "hidden_slides": hidden_slides,
+        "unused_layouts": unused_layouts,
+        "unused_masters": unused_masters,
+        "unreachable_media": unreachable_media,
+        "embedded_fonts": embedded_fonts,
+    }
+    _validate_toggles(toggles)
+    if not any(toggles.values()):
+        return ScrubReport(
+            notes_master_retained=any(
+                rel.reltype.endswith("/notesMaster")
+                for rel in prs.part.rels.values()
+                if not rel.is_external
+            )
+        )
+
     from pptx._transaction import PackageTransaction
 
     with PackageTransaction(prs.part.package, prs):
@@ -152,9 +172,7 @@ def _scrub_presentation(
         "unreachable_media": unreachable_media,
         "embedded_fonts": embedded_fonts,
     }
-    for name, value in toggles.items():
-        if not isinstance(value, bool):
-            raise ValueError("%s must be True or False, got %r" % (name, value))
+    _validate_toggles(toggles)
 
     from pptx.errors import UnsupportedStructureError, materialize_slides
 
@@ -413,3 +431,10 @@ def _scrub_presentation(
         parts_removed=tuple(sorted(parts_removed)),
         parts_modified=tuple(sorted(modified)),
     )
+
+
+def _validate_toggles(toggles: dict) -> None:
+    """Raise |ValueError| unless every scrub toggle is boolean."""
+    for name, value in toggles.items():
+        if not isinstance(value, bool):
+            raise ValueError("%s must be True or False, got %r" % (name, value))

--- a/src/pptx/shapes/picture.py
+++ b/src/pptx/shapes/picture.py
@@ -36,21 +36,6 @@ def _part_xml_references_rId(root, rId: str) -> bool:
     return False
 
 
-def _require_picture_slide_enrolled(picture) -> None:
-    """Refuse a picture retained after its owning slide was deleted."""
-    from pptx.errors import TargetNotFoundError, materialize_slides
-
-    presentation = picture.part.package.presentation_part.presentation
-    if any(
-        slide.part is picture.part
-        for slide in materialize_slides(presentation, "replace_image")
-    ):
-        return
-    raise TargetNotFoundError(
-        "picture is stale: its slide is no longer enrolled in the presentation"
-    )
-
-
 class _BasePicture(BaseShape):
     """Base class for shapes based on a `p:pic` element."""
 
@@ -204,7 +189,6 @@ class Picture(_BasePicture):
 
         # -- validation pass, complete before any mutation --
         require_shape_attached(self, argument="picture")
-        _require_picture_slide_enrolled(self)
         if not isinstance(allow_format_change, bool):
             raise ValueError(
                 "allow_format_change must be a bool, got %r" % (allow_format_change,)

--- a/src/pptx/shapes/picture.py
+++ b/src/pptx/shapes/picture.py
@@ -36,6 +36,21 @@ def _part_xml_references_rId(root, rId: str) -> bool:
     return False
 
 
+def _require_picture_slide_enrolled(picture) -> None:
+    """Refuse a picture retained after its owning slide was deleted."""
+    from pptx.errors import TargetNotFoundError, materialize_slides
+
+    presentation = picture.part.package.presentation_part.presentation
+    if any(
+        slide.part is picture.part
+        for slide in materialize_slides(presentation, "replace_image")
+    ):
+        return
+    raise TargetNotFoundError(
+        "picture is stale: its slide is no longer enrolled in the presentation"
+    )
+
+
 class _BasePicture(BaseShape):
     """Base class for shapes based on a `p:pic` element."""
 
@@ -189,6 +204,7 @@ class Picture(_BasePicture):
 
         # -- validation pass, complete before any mutation --
         require_shape_attached(self, argument="picture")
+        _require_picture_slide_enrolled(self)
         if not isinstance(allow_format_change, bool):
             raise ValueError(
                 "allow_format_change must be a bool, got %r" % (allow_format_change,)
@@ -220,16 +236,19 @@ class Picture(_BasePicture):
             )
 
         # -- mutation --
-        image_part = self.part.package.get_or_add_image_part(io.BytesIO(new_image.blob))
-        new_rId = self.part.relate_to(image_part, RT.IMAGE)
-        if new_rId == old_rId:
-            return  # -- identical image bytes: already in place
-        self._pic.blipFill.blip.rEmbed = new_rId
-        # -- another shape on this slide may still reference old_rId (pictures added from
-        # -- identical bytes share one relationship); XmlPart.drop_rel only counts @r:id
-        # -- references, so guard with a scan over ALL r-namespace attributes.
-        if not _part_xml_references_rId(self.part._element, old_rId):
-            self.part.drop_rel(old_rId)
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
+            image_part = self.part.package.get_or_add_image_part(io.BytesIO(new_image.blob))
+            new_rId = self.part.relate_to(image_part, RT.IMAGE)
+            if new_rId == old_rId:
+                return  # -- identical image bytes: already in place
+            self._pic.blipFill.blip.rEmbed = new_rId
+            # -- another shape on this slide may still reference old_rId (pictures added from
+            # -- identical bytes share one relationship); XmlPart.drop_rel only counts @r:id
+            # -- references, so guard with a scan over ALL r-namespace attributes.
+            if not _part_xml_references_rId(self.part._element, old_rId):
+                self.part.drop_rel(old_rId)
 
     @property
     def auto_shape_type(self) -> MSO_SHAPE | None:

--- a/src/pptx/shapes/shapetree.py
+++ b/src/pptx/shapes/shapetree.py
@@ -658,11 +658,12 @@ class SlideShapes(_BaseGroupShapes):
         before anything changes. A shape from another presentation raises
         |TargetNotFoundError|.
         """
-        from pptx._ownership import require_shape_attached
+        from pptx._ownership import require_shape_attached, require_shape_tree_attached
         from pptx.errors import RelationshipPolicyError, TargetNotFoundError
         from pptx.opc.constants import RELATIONSHIP_TYPE as RT
         from pptx.slideops import _copy_chart_part, _rewrite_r_references, _validate_chart_rels
 
+        require_shape_tree_attached(self)
         require_shape_attached(shape)
         source_element = shape._element
         source_part = shape.part
@@ -706,22 +707,26 @@ class SlideShapes(_BaseGroupShapes):
             cNvPr.set("id", str(next_id))
             next_id += 1
 
-        rId_mapping = {}
-        allocated: set = set()
-        for old_rId, action, rel in plan:
-            if action == "external":
-                rId_mapping[old_rId] = self.part.rels.get_or_add_ext_rel(
-                    rel.reltype, rel.target_ref
-                )
-            elif action == "share":
-                rId_mapping[old_rId] = self.part.relate_to(rel.target_part, rel.reltype)
-            else:  # -- chart: deep copy with workbook/style parts
-                rId_mapping[old_rId] = self.part.relate_to(
-                    _copy_chart_part(rel.target_part, allocated), rel.reltype
-                )
-        _rewrite_r_references(new_element, rId_mapping)
-        self._spTree.append(new_element)
-        return self._shape_factory(new_element)
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self, shape):
+            rId_mapping = {}
+            allocated: set = set()
+            for old_rId, action, rel in plan:
+                if action == "external":
+                    rId_mapping[old_rId] = self.part.rels.get_or_add_ext_rel(
+                        rel.reltype, rel.target_ref
+                    )
+                elif action == "share":
+                    rId_mapping[old_rId] = self.part.relate_to(rel.target_part, rel.reltype)
+                else:  # -- chart: deep copy with workbook/style parts
+                    rId_mapping[old_rId] = self.part.relate_to(
+                        _copy_chart_part(rel.target_part, allocated), rel.reltype
+                    )
+            _rewrite_r_references(new_element, rId_mapping)
+            self._spTree.append(new_element)
+            copied_shape = self._shape_factory(new_element)
+        return copied_shape
 
     def chart_by_name(self, name: str):
         """Return the |Chart| held by the shape on this slide named `name`.
@@ -760,7 +765,10 @@ class SlideShapes(_BaseGroupShapes):
         this collection — including a shape inside a group — raises |TargetNotFoundError|
         (delete the group, or ungroup first).
         """
+        from pptx._ownership import require_shape_tree_attached
         from pptx.errors import TargetNotFoundError, UnsupportedStructureError
+
+        require_shape_tree_attached(self)
 
         element = getattr(shape, "_element", None)
         if element is None or element.getparent() is not self._spTree:
@@ -775,10 +783,13 @@ class SlideShapes(_BaseGroupShapes):
                 "shape %r references missing relationships: %s"
                 % (getattr(shape, "name", shape), ", ".join(missing_rIds))
             )
-        self._spTree.remove(element)
-        for rId in sorted(subtree_rIds):
-            if not _part_references_rId(self.part._element, rId):
-                self.part.drop_rel(rId)
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self, shape):
+            self._spTree.remove(element)
+            for rId in sorted(subtree_rIds):
+                if not _part_references_rId(self.part._element, rId):
+                    self.part.drop_rel(rId)
 
     def move(self, shape, to_index: int) -> None:
         """Move `shape` to 0-based `to_index` in this collection's z-order.
@@ -787,7 +798,10 @@ class SlideShapes(_BaseGroupShapes):
         the same order this collection iterates. `to_index` outside range raises
         |ValueError|; a shape not directly in this collection raises |TargetNotFoundError|.
         """
+        from pptx._ownership import require_shape_tree_attached
         from pptx.errors import TargetNotFoundError
+
+        require_shape_tree_attached(self)
 
         element = getattr(shape, "_element", None)
         members = list(self._iter_member_elms())
@@ -804,11 +818,14 @@ class SlideShapes(_BaseGroupShapes):
             raise ValueError(
                 "to_index must be an int in range 0..%d, got %r" % (len(members) - 1, to_index)
             )
-        members.remove(element)
-        if to_index >= len(members):
-            members[-1].addnext(element)
-        else:
-            members[to_index].addprevious(element)
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self, shape):
+            members.remove(element)
+            if to_index >= len(members):
+                members[-1].addnext(element)
+            else:
+                members[to_index].addprevious(element)
 
     def picture_by_name(self, name: str):
         """Return the |Picture| on this slide named `name` (group-aware).

--- a/src/pptx/shapes/shapetree.py
+++ b/src/pptx/shapes/shapetree.py
@@ -661,7 +661,12 @@ class SlideShapes(_BaseGroupShapes):
         from pptx._ownership import require_shape_attached, require_shape_tree_attached
         from pptx.errors import RelationshipPolicyError, TargetNotFoundError
         from pptx.opc.constants import RELATIONSHIP_TYPE as RT
-        from pptx.slideops import _copy_chart_part, _rewrite_r_references, _validate_chart_rels
+        from pptx.slideops import (
+            _copy_chart_part,
+            _CopySession,
+            _rewrite_r_references,
+            _validate_chart_rels,
+        )
 
         require_shape_tree_attached(self)
         require_shape_attached(shape)
@@ -707,11 +712,23 @@ class SlideShapes(_BaseGroupShapes):
             cNvPr.set("id", str(next_id))
             next_id += 1
 
+        copied_sources = [source_part]
+        for _, action, rel in plan:
+            if action != "chart":
+                continue
+            copied_sources.append(rel.target_part)
+            copied_sources.extend(
+                child.target_part
+                for child in rel.target_part.rels.values()
+                if not child.is_external
+            )
+        allocated = _CopySession(self.part.package, copied_sources)
+        allocated.remap_element(new_element)
+
         from pptx._transaction import PackageTransaction
 
         with PackageTransaction(self.part.package, self, shape):
             rId_mapping = {}
-            allocated: set = set()
             for old_rId, action, rel in plan:
                 if action == "external":
                     rId_mapping[old_rId] = self.part.rels.get_or_add_ext_rel(

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -833,15 +833,24 @@ class SlideLayouts(ParentedElementProxy):
         """
         from pptx._transaction import PackageTransaction
 
+        # Preserve the established error contract before attachment checks.
+        if slide_layout.used_by_slides:
+            raise ValueError("cannot remove slide-layout in use by one or more slides")
+
+        # Upstream supports isolated collection proxies in its unit-level API contract.
+        # A real presentation always supplies a parent and takes the hardened path below.
+        if self._parent is None:
+            target_idx = self.index(slide_layout)
+            target_sldLayoutId = self._sldLayoutIdLst.sldLayoutId_lst[target_idx]
+            self._sldLayoutIdLst.remove(target_sldLayoutId)
+            slide_layout.slide_master.part.drop_rel(target_sldLayoutId.rId)
+            return
+
         if not isinstance(slide_layout, SlideLayout):
             raise ValueError("slide_layout must be a SlideLayout, got %r" % (slide_layout,))
         if slide_layout.part.package is not self.part.package:
             raise TargetNotFoundError("slide_layout belongs to a different presentation")
         _require_layout_enrolled(slide_layout)
-
-        # ---raise if layout is in use---
-        if slide_layout.used_by_slides:
-            raise ValueError("cannot remove slide-layout in use by one or more slides")
 
         # ---target layout is identified by its index in this collection---
         target_idx = self.index(slide_layout)

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -24,6 +24,77 @@ from pptx.shapes.shapetree import (
 from pptx.shared import ElementProxy, ParentedElementProxy, PartElementProxy
 from pptx.util import lazyproperty
 
+
+def _relationship_references(root, rId: str) -> bool:
+    """Return whether any relationship-qualified XML attribute contains `rId`."""
+    return any(
+        value == rId
+        and name.startswith("{http://schemas.openxmlformats.org/officeDocument/2006/relationships}")
+        for element in root.iter()
+        for name, value in element.attrib.items()
+    )
+
+
+def _require_slide_enrolled(slide: "Slide", *, argument: str = "slide") -> None:
+    """Refuse a detached slide proxy before it can mutate unreachable XML."""
+    package = slide.part.package
+    presentation_part = package.presentation_part
+    matches = []
+    for sldId in presentation_part._element.sldIdLst.sldId_lst:
+        try:
+            rel = presentation_part.rels[sldId.rId]
+            if not rel.is_external and rel.reltype == RT.SLIDE and rel.target_part is slide.part:
+                matches.append(sldId)
+        except (AssertionError, KeyError, ValueError):
+            continue
+    if len(matches) != 1 or slide._element is not slide.part._element:
+        raise TargetNotFoundError("%s is stale or no longer enrolled" % argument)
+
+
+def _require_layout_enrolled(layout: "SlideLayout", *, argument: str = "slide_layout") -> None:
+    """Refuse a detached layout proxy before it can be selected as a target."""
+    from pptx.parts.slide import SlideMasterPart
+
+    package = layout.part.package
+    matches = []
+    for part in package.iter_parts():
+        if not isinstance(part, SlideMasterPart):
+            continue
+        id_list = part._element.sldLayoutIdLst
+        if id_list is None:
+            continue
+        for entry in id_list.sldLayoutId_lst:
+            try:
+                rel = part.rels[entry.rId]
+                if (
+                    not rel.is_external
+                    and rel.reltype == RT.SLIDE_LAYOUT
+                    and rel.target_part is layout.part
+                ):
+                    matches.append((part, entry))
+            except (AssertionError, KeyError, ValueError):
+                continue
+    if len(matches) != 1 or layout._element is not layout.part._element:
+        raise TargetNotFoundError("%s is stale or no longer enrolled" % argument)
+
+
+def _inbound_relationships(package, target_part):
+    """Return every reachable internal relationship targeting `target_part`."""
+    inbound = []
+    owners = [package] + list(package.iter_parts())
+    for owner in owners:
+        relationships = package._rels if owner is package else owner.rels
+        for rId, rel in relationships.items():
+            if rel.is_external:
+                continue
+            try:
+                if rel.target_part is target_part:
+                    inbound.append((owner, rId, rel))
+            except (AssertionError, ValueError):
+                continue
+    return tuple(inbound)
+
+
 if TYPE_CHECKING:
     from datetime import datetime
 
@@ -358,8 +429,7 @@ class Slide(_BaseSlide):
         text_frame = notes_slide.notes_text_frame
         if text_frame is None:
             raise UnsupportedStructureError(
-                "notes slide of slide %d has no body placeholder to hold notes text"
-                % self.slide_id
+                "notes slide of slide %d has no body placeholder to hold notes text" % self.slide_id
             )
         return text_frame
 
@@ -459,6 +529,7 @@ class Slides(ParentedElementProxy):
         `source`/`after` accept a |Slide| or a 0-based index; a |Slide| from another
         presentation raises |TargetNotFoundError|.
         """
+        from pptx._transaction import PackageTransaction
         from pptx.slideops import clone_slide_part, enroll_clone_in_section
 
         if policy is None:
@@ -470,16 +541,18 @@ class Slides(ParentedElementProxy):
         anchor_index = self.index(anchor_slide)
 
         source_slide_id = source_slide.slide_id
-        new_part = clone_slide_part(source_slide.part, policy)
-        rId = self.part.relate_to(new_part, RT.SLIDE)
-        self._sldIdLst.add_sldId(rId)
-        sldId = self._sldIdLst[-1]
-        self._sldIdLst.remove(sldId)
-        self._sldIdLst.insert(anchor_index + 1, sldId)
-        # -- enroll the copy in the source's section, right after it (custom shows are
-        # -- deliberately not extended: a copy is not part of a curated show)
-        enroll_clone_in_section(self._sldIdLst.getparent(), source_slide_id, sldId.id)
-        return new_part.slide
+        with PackageTransaction(self.part.package, self, source_slide, anchor_slide):
+            new_part = clone_slide_part(source_slide.part, policy)
+            rId = self.part.relate_to(new_part, RT.SLIDE)
+            self._sldIdLst.add_sldId(rId)
+            sldId = self._sldIdLst[-1]
+            self._sldIdLst.remove(sldId)
+            self._sldIdLst.insert(anchor_index + 1, sldId)
+            # -- enroll the copy in the source's section, right after it (custom shows are
+            # -- deliberately not extended: a copy is not part of a curated show)
+            enroll_clone_in_section(self._sldIdLst.getparent(), source_slide_id, sldId.id)
+            cloned_slide = new_part.slide
+        return cloned_slide
 
     def delete(self, slide: Slide | int) -> None:
         """Remove `slide` from this presentation.
@@ -489,17 +562,40 @@ class Slides(ParentedElementProxy):
         graph (the slide, and e.g. its charts and notes if unshared) are never serialized
         again — orphans structurally cannot reach disk. Deleting the last slide is allowed.
         """
+        from pptx._transaction import PackageTransaction
         from pptx.slideops import remove_slide_from_id_lists
 
         target = self._resolve_slide(slide)
         for sldId in self._sldIdLst.sldId_lst:
             if sldId.id == target.slide_id:
                 slide_id, rId = sldId.id, sldId.rId
-                self._sldIdLst.remove(sldId)
-                self.part.drop_rel(rId)
-                # -- sections (by slide id) and custom shows (by rId) reference slides
-                # -- outside the rels graph; purge those entries too
-                remove_slide_from_id_lists(self._sldIdLst.getparent(), slide_id, rId)
+                notes_owners = {
+                    rel.target_part
+                    for rel in target.part.rels.values()
+                    if not rel.is_external and rel.reltype == RT.NOTES_SLIDE
+                }
+                aliases = [
+                    (owner, alias_rId)
+                    for owner, alias_rId, _ in _inbound_relationships(
+                        self.part.package, target.part
+                    )
+                    if not ((owner is self.part and alias_rId == rId) or owner in notes_owners)
+                ]
+                if aliases:
+                    raise UnsupportedStructureError(
+                        "slide deletion refused: slide part has additional inbound "
+                        "relationship aliases"
+                    )
+                with PackageTransaction(self.part.package, self, target):
+                    self._sldIdLst.remove(sldId)
+                    # -- sections (by slide id) and custom shows (by rId) reference slides
+                    # -- outside the rels graph; purge those entries too
+                    remove_slide_from_id_lists(self._sldIdLst.getparent(), slide_id, rId)
+                    if _relationship_references(self.part._element, rId):
+                        raise UnsupportedStructureError(
+                            "slide deletion refused: relationship %s remains referenced" % rId
+                        )
+                    self.part.drop_rel(rId)
                 return
 
     def move(self, slide: Slide | int, to_index: int) -> None:
@@ -508,8 +604,10 @@ class Slides(ParentedElementProxy):
         paper-pptx addition. `to_index` outside `range(len(slides))` raises |ValueError|.
         """
         target = self._resolve_slide(slide)
-        if not isinstance(to_index, int) or isinstance(to_index, bool) or not (
-            0 <= to_index < len(self)
+        if (
+            not isinstance(to_index, int)
+            or isinstance(to_index, bool)
+            or not (0 <= to_index < len(self))
         ):
             raise ValueError(
                 "to_index must be an int in range 0..%d, got %r" % (len(self) - 1, to_index)
@@ -541,14 +639,16 @@ class Slides(ParentedElementProxy):
         range); a |Slide| not belonging to this presentation raises |TargetNotFoundError|.
         """
         if isinstance(value, int) and not isinstance(value, bool):
-            return self[value]
+            slide = self[value]
+            _require_slide_enrolled(slide)
+            return slide
         if isinstance(value, Slide):
             for slide in self:
                 if slide == value:
+                    _require_slide_enrolled(value)
                     return slide
             raise TargetNotFoundError(
-                "slide with id %d is not in this presentation's slide collection"
-                % value.slide_id
+                "slide with id %d is not in this presentation's slide collection" % value.slide_id
             )
         raise ValueError("expected a Slide or int index, got %r" % (value,))
 
@@ -571,7 +671,6 @@ class Slides(ParentedElementProxy):
             if this_slide == slide:
                 return idx
         raise ValueError("%s is not in slide collection" % slide)
-
 
 
 class HeaderFooters(object):
@@ -732,6 +831,14 @@ class SlideLayouts(ParentedElementProxy):
         Raises ValueError when `slide_layout` is in use; a slide layout which is the basis for one
         or more slides cannot be removed.
         """
+        from pptx._transaction import PackageTransaction
+
+        if not isinstance(slide_layout, SlideLayout):
+            raise ValueError("slide_layout must be a SlideLayout, got %r" % (slide_layout,))
+        if slide_layout.part.package is not self.part.package:
+            raise TargetNotFoundError("slide_layout belongs to a different presentation")
+        _require_layout_enrolled(slide_layout)
+
         # ---raise if layout is in use---
         if slide_layout.used_by_slides:
             raise ValueError("cannot remove slide-layout in use by one or more slides")
@@ -742,12 +849,27 @@ class SlideLayouts(ParentedElementProxy):
         # --remove layout from p:sldLayoutIds of its master
         # --this stops layout from showing up, but doesn't remove it from package
         target_sldLayoutId = self._sldLayoutIdLst.sldLayoutId_lst[target_idx]
-        self._sldLayoutIdLst.remove(target_sldLayoutId)
+        rId = target_sldLayoutId.rId
+        aliases = [
+            (owner, alias_rId)
+            for owner, alias_rId, _ in _inbound_relationships(self.part.package, slide_layout.part)
+            if owner is not self.part or alias_rId != rId
+        ]
+        if aliases:
+            raise UnsupportedStructureError(
+                "slide-layout removal refused: layout part has additional inbound "
+                "relationship aliases"
+            )
 
-        # --drop relationship from master to layout
-        # --this removes layout from package, along with everything (only) it refers to,
-        # --including images (not used elsewhere) and hyperlinks
-        slide_layout.slide_master.part.drop_rel(target_sldLayoutId.rId)
+        with PackageTransaction(self.part.package, self, slide_layout):
+            self._sldLayoutIdLst.remove(target_sldLayoutId)
+            if _relationship_references(self.part._element, rId):
+                raise UnsupportedStructureError(
+                    "slide-layout removal refused: relationship %s remains referenced" % rId
+                )
+            # --drop relationship from master to layout
+            # --this removes layout from package, along with everything (only) it refers to
+            self.part.drop_rel(rId)
 
 
 class SlideMaster(_BaseMaster):

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -627,8 +627,11 @@ class Slides(ParentedElementProxy):
             )
         current_index = self.index(target)
         sldId = self._sldIdLst.sldId_lst[current_index]
-        self._sldIdLst.remove(sldId)
-        self._sldIdLst.insert(to_index, sldId)
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self, target):
+            self._sldIdLst.remove(sldId)
+            self._sldIdLst.insert(to_index, sldId)
 
     def reorder(self, new_order: Sequence[int]) -> None:
         """Permute the slide sequence: new position i shows the slide now at `new_order[i]`.
@@ -642,8 +645,11 @@ class Slides(ParentedElementProxy):
                 % (len(self), list(new_order))
             )
         current = list(self._sldIdLst.sldId_lst)
-        for index in new_order:
-            self._sldIdLst.append(current[index])  # -- re-appending moves the element
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
+            for index in new_order:
+                self._sldIdLst.append(current[index])  # -- re-appending moves the element
 
     def _resolve_slide(self, value: Slide | int) -> Slide:
         """Return the |Slide| in this collection for `value` (a Slide or 0-based index).

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -574,6 +574,19 @@ class Slides(ParentedElementProxy):
                     for rel in target.part.rels.values()
                     if not rel.is_external and rel.reltype == RT.NOTES_SLIDE
                 }
+                for notes_part in notes_owners:
+                    shared_notes = [
+                        (owner, notes_rId)
+                        for owner, notes_rId, _ in _inbound_relationships(
+                            self.part.package, notes_part
+                        )
+                        if owner is not target.part
+                    ]
+                    if shared_notes:
+                        raise UnsupportedStructureError(
+                            "slide deletion refused: its notes part is shared by another "
+                            "reachable package part"
+                        )
                 aliases = [
                     (owner, alias_rId)
                     for owner, alias_rId, _ in _inbound_relationships(
@@ -681,9 +694,10 @@ class HeaderFooters(object):
     master; the schema default is visible). Assigning |None| removes the attribute.
     """
 
-    def __init__(self, slide_elm):
+    def __init__(self, owner):
         super(HeaderFooters, self).__init__()
-        self._element = slide_elm
+        self._owner = owner
+        self._element = owner._element
 
     @property
     def slide_number_visible(self) -> bool | None:
@@ -716,14 +730,21 @@ class HeaderFooters(object):
         self._set_flag("dt", value)
 
     def _set_flag(self, attr_name: str, value: "bool | None") -> None:
-        if value is None:
-            hf = self._element.hf
-            if hf is not None:
-                setattr(hf, attr_name, None)
-            return
-        if not isinstance(value, bool):
+        from pptx._ownership import require_element_attached
+        from pptx._transaction import PackageTransaction
+
+        require_element_attached(
+            self._element, self._owner.part, argument="header/footer flags"
+        )
+        if not isinstance(value, bool) and value is not None:
             raise ValueError("visibility must be True, False, or None, got %r" % (value,))
-        setattr(self._element.get_or_add_hf(), attr_name, value)
+        with PackageTransaction(self._owner.part.package, self, self._owner):
+            if value is None:
+                hf = self._element.hf
+                if hf is not None:
+                    setattr(hf, attr_name, None)
+                return
+            setattr(self._element.get_or_add_hf(), attr_name, value)
 
 
 class SlideLayout(_BaseSlide):
@@ -737,7 +758,7 @@ class SlideLayout(_BaseSlide):
     @property
     def header_footers(self) -> HeaderFooters:
         """|HeaderFooters| flags for this layout (paper-pptx addition)."""
-        return HeaderFooters(self._element)
+        return HeaderFooters(self)
 
     def iter_cloneable_placeholders(self) -> Iterator[LayoutPlaceholder]:
         """Generate layout-placeholders on this slide-layout that should be cloned to a new slide.
@@ -893,7 +914,7 @@ class SlideMaster(_BaseMaster):
     @property
     def header_footers(self) -> HeaderFooters:
         """|HeaderFooters| flags for this master (paper-pptx addition)."""
-        return HeaderFooters(self._element)
+        return HeaderFooters(self)
 
     @lazyproperty
     def slide_layouts(self) -> SlideLayouts:

--- a/src/pptx/slideops.py
+++ b/src/pptx/slideops.py
@@ -74,6 +74,16 @@ class _CopySession(set):
         root = _xml_root(copied_part)
         if root is None:
             return
+        self.remap_element(root)
+        if not isinstance(copied_part, XmlPart):
+            from lxml import etree
+
+            copied_part.blob = etree.tostring(
+                root, xml_declaration=True, encoding="UTF-8", standalone=True
+            )
+
+    def remap_element(self, root) -> None:
+        """Apply this copy session's document-wide identity plan to an XML subtree."""
         for element in root.iter():
             if element.tag == _A16_CREATION_ID:
                 _replace_identity_attribute(element, "id", self._a16_mapping)
@@ -84,12 +94,6 @@ class _CopySession(set):
                 _replace_identity_attribute(element, "pred", self._a16_mapping)
             elif element.tag == _A_FIELD and element.get("id"):
                 element.set("id", self._fresh_guid())
-        if not isinstance(copied_part, XmlPart) and root is not None:
-            from lxml import etree
-
-            copied_part.blob = etree.tostring(
-                root, xml_declaration=True, encoding="UTF-8", standalone=True
-            )
 
     def _fresh_guid(self) -> str:
         while True:

--- a/src/pptx/slideops.py
+++ b/src/pptx/slideops.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import copy
 import re
+import uuid
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from pptx.errors import RelationshipPolicyError
@@ -39,6 +40,95 @@ _MEDIA_RELTYPES = frozenset([RT.IMAGE, RT.MEDIA, RT.VIDEO, RT.AUDIO])
 _CHART_CHILD_RELTYPES = frozenset([RT.PACKAGE, _CHART_COLOR_STYLE, _CHART_STYLE])
 #: relationship types allowed FROM a notes-slide part
 _NOTES_CHILD_RELTYPES = frozenset([RT.NOTES_MASTER, RT.SLIDE])
+_A16_CREATION_ID = "{http://schemas.microsoft.com/office/drawing/2014/main}creationId"
+_A16_CXN_DE_REFS = "{http://schemas.microsoft.com/office/drawing/2014/main}cxnDERefs"
+_A16_PRED_DE_REF = "{http://schemas.microsoft.com/office/drawing/2014/main}predDERef"
+_A_FIELD = "{http://schemas.openxmlformats.org/drawingml/2006/main}fld"
+
+
+class _CopySession(set):
+    """Partname reservations and document-wide identity remaps for one copy."""
+
+    def __init__(self, package, source_parts):
+        super().__init__()
+        self._reserved = _document_identity_values(package)
+        self._a16_mapping = {}
+        seen = set()
+        for part in source_parts:
+            root = _xml_root(part)
+            if root is None:
+                continue
+            for element in root.iter(_A16_CREATION_ID):
+                old = element.get("id")
+                if not old:
+                    continue
+                key = old.lower()
+                if key in seen:
+                    raise RelationshipPolicyError(
+                        "copied parts contain duplicate a16 creation identity %r" % old
+                    )
+                seen.add(key)
+                self._a16_mapping[key] = self._fresh_guid()
+
+    def remap(self, source_part, copied_part) -> None:
+        root = _xml_root(copied_part)
+        if root is None:
+            return
+        for element in root.iter():
+            if element.tag == _A16_CREATION_ID:
+                _replace_identity_attribute(element, "id", self._a16_mapping)
+            elif element.tag == _A16_CXN_DE_REFS:
+                _replace_identity_attribute(element, "st", self._a16_mapping)
+                _replace_identity_attribute(element, "end", self._a16_mapping)
+            elif element.tag == _A16_PRED_DE_REF:
+                _replace_identity_attribute(element, "pred", self._a16_mapping)
+            elif element.tag == _A_FIELD and element.get("id"):
+                element.set("id", self._fresh_guid())
+        if not isinstance(copied_part, XmlPart) and root is not None:
+            from lxml import etree
+
+            copied_part.blob = etree.tostring(
+                root, xml_declaration=True, encoding="UTF-8", standalone=True
+            )
+
+    def _fresh_guid(self) -> str:
+        while True:
+            value = "{%s}" % str(uuid.uuid4()).upper()
+            if value.lower() not in self._reserved:
+                self._reserved.add(value.lower())
+                return value
+
+
+def _replace_identity_attribute(element, name: str, mapping: dict) -> None:
+    value = element.get(name)
+    if value is not None and value.lower() in mapping:
+        element.set(name, mapping[value.lower()])
+
+
+def _xml_root(part):
+    if isinstance(part, XmlPart):
+        return part._element
+    content_type = part.content_type.partition(";")[0].strip().lower()
+    if content_type not in ("application/xml", "text/xml") and not content_type.endswith("+xml"):
+        return None
+    from pptx.oxml import parse_xml
+
+    try:
+        return parse_xml(part.blob)
+    except Exception:
+        return None
+
+
+def _document_identity_values(package) -> set:
+    values = set()
+    for part in package.iter_parts():
+        root = _xml_root(part)
+        if root is None:
+            continue
+        for element in root.iter():
+            if element.tag in (_A16_CREATION_ID, _A_FIELD) and element.get("id"):
+                values.add(element.get("id").lower())
+    return values
 
 
 def clone_slide_part(source_part: "SlidePart", policy) -> "SlidePart":
@@ -56,13 +146,27 @@ def clone_slide_part(source_part: "SlidePart", policy) -> "SlidePart":
     # -- relates the new slide, so `package.next_partname` cannot see them. `allocated`
     # -- tracks every partname assigned during THIS clone so two deep copies sharing a
     # -- template (e.g. two charts) can never collide.
-    allocated: "set" = set()
+    copied_sources = [source_part]
+    for _, action, rel in plan:
+        if action == "copy":
+            copied_sources.append(rel.target_part)
+        elif action == "chart":
+            copied_sources.append(rel.target_part)
+            copied_sources.extend(
+                child.target_part
+                for child in rel.target_part.rels.values()
+                if not child.is_external
+            )
+        elif action == "notes":
+            copied_sources.append(rel.target_part)
+    allocated = _CopySession(package, copied_sources)
     new_part = SlidePart(
         _allocate_partname(package, "/ppt/slides/slide%d.xml", allocated),
         CT.PML_SLIDE,
         package,
         copy.deepcopy(source_part._element),
     )
+    allocated.remap(source_part, new_part)
 
     rId_mapping: "Dict[str, str]" = {}
     for old_rId, action, rel in plan:
@@ -104,9 +208,7 @@ def remove_slide_from_id_lists(presentation_elm, slide_id: int, rId: str) -> Non
     ):
         if section_sldId.get("id") == slide_id_str:
             section_sldId.getparent().remove(section_sldId)
-    for show_sld in presentation_elm.findall(
-        ".//{%s}custShowLst//{%s}sld" % (_P_NS, _P_NS)
-    ):
+    for show_sld in presentation_elm.findall(".//{%s}custShowLst//{%s}sld" % (_P_NS, _P_NS)):
         if show_sld.get("{%s}id" % _R_NS) == rId:
             show_sld.getparent().remove(show_sld)
 
@@ -156,7 +258,9 @@ def _validated_plan(source_part, policy) -> "List[Tuple[str, str, object]]":
         rel = source_part.rels[rId]
         if rel.is_external:
             plan.append((rId, "external", rel))
-        elif rel.reltype == RT.SLIDE_LAYOUT:
+            continue
+        target = _owned_target(source_part, rel, "slide clone")
+        if rel.reltype == RT.SLIDE_LAYOUT:
             plan.append((rId, "share", rel))
         elif rel.reltype in _MEDIA_RELTYPES:
             plan.append((rId, "share" if policy.share_media else "copy", rel))
@@ -167,11 +271,11 @@ def _validated_plan(source_part, policy) -> "List[Tuple[str, str, object]]":
                     " editable chart part between slides is exactly the cross-contamination"
                     " this API exists to prevent, and is not offered in v0"
                 )
-            _validate_chart_rels(rel.target_part)
+            _validate_chart_rels(target)
             plan.append((rId, "chart", rel))
         elif rel.reltype == RT.NOTES_SLIDE:
             if policy.deep_copy_notes:
-                _validate_notes_rels(rel.target_part)
+                _validate_notes_rels(target)
                 plan.append((rId, "notes", rel))
             else:
                 plan.append((rId, "drop", rel))
@@ -190,12 +294,13 @@ def _validate_chart_rels(chart_part) -> None:
         rel = chart_part.rels[rId]
         if rel.is_external:
             continue
+        child_part = _owned_target(chart_part, rel, "chart clone")
         if rel.reltype not in _CHART_CHILD_RELTYPES:
             raise RelationshipPolicyError(
                 "chart part %s has relationship type clone does not support in v0: %s"
                 % (chart_part.partname, rel.reltype)
             )
-        if any(not child.is_external for child in rel.target_part.rels.values()):
+        if any(not child.is_external for child in child_part.rels.values()):
             raise RelationshipPolicyError(
                 "chart child part %s has internal relationships of its own; clone supports"
                 " only leaf chart children in v0" % rel.target_part.partname
@@ -205,11 +310,28 @@ def _validate_chart_rels(chart_part) -> None:
 def _validate_notes_rels(notes_part) -> None:
     for rId in notes_part.rels:
         rel = notes_part.rels[rId]
+        if not rel.is_external:
+            _owned_target(notes_part, rel, "notes clone")
         if not rel.is_external and rel.reltype not in _NOTES_CHILD_RELTYPES:
             raise RelationshipPolicyError(
                 "notes slide %s has relationship type clone does not support in v0: %s"
                 % (notes_part.partname, rel.reltype)
             )
+
+
+def _owned_target(owner_part, rel, context: str):
+    """Return an internal target only when it belongs to the owner's package."""
+    try:
+        target = rel.target_part
+    except (AssertionError, AttributeError, TypeError, ValueError) as exc:
+        raise RelationshipPolicyError(
+            "%s relationship %s has an invalid internal target" % (context, rel.rId)
+        ) from exc
+    if target.package is not owner_part.package:
+        raise RelationshipPolicyError(
+            "%s relationship %s targets a part owned by another package" % (context, rel.rId)
+        )
+    return target
 
 
 def _copy_chart_part(chart_part, allocated):
@@ -249,8 +371,12 @@ def _copy_leaf_part(part, allocated):
     package = part.package
     partname = _allocate_partname(package, _partname_template(str(part.partname)), allocated)
     if isinstance(part, XmlPart):
-        return type(part)(partname, part.content_type, package, copy.deepcopy(part._element))
-    return type(part)(partname, part.content_type, package, part.blob)
+        copied = type(part)(partname, part.content_type, package, copy.deepcopy(part._element))
+    else:
+        copied = type(part)(partname, part.content_type, package, part.blob)
+    if hasattr(allocated, "remap"):
+        allocated.remap(part, copied)
+    return copied
 
 
 def _partname_template(partname: str) -> str:

--- a/src/pptx/table.py
+++ b/src/pptx/table.py
@@ -76,10 +76,13 @@ class Table(object):
         if conflicts:
             self._refuse_merge_conflict("deleting column %d" % col_idx, conflicts)
 
-        self._tbl.tblGrid.remove(self._tbl.tblGrid.gridCol_lst[col_idx])
-        for tr in self._tbl.tr_lst:
-            tr.remove(tr.tc_lst[col_idx])
-        self.notify_width_changed()
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
+            self._tbl.tblGrid.remove(self._tbl.tblGrid.gridCol_lst[col_idx])
+            for tr in self._tbl.tr_lst:
+                tr.remove(tr.tc_lst[col_idx])
+            self.notify_width_changed()
 
     def delete_row(self, row_idx: int) -> None:
         """Remove the row at 0-based `row_idx`, cells included.
@@ -108,8 +111,11 @@ class Table(object):
         if conflicts:
             self._refuse_merge_conflict("deleting row %d" % row_idx, conflicts)
 
-        self._tbl.remove(self._tbl.tr_lst[row_idx])
-        self.notify_height_changed()
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
+            self._tbl.remove(self._tbl.tr_lst[row_idx])
+            self.notify_height_changed()
 
     @property
     def first_col(self) -> bool:
@@ -187,11 +193,15 @@ class Table(object):
         new_width = Emu(width) if width is not None else Emu(
             self._tbl.tblGrid.gridCol_lst[neighbor_idx].w
         )
-        gridCol = self._tbl.tblGrid.insert_gridCol_at(after + 1, new_width)
-        for tr in self._tbl.tr_lst:
-            tr.insert_tc_at(after + 1)
-        self.notify_width_changed()
-        return _Column(gridCol, self.columns)
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
+            gridCol = self._tbl.tblGrid.insert_gridCol_at(after + 1, new_width)
+            for tr in self._tbl.tr_lst:
+                tr.insert_tc_at(after + 1)
+            self.notify_width_changed()
+            column = _Column(gridCol, self.columns)
+        return column
 
     def insert_row(self, after: int, *, copy_format_from: int | None = None) -> _Row:
         """Insert a new empty row immediately after 0-based row `after`; return it.
@@ -231,18 +241,22 @@ class Table(object):
             0 if after == -1 else after
         )
         template_tr = self._tbl.tr_lst[template_idx]
-        tr = self._tbl.insert_tr_at(after + 1, Emu(template_tr.h))
-        for col_idx in range(len(self._tbl.tblGrid.gridCol_lst)):
-            tc = tr.add_tc()
-            if copy_format_from is not None:
-                template_tcPr = template_tr.tc_lst[col_idx].tcPr
-                if template_tcPr is not None:
-                    existing_tcPr = tc.tcPr
-                    if existing_tcPr is not None:
-                        tc.remove(existing_tcPr)
-                    tc.append(deepcopy(template_tcPr))
-        self.notify_height_changed()
-        return _Row(tr, self.rows)
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
+            tr = self._tbl.insert_tr_at(after + 1, Emu(template_tr.h))
+            for col_idx in range(len(self._tbl.tblGrid.gridCol_lst)):
+                tc = tr.add_tc()
+                if copy_format_from is not None:
+                    template_tcPr = template_tr.tc_lst[col_idx].tcPr
+                    if template_tcPr is not None:
+                        existing_tcPr = tc.tcPr
+                        if existing_tcPr is not None:
+                            tc.remove(existing_tcPr)
+                        tc.append(deepcopy(template_tcPr))
+            self.notify_height_changed()
+            row = _Row(tr, self.rows)
+        return row
 
     def iter_cells(self) -> Iterator[_Cell]:
         """Generate _Cell object for each cell in this table.

--- a/src/pptx/text/bullet.py
+++ b/src/pptx/text/bullet.py
@@ -60,9 +60,10 @@ class BulletFormat(object):
     effective-style inspection API to see what actually renders).
     """
 
-    def __init__(self, p: CT_TextParagraph):
+    def __init__(self, p: CT_TextParagraph, part=None):
         super(BulletFormat, self).__init__()
         self._p = p
+        self._part = part
 
     @property
     def type(self) -> PP_BULLET_TYPE | None:
@@ -131,14 +132,16 @@ class BulletFormat(object):
         `font_name` sets a bullet-specific typeface (`a:buFont`); `size_percent` scales the
         bullet relative to the text size (fraction, 0.25–4.0).
         """
+        self._require_attached()
         if not isinstance(char, str) or len(char) == 0:
             raise ValueError("char must be a non-empty str, got %r" % (char,))
         _require_xml_encodable(char, "char")
         self._validate_common(font_name, size_percent, left_margin, hanging_indent)
-        pPr = self._p.get_or_add_pPr()
-        self._remove_buBlip(pPr)
-        pPr.get_or_change_to_buChar().char = char
-        self._apply_common(pPr, font_name, size_percent, left_margin, hanging_indent)
+        with self._transaction():
+            pPr = self._p.get_or_add_pPr()
+            self._remove_buBlip(pPr)
+            pPr.get_or_change_to_buChar().char = char
+            self._apply_common(pPr, font_name, size_percent, left_margin, hanging_indent)
 
     def set_numbered(
         self,
@@ -155,26 +158,46 @@ class BulletFormat(object):
         `scheme` is an ECMA-376 auto-number token like "arabicPeriod" or "romanUcParenR";
         an unknown token raises |ValueError|. Numbering restarts at `start_at`.
         """
+        self._require_attached()
         if isinstance(start_at, bool):
             raise ValueError("start_at must be a positive int, got %r" % (start_at,))
         ST_TextAutonumberScheme.validate(scheme)
         ST_TextBulletStartAtNum.validate(start_at)
         self._validate_common(font_name, size_percent, left_margin, hanging_indent)
-        pPr = self._p.get_or_add_pPr()
-        self._remove_buBlip(pPr)
-        buAutoNum = pPr.get_or_change_to_buAutoNum()
-        buAutoNum.type = scheme
-        buAutoNum.startAt = start_at
-        self._apply_common(pPr, font_name, size_percent, left_margin, hanging_indent)
+        with self._transaction():
+            pPr = self._p.get_or_add_pPr()
+            self._remove_buBlip(pPr)
+            buAutoNum = pPr.get_or_change_to_buAutoNum()
+            buAutoNum.type = scheme
+            buAutoNum.startAt = start_at
+            self._apply_common(pPr, font_name, size_percent, left_margin, hanging_indent)
 
     def set_none(self) -> None:
         """Set an explicit "no bullet" (`a:buNone`), overriding any inherited bullet.
 
         Margins, bullet font, and bullet size attributes are left untouched.
         """
-        pPr = self._p.get_or_add_pPr()
-        self._remove_buBlip(pPr)
-        pPr.get_or_change_to_buNone()
+        self._require_attached()
+        with self._transaction():
+            pPr = self._p.get_or_add_pPr()
+            self._remove_buBlip(pPr)
+            pPr.get_or_change_to_buNone()
+
+    def _require_attached(self) -> None:
+        if self._part is None:
+            return
+        from pptx._ownership import require_element_attached
+
+        require_element_attached(self._p, self._part, argument="paragraph")
+
+    def _transaction(self):
+        if self._part is None:
+            from contextlib import nullcontext
+
+            return nullcontext()
+        from pptx._transaction import PackageTransaction
+
+        return PackageTransaction(self._part.package, self)
 
     @staticmethod
     def _remove_buBlip(pPr) -> None:

--- a/src/pptx/text/text.py
+++ b/src/pptx/text/text.py
@@ -190,6 +190,9 @@ class TextFrame(Subshape):
         below the floor are raised to it. Validation completes fully before the first write
         (a refusal leaves the frame byte-identical).
         """
+        from pptx._ownership import require_element_attached
+
+        require_element_attached(self._txBody, self.part, argument="text frame")
         scale = self.font_scale
         reduction = self.line_space_reduction
         scale = 100.0 if scale is None else scale
@@ -249,30 +252,32 @@ class TextFrame(Subshape):
                         % (reduction, para_idx, shape_name)
                     )
 
-        # -- mutation pass --
-        if scale != 100.0:
-            for rPr in self._iter_explicitly_sized_rPrs():
-                rPr.sz = max(100, int(round(rPr.sz * scale / 100.0)))
-            for r, resolved_centipoints in resolved_run_sizes.items():
-                r.get_or_add_rPr().sz = max(
-                    100, int(round(resolved_centipoints * scale / 100.0))
-                )
-        if reduction != 0.0:
-            for paragraph in self.paragraphs:
-                spacing = paragraph.line_spacing
-                factor = (100.0 - reduction) / 100.0
-                if isinstance(spacing, Length):
-                    paragraph.line_spacing = Centipoints(
-                        int(round(spacing.centipoints * factor))
+        from pptx._transaction import PackageTransaction
+
+        with PackageTransaction(self.part.package, self):
+            if scale != 100.0:
+                for rPr in self._iter_explicitly_sized_rPrs():
+                    rPr.sz = max(100, int(round(rPr.sz * scale / 100.0)))
+                for r, resolved_centipoints in resolved_run_sizes.items():
+                    r.get_or_add_rPr().sz = max(
+                        100, int(round(resolved_centipoints * scale / 100.0))
                     )
-                else:
-                    paragraph.line_spacing = spacing * factor
-        if min_font_size is not None:
-            floor_centipoints = Emu(min_font_size).centipoints
-            for rPr in self._iter_explicitly_sized_rPrs():
-                if rPr.sz < floor_centipoints:
-                    rPr.sz = floor_centipoints
-        self.auto_size = MSO_AUTO_SIZE.NONE
+            if reduction != 0.0:
+                for paragraph in self.paragraphs:
+                    spacing = paragraph.line_spacing
+                    factor = (100.0 - reduction) / 100.0
+                    if isinstance(spacing, Length):
+                        paragraph.line_spacing = Centipoints(
+                            int(round(spacing.centipoints * factor))
+                        )
+                    else:
+                        paragraph.line_spacing = spacing * factor
+            if min_font_size is not None:
+                floor_centipoints = Emu(min_font_size).centipoints
+                for rPr in self._iter_explicitly_sized_rPrs():
+                    if rPr.sz < floor_centipoints:
+                        rPr.sz = floor_centipoints
+            self.auto_size = MSO_AUTO_SIZE.NONE
 
     def _resolve_run_size(self, r):
         """Return `r`'s effective font size in centipoints via the inheritance walk, or None.
@@ -676,7 +681,12 @@ class _Paragraph(Subshape):
     def _add_field(self, field_type: str, cached_text: str) -> None:
         import uuid
 
-        self._p.add_fld("{%s}" % str(uuid.uuid4()).upper(), field_type, cached_text)
+        from pptx._ownership import require_element_attached
+        from pptx._transaction import PackageTransaction
+
+        require_element_attached(self._p, self.part, argument="paragraph")
+        with PackageTransaction(self.part.package, self):
+            self._p.add_fld("{%s}" % str(uuid.uuid4()).upper(), field_type, cached_text)
 
     def add_run(self) -> _Run:
         """Return a new run appended to the runs in this paragraph."""
@@ -705,7 +715,7 @@ class _Paragraph(Subshape):
         (|None| means inherited); setters write real `a:buChar`/`a:buAutoNum`/`a:buNone`
         bullets with hanging-indent geometry.
         """
-        return BulletFormat(self._p)
+        return BulletFormat(self._p, self.part)
 
     def clear(self):
         """Remove all content from this paragraph.

--- a/tests/paper/test_autofit.py
+++ b/tests/paper/test_autofit.py
@@ -12,7 +12,7 @@ import pytest
 
 from pptx import Presentation
 from pptx.enum.text import MSO_AUTO_SIZE
-from pptx.errors import PaperRefusal, UnsupportedStructureError
+from pptx.errors import PaperRefusal, TargetNotFoundError, UnsupportedStructureError
 from pptx.util import Pt
 
 from . import corpus
@@ -37,6 +37,30 @@ def _autofit_frame(prs):
 
 def _open(relpath):
     return Presentation(str(corpus.fixture_path(relpath)))
+
+
+def test_normalize_autofit_refuses_a_text_frame_on_a_deleted_shape():
+    prs = _open(NONE)
+    slide = prs.slides[0]
+    shape = next(shape for shape in slide.shapes if shape.name == "autofit_box")
+    text_frame = shape.text_frame
+    slide.shapes.delete(shape)
+
+    with pytest.raises(TargetNotFoundError, match="text frame is stale"):
+        text_frame.normalize_autofit()
+
+
+def test_normalize_autofit_refuses_a_text_frame_on_a_removed_layout():
+    prs = Presentation()
+    master = prs.slide_masters[0]
+    layout = master.slide_layouts[1]
+    text_frame = next(
+        shape for shape in layout.shapes if shape.has_text_frame
+    ).text_frame
+    master.slide_layouts.remove(layout)
+
+    with pytest.raises(TargetNotFoundError, match="text frame is stale"):
+        text_frame.normalize_autofit()
 
 
 # ------------------------------------------------------------------------- reading details

--- a/tests/paper/test_bullets.py
+++ b/tests/paper/test_bullets.py
@@ -13,6 +13,7 @@ from lxml import etree
 
 from pptx import Presentation
 from pptx.enum.text import PP_BULLET_TYPE
+from pptx.errors import TargetNotFoundError
 from pptx.text.bullet import BulletFormat
 from pptx.util import Emu
 
@@ -41,6 +42,47 @@ def _bullet_choice_children(paragraph):
         return []
     tags = {"{%s}buNone" % _A, "{%s}buChar" % _A, "{%s}buAutoNum" % _A}
     return [child for child in pPr if child.tag in tags]
+
+
+def test_bullet_setter_refuses_a_paragraph_on_a_deleted_slide():
+    prs = _open_minimal()
+    slide = prs.slides[0]
+    bullet = slide.shapes[0].text_frame.paragraphs[0].bullet
+    prs.slides.delete(slide)
+
+    with pytest.raises(TargetNotFoundError, match="paragraph is stale"):
+        bullet.set_character()
+
+
+def test_bullet_setter_refuses_a_paragraph_on_a_removed_layout():
+    prs = Presentation()
+    master = prs.slide_masters[0]
+    layout = master.slide_layouts[1]
+    shape = next(shape for shape in layout.shapes if shape.has_text_frame)
+    bullet = shape.text_frame.paragraphs[0].bullet
+    master.slide_layouts.remove(layout)
+
+    with pytest.raises(TargetNotFoundError, match="paragraph is stale"):
+        bullet.set_none()
+
+
+def test_bullet_write_rolls_back_a_late_common_format_failure(monkeypatch):
+    prs = _open_minimal()
+    paragraph = _add_box_with_text(prs).text_frame.paragraphs[0]
+    bullet = paragraph.bullet
+    before = snapshot_parts(prs)
+    original = BulletFormat._apply_common
+
+    def fail_after_common(self, *args):
+        original(self, *args)
+        raise RuntimeError("forced late bullet failure")
+
+    monkeypatch.setattr(BulletFormat, "_apply_common", fail_after_common)
+    with pytest.raises(RuntimeError, match="forced late bullet failure"):
+        bullet.set_character("-", font_name="Arial", size_percent=0.75)
+
+    assert snapshot_parts(prs) == before
+    assert paragraph.bullet is bullet
 
 
 # ----------------------------------------------------------------------- reading local state

--- a/tests/paper/test_chart_routing.py
+++ b/tests/paper/test_chart_routing.py
@@ -7,6 +7,7 @@ typed refusals for structures the mechanism can't honor, then routing to upstrea
 
 from __future__ import annotations
 
+import copy
 import io
 
 import pytest
@@ -19,6 +20,8 @@ from pptx.errors import (
     TargetNotFoundError,
     UnsupportedStructureError,
 )
+from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+from pptx.oxml.ns import qn
 from pptx.util import Inches
 
 from . import corpus
@@ -99,6 +102,56 @@ def test_replace_data_safe_round_trips_with_exact_budget():
         ("FY26", (12.0, 13.0)),
     ]
     assert list(reopened_chart.plots[0].categories) == ["North", "South"]
+
+
+def test_replace_data_safe_refuses_a_workbook_shared_by_another_reachable_chart():
+    prs = _open(CHART_NOTES)
+    slide = prs.slides[0]
+    chart = slide.shapes.chart_by_name(CHART_NAME)
+    chart_data = CategoryChartData()
+    chart_data.categories = ["old"]
+    chart_data.add_series("other", (2,))
+    other = slide.shapes.add_chart(
+        XL_CHART_TYPE.COLUMN_CLUSTERED,
+        Inches(5),
+        Inches(1),
+        Inches(2),
+        Inches(2),
+        chart_data,
+    ).chart
+    shared_workbook = chart._workbook.xlsx_part
+    old_rId = other._chartSpace.xlsx_part_rId
+    shared_rId = other.part.relate_to(shared_workbook, RT.PACKAGE)
+    other._chartSpace.externalData.set(qn("r:id"), shared_rId)
+    if old_rId != shared_rId:
+        other.part.drop_rel(old_rId)
+    before = save_to_bytes(prs)
+
+    with pytest.raises(UnsupportedStructureError, match="workbook is shared"):
+        chart.replace_data_safe(["new"], [("series", (9,))])
+
+    assert save_to_bytes(prs) == before
+    assert other._workbook.xlsx_part is shared_workbook
+
+
+def test_replace_data_safe_refuses_a_stale_chart_root():
+    prs = _open(CHART_NOTES)
+    chart = prs.slides[0].shapes.chart_by_name(CHART_NAME)
+    chart.part._element = copy.deepcopy(chart.part._element)
+
+    with pytest.raises(TargetNotFoundError, match="chart is stale"):
+        chart.replace_data_safe(["x"], [("series", (1,))])
+
+
+def test_replace_data_safe_refuses_a_chart_removed_from_its_slide():
+    prs = _open(CHART_NOTES)
+    slide = prs.slides[0]
+    chart_shape = slide.shapes.shape_by_name(CHART_NAME)
+    chart = chart_shape.chart
+    slide.shapes.delete(chart_shape)
+
+    with pytest.raises(TargetNotFoundError, match="chart is stale"):
+        chart.replace_data_safe(["x"], [("series", (1,))])
 
 
 @pytest.mark.parametrize(

--- a/tests/paper/test_chart_routing.py
+++ b/tests/paper/test_chart_routing.py
@@ -130,8 +130,44 @@ def test_replace_data_safe_refuses_a_workbook_shared_by_another_reachable_chart(
     with pytest.raises(UnsupportedStructureError, match="workbook is shared"):
         chart.replace_data_safe(["new"], [("series", (9,))])
 
-    assert save_to_bytes(prs) == before
+    assert zip_member_map(save_to_bytes(prs)) == zip_member_map(before)
     assert other._workbook.xlsx_part is shared_workbook
+
+
+def test_replace_data_safe_refuses_a_chart_part_shared_by_two_shapes():
+    prs = _open(CHART_NOTES)
+    source_slide = prs.slides[0]
+    chart_shape = source_slide.shapes.shape_by_name(CHART_NAME)
+    chart = chart_shape.chart
+    other_slide = prs.slides.add_slide(prs.slide_layouts[6])
+    copied_frame = copy.deepcopy(chart_shape._element)
+    copied_frame.nvGraphicFramePr.cNvPr.set("id", "999")
+    copied_frame.nvGraphicFramePr.cNvPr.set("name", "Shared chart view")
+    rId = other_slide.part.relate_to(chart.part, RT.CHART)
+    copied_frame.find(".//%s" % qn("c:chart")).set(qn("r:id"), rId)
+    other_slide._element.cSld.spTree.append(copied_frame)
+
+    with pytest.raises(UnsupportedStructureError, match="shared by multiple"):
+        chart.replace_data_safe(["new"], [("series", (9,))])
+
+
+def test_replace_data_safe_supports_a_chart_on_a_reachable_layout():
+    prs = _open(CHART_NOTES)
+    slide = prs.slides[0]
+    chart_shape = slide.shapes.shape_by_name(CHART_NAME)
+    chart_part = chart_shape.chart.part
+    chart_ref = chart_shape._element.find(".//%s" % qn("c:chart"))
+    old_rId = chart_ref.get(qn("r:id"))
+    layout = slide.slide_layout
+    layout_rId = layout.part.relate_to(chart_part, RT.CHART)
+    chart_ref.set(qn("r:id"), layout_rId)
+    layout._element.cSld.spTree.append(chart_shape._element)
+    slide.part.drop_rel(old_rId)
+    layout_chart = next(shape.chart for shape in layout.shapes if shape.has_chart)
+
+    layout_chart.replace_data_safe(["new"], [("series", (9,))])
+
+    assert tuple(layout_chart.series[0].values) == (9.0,)
 
 
 def test_replace_data_safe_refuses_a_stale_chart_root():

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -468,6 +468,23 @@ def test_unreadable_package_refuses_typed(tmp_path):
         diff_decks(str(garbage), _path(V1))
 
 
+def test_text_diff_refuses_notes_without_a_body_placeholder():
+    from pptx.enum.shapes import PP_PLACEHOLDER
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    notes_slide = slide.notes_slide
+    body = next(
+        shape
+        for shape in notes_slide.placeholders
+        if shape.placeholder_format.type == PP_PLACEHOLDER.BODY
+    )
+    body._element.getparent().remove(body._element)
+
+    with pytest.raises(UnsupportedStructureError, match="no body placeholder"):
+        diff_decks(prs, prs, detail="text")
+
+
 # ------------------------------------------------------------------ typed refusals on bad input
 
 

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -393,6 +393,30 @@ def test_field_movement_is_reported_without_false_formatting_shifts():
     assert report.slide_changes[0].effective_shifts == ()
 
 
+def test_inserted_literal_run_does_not_create_false_formatting_shifts():
+    before = Presentation()
+    slide = before.slides.add_slide(before.slide_layouts[6])
+    paragraph = slide.shapes.add_textbox(0, 0, 914400, 914400).text_frame.paragraphs[0]
+    first = paragraph.add_run()
+    first.text = "A"
+    first.font.bold = True
+    paragraph.add_run().text = "B"
+    stream = io.BytesIO()
+    before.save(stream)
+    after = Presentation(io.BytesIO(stream.getvalue()))
+    changed = after.slides[0].shapes[0].text_frame.paragraphs[0]
+    inserted = changed.add_run()
+    inserted.text = "X"
+    inserted.font.italic = True
+    changed._p.remove(inserted._r)
+    first_run = changed._p.find(qn("a:r"))
+    first_run.addprevious(inserted._r)
+
+    report = diff_decks(before, after, detail="full")
+
+    assert report.slide_changes[0].effective_shifts == ()
+
+
 def test_full_detail_sees_emphasis_shifts():
     """Regression: bold/italic/underline participate in resolution-state
     comparison - a mutant dropping them must fail here."""

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -181,6 +181,23 @@ def test_seekable_stream_positions_survive_success_and_failure():
     assert unreadable.tell() == 3
 
 
+def test_exact_package_stream_read_failure_is_typed_and_restores_position():
+    class FailingExactRead(io.BytesIO):
+        def read(self, size=-1):
+            if self.tell() == 0 and size == 1024 * 1024:
+                raise OSError("forced exact-map read failure")
+            return super().read(size)
+
+    data = corpus.fixture_path("self_generated/minimal_clean.pptx").read_bytes()
+    source = FailingExactRead(data)
+    source.seek(17)
+
+    with pytest.raises(UnsupportedStructureError, match="cannot read before input stream"):
+        diff_decks(source, _path("self_generated/minimal_clean.pptx"))
+
+    assert source.tell() == 17
+
+
 # ------------------------------------------------------------------------------ detail levels
 
 
@@ -348,6 +365,32 @@ def test_field_type_change_is_reported_when_visible_text_is_unchanged():
     assert change["before"] == change["after"] == ""
     assert change["field_types_before"] == ["slidenum"]
     assert change["field_types_after"] == ["datetime1"]
+
+
+def test_field_movement_is_reported_without_false_formatting_shifts():
+    before = Presentation()
+    slide = before.slides.add_slide(before.slide_layouts[6])
+    paragraph = slide.shapes.add_textbox(0, 0, 914400, 914400).text_frame.paragraphs[0]
+    first = paragraph.add_run()
+    first.text = "Page "
+    first.font.bold = True
+    paragraph.add_slide_number_field()
+    paragraph.add_run().text = " of total"
+    stream = io.BytesIO()
+    before.save(stream)
+    after = Presentation(io.BytesIO(stream.getvalue()))
+    changed_paragraph = after.slides[0].shapes[0].text_frame.paragraphs[0]._p
+    field = changed_paragraph.find(qn("a:fld"))
+    changed_paragraph.remove(field)
+    pPr = changed_paragraph.find(qn("a:pPr"))
+    changed_paragraph.insert(1 if pPr is not None else 0, field)
+
+    report = diff_decks(before, after, detail="full")
+    change = report.slide_changes[0].text_changes[0]
+
+    assert change["fields_before"] == [{"offset": 5, "type": "slidenum"}]
+    assert change["fields_after"] == [{"offset": 0, "type": "slidenum"}]
+    assert report.slide_changes[0].effective_shifts == ()
 
 
 def test_full_detail_sees_emphasis_shifts():

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 import io
 import json
+import zipfile
 
 import pytest
+from lxml import etree
 
 from pptx import Presentation
 from pptx.diff import diff_decks
+from pptx.errors import UnsupportedStructureError
+from pptx.oxml.ns import qn
 
 from . import corpus
 
@@ -127,6 +131,56 @@ def test_package_changes_make_z_order_only_edit_nonempty():
     }
 
 
+@pytest.mark.parametrize("source_kind", ["path", "stream"])
+def test_package_changes_use_original_package_members(tmp_path, source_kind):
+    source = corpus.fixture_path("self_generated/minimal_clean.pptx")
+    modified = io.BytesIO()
+    with zipfile.ZipFile(source) as before, zipfile.ZipFile(modified, "w") as after:
+        for info in before.infolist():
+            data = before.read(info.filename)
+            if info.filename == "[Content_Types].xml":
+                root = etree.fromstring(data)
+                namespace = root.tag.partition("}")[0] + "}"
+                etree.SubElement(
+                    root,
+                    namespace + "Default",
+                    Extension="paper-unused",
+                    ContentType="application/x-paper-unused",
+                )
+                data = etree.tostring(root, xml_declaration=True, encoding="UTF-8")
+            after.writestr(info, data)
+    modified.seek(0)
+
+    if source_kind == "path":
+        changed_source = tmp_path / "unused-content-type.pptx"
+        changed_source.write_bytes(modified.getvalue())
+    else:
+        changed_source = modified
+
+    report = diff_decks(source, changed_source)
+    assert [delta.partname for delta in report.package_changes] == ["/[Content_Types].xml"]
+
+
+def test_seekable_stream_positions_survive_success_and_failure():
+    data = corpus.fixture_path("self_generated/minimal_clean.pptx").read_bytes()
+    before = io.BytesIO(data)
+    after = io.BytesIO(data)
+    before.seek(11)
+    after.seek(23)
+
+    assert diff_decks(before, after).is_empty
+    assert before.tell() == 11
+    assert after.tell() == 23
+
+    unreadable = io.BytesIO(b"not a presentation")
+    before.seek(17)
+    unreadable.seek(3)
+    with pytest.raises(UnsupportedStructureError, match="not a readable presentation"):
+        diff_decks(before, unreadable)
+    assert before.tell() == 17
+    assert unreadable.tell() == 3
+
+
 # ------------------------------------------------------------------------------ detail levels
 
 
@@ -160,6 +214,20 @@ def test_full_detail_reports_effective_shifts():
     assert {(s.text, s.before["size"]["value"], s.after["size"]["value"]) for s in shifts} == {
         (s.text, s.before["size"]["value"], s.after["size"]["value"])
         for s in rebind_report.run_shifts
+    }
+
+
+def test_diff_reports_geometry_changed_by_layout_rebind():
+    before = Presentation(_path("self_generated/minimal_clean.pptx"))
+    after = Presentation(_path("self_generated/minimal_clean.pptx"))
+    after.slides[0].rebind_layout(after.slide_layouts[1])
+
+    report = diff_decks(before, after, detail="structure")
+
+    geometry = report.slide_changes[0].geometry_changes
+    assert geometry
+    assert {change["facet"] for change in geometry} == {
+        "left", "top", "width", "height"
     }
 
 
@@ -259,6 +327,27 @@ def test_trailing_whitespace_edit_is_a_reported_text_change():
         for c in change.text_changes
     ]
     assert ("Trailing space ", "Trailing space") in deltas
+
+
+def test_field_type_change_is_reported_when_visible_text_is_unchanged():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    paragraph = slide.shapes.add_textbox(
+        0, 0, 914400, 914400
+    ).text_frame.paragraphs[0]
+    paragraph.add_slide_number_field()
+    before = io.BytesIO()
+    prs.save(before)
+
+    changed = Presentation(io.BytesIO(before.getvalue()))
+    field = changed.slides[0].shapes[0].text_frame.paragraphs[0]._p.find(qn("a:fld"))
+    field.set("type", "datetime1")
+
+    report = diff_decks(io.BytesIO(before.getvalue()), changed, detail="text")
+    change = report.slide_changes[0].text_changes[0]
+    assert change["before"] == change["after"] == ""
+    assert change["field_types_before"] == ["slidenum"]
+    assert change["field_types_after"] == ["datetime1"]
 
 
 def test_full_detail_sees_emphasis_shifts():

--- a/tests/paper/test_edit_text.py
+++ b/tests/paper/test_edit_text.py
@@ -6,6 +6,7 @@ replace(x→y) then replace(y→x) restores visible text AND formatting.
 
 from __future__ import annotations
 
+import copy
 import io
 
 import pytest
@@ -23,7 +24,7 @@ from pptx.inspect import BlockAnchor, inspect_text
 from pptx.util import Emu
 
 from . import corpus
-from .contract import assert_changed_parts, save_to_bytes, snapshot_parts
+from .contract import assert_changed_parts, save_to_bytes, snapshot_parts, zip_member_map
 from .lo import lo_load_smoke
 
 MINIMAL = "self_generated/minimal_clean.pptx"
@@ -72,6 +73,35 @@ def test_replace_text_round_trips_with_exact_budget():
     after = save_to_bytes(prs)
     assert_changed_parts(before, after, expect_changed=["ppt/slides/slide1.xml"])
     assert _reopen(after).slides[0].shapes.title.text == "Renamed fixture"
+
+
+def test_replace_text_rolls_back_after_a_late_mutation(monkeypatch):
+    import pptx.edit as edit_module
+
+    prs = _open(MINIMAL)
+    before = save_to_bytes(prs)
+    original = edit_module._replace_in_paragraph
+
+    def fail_after_replacement(paragraph, find, replace):
+        count = original(paragraph, find, replace)
+        if count:
+            raise RuntimeError("forced late text failure")
+        return count
+
+    monkeypatch.setattr(edit_module, "_replace_in_paragraph", fail_after_replacement)
+    with pytest.raises(RuntimeError, match="forced late text failure"):
+        replace_text(prs, "Minimal clean", "Changed")
+
+    assert zip_member_map(save_to_bytes(prs)) == zip_member_map(before)
+    assert prs.slides[0].shapes.title.text == "Minimal clean fixture"
+
+
+def test_replace_text_refuses_a_stale_presentation_root():
+    prs = _open(MINIMAL)
+    prs.part._element = copy.deepcopy(prs.part._element)
+
+    with pytest.raises(TargetNotFoundError, match="presentation is stale"):
+        replace_text(prs, "Minimal", "Changed")
 
 
 def test_replacement_inherits_the_match_start_runs_formatting():

--- a/tests/paper/test_effective_inspect.py
+++ b/tests/paper/test_effective_inspect.py
@@ -53,6 +53,15 @@ def test_title_size_resolves_through_layout_override():
     assert _supplied_levels(font.size) == ["layout placeholder lstStyle lvl1"]
 
 
+def test_placeholder_inheritance_requires_an_exact_layout_idx_match():
+    prs = _open(BRANDED)
+    title = prs.slides[0].shapes.title
+    title.element.ph.idx = 999
+
+    with pytest.raises(UnsupportedStructureError, match="requires an exact idx match"):
+        title.text_frame.paragraphs[0].runs[0].effective_font()
+
+
 def test_title_name_resolves_through_master_theme_reference():
     expected = _ground_truth(BRANDED)["expected_effective"]["title_run"]
     font = _open(BRANDED).slides[0].shapes.title.text_frame.paragraphs[0].runs[0].effective_font()

--- a/tests/paper/test_effective_inspect.py
+++ b/tests/paper/test_effective_inspect.py
@@ -27,6 +27,7 @@ BRANDED = "self_generated/branded_template.pptx"
 CLRMAP = "self_generated/clrmap_remap.pptx"
 GAUNTLET = "self_generated/gauntlet.pptx"
 _A = "http://schemas.openxmlformats.org/drawingml/2006/main"
+_P = "http://schemas.openxmlformats.org/presentationml/2006/main"
 
 
 def _open(relpath):
@@ -60,6 +61,38 @@ def test_placeholder_inheritance_requires_an_exact_layout_idx_match():
 
     with pytest.raises(UnsupportedStructureError, match="requires an exact idx match"):
         title.text_frame.paragraphs[0].runs[0].effective_font()
+
+
+def test_layout_color_map_override_applies_to_layout_inherited_color():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    title = slide.shapes.title
+    paragraph = title.text_frame.paragraphs[0]
+    paragraph.clear()
+    run = paragraph.add_run()
+    run.text = "Layout-mapped color"
+    layout = slide.slide_layout
+    layout_title = layout.placeholders.get(idx=title.placeholder_format.idx)
+    lst_style = layout_title._element.find("{%s}txBody/{%s}lstStyle" % (_P, _A))
+    level_properties = etree.SubElement(lst_style, "{%s}lvl1pPr" % _A)
+    default_run_properties = etree.SubElement(level_properties, "{%s}defRPr" % _A)
+    solid_fill = etree.SubElement(default_run_properties, "{%s}solidFill" % _A)
+    etree.SubElement(solid_fill, "{%s}schemeClr" % _A).set("val", "tx1")
+    clr_map_override = layout._element.find("{%s}clrMapOvr" % _P)
+    if clr_map_override is None:
+        clr_map_override = etree.SubElement(layout._element, "{%s}clrMapOvr" % _P)
+    else:
+        clr_map_override.clear()
+    override = etree.SubElement(clr_map_override, "{%s}overrideClrMapping" % _A)
+    mapping = dict(prs.slide_masters[0].element.find("{%s}clrMap" % _P).attrib)
+    mapping["tx1"] = "accent3"
+    for key, value in mapping.items():
+        override.set(key, value)
+
+    effective = run.effective_font().color_rgb
+
+    assert effective.value == "9BBB59"
+    assert any(step.level == "layout clrMapOvr" for step in effective.provenance)
 
 
 def test_title_name_resolves_through_master_theme_reference():

--- a/tests/paper/test_fields_hf.py
+++ b/tests/paper/test_fields_hf.py
@@ -37,6 +37,17 @@ def _footer_box(prs):
     return box
 
 
+def test_header_footer_flags_refuse_after_layout_removal():
+    prs = Presentation()
+    layout = prs.slide_layouts[0]
+    master = layout.slide_master
+    flags = layout.header_footers
+    master.slide_layouts.remove(layout)
+
+    with pytest.raises(TargetNotFoundError, match="stale"):
+        flags.footer_visible = False
+
+
 # ------------------------------------------------------------------------------ a:fld fields
 
 

--- a/tests/paper/test_fields_hf.py
+++ b/tests/paper/test_fields_hf.py
@@ -9,6 +9,7 @@ import pytest
 from lxml import etree
 
 from pptx import Presentation
+from pptx.errors import TargetNotFoundError
 from pptx.inspect import inspect_text
 from pptx.util import Emu
 
@@ -37,6 +38,30 @@ def _footer_box(prs):
 
 
 # ------------------------------------------------------------------------------ a:fld fields
+
+
+def test_field_setter_refuses_a_deleted_paragraph_proxy():
+    prs = _open(MINIMAL)
+    slide = prs.slides[0]
+    shape = _footer_box(prs)
+    paragraph = shape.text_frame.paragraphs[0]
+    slide.shapes.delete(shape)
+
+    with pytest.raises(TargetNotFoundError, match="paragraph is stale"):
+        paragraph.add_slide_number_field()
+
+
+def test_field_setter_refuses_a_paragraph_on_a_removed_layout():
+    prs = Presentation()
+    master = prs.slide_masters[0]
+    layout = master.slide_layouts[1]
+    paragraph = next(
+        shape for shape in layout.shapes if shape.has_text_frame
+    ).text_frame.paragraphs[0]
+    master.slide_layouts.remove(layout)
+
+    with pytest.raises(TargetNotFoundError, match="paragraph is stale"):
+        paragraph.add_slide_number_field()
 
 
 def test_slide_number_field_round_trips_with_exact_budget():

--- a/tests/paper/test_hf_apply.py
+++ b/tests/paper/test_hf_apply.py
@@ -16,7 +16,7 @@ from datetime import datetime
 import pytest
 
 from pptx import Presentation
-from pptx.errors import PaperRefusal, UnsupportedStructureError
+from pptx.errors import PaperRefusal, TargetNotFoundError, UnsupportedStructureError
 
 from . import corpus
 from .contract import (
@@ -109,6 +109,37 @@ def test_apply_has_exact_slide_only_budget():
         save_to_bytes(prs),
         expect_changed=["ppt/slides/slide%d.xml" % n for n in (1, 2, 3, 4)],
     )
+
+
+def test_apply_to_all_rolls_back_a_late_slide_write(monkeypatch):
+    import pptx.hf as hf_module
+
+    prs = _open(GAUNTLET)
+    before = save_to_bytes(prs)
+    real_apply = hf_module._apply_to_slide
+    calls = 0
+
+    def fail_after_second_slide(*args, **kwargs):
+        nonlocal calls
+        real_apply(*args, **kwargs)
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("forced late footer failure")
+
+    monkeypatch.setattr(hf_module, "_apply_to_slide", fail_after_second_slide)
+    with pytest.raises(RuntimeError, match="forced late footer failure"):
+        prs.apply_footers(footer="Rollback", slide_number=True, now=NOW)
+
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+def test_per_slide_apply_refuses_a_publicly_deleted_slide_before_arguments():
+    prs = _open(MINIMAL)
+    slide = prs.slides[0]
+    prs.slides.delete(slide)
+
+    with pytest.raises(TargetNotFoundError, match="slide is stale"):
+        slide.apply_footers(footer="")
 
 
 def test_reapplying_same_state_is_a_complete_noop():

--- a/tests/paper/test_image_replace.py
+++ b/tests/paper/test_image_replace.py
@@ -241,6 +241,51 @@ def test_replace_image_refuses_a_deleted_picture_without_adding_relationships():
     assert tuple(slide.part.rels) == relationships_before
 
 
+def test_replace_image_refuses_a_picture_on_a_deleted_but_reachable_slide():
+    prs = _open(GAUNTLET)
+    slide = prs.slides[2]
+    picture = _cropped_picture(prs)
+    prs.slides[0].part.relate_to(
+        slide.part, "https://paper.design/relationships/keep-deleted-slide-reachable"
+    )
+    sldId = next(
+        entry
+        for entry in prs.part._element.sldIdLst.sldId_lst
+        if prs.part.rels[entry.rId].target_part is slide.part
+    )
+    prs.part._element.sldIdLst.remove(sldId)
+    prs.part.drop_rel(sldId.rId)
+    relationships_before = tuple(slide.part.rels)
+
+    with pytest.raises(TargetNotFoundError, match="no longer enrolled"):
+        picture.replace_image(io.BytesIO(_png_bytes()))
+
+    assert tuple(slide.part.rels) == relationships_before
+
+
+def test_replace_image_rolls_back_after_a_late_relationship_failure(monkeypatch):
+    from pptx.parts.slide import SlidePart
+
+    prs = _open(GAUNTLET)
+    picture = _cropped_picture(prs)
+    original_rId = picture._pic.blip_rId
+    original_blob = picture.image.blob
+    before = save_to_bytes(prs)
+    original_drop_rel = SlidePart.drop_rel
+
+    def fail_after_drop(part, rId):
+        original_drop_rel(part, rId)
+        raise RuntimeError("forced late image failure")
+
+    monkeypatch.setattr(SlidePart, "drop_rel", fail_after_drop)
+    with pytest.raises(RuntimeError, match="forced late image failure"):
+        picture.replace_image(io.BytesIO(_png_bytes((200, 10, 10))))
+
+    assert save_to_bytes(prs) == before
+    assert picture._pic.blip_rId == original_rId
+    assert picture.image.blob == original_blob
+
+
 def test_replace_keeps_relationship_alive_for_sibling_picture_sharing_it():
     """Regression: two pictures added from identical bytes share ONE relationship; replacing
     one used to drop the rel and leave the sibling's r:embed dangling (unloadable deck)."""

--- a/tests/paper/test_image_replace.py
+++ b/tests/paper/test_image_replace.py
@@ -15,6 +15,7 @@ from PIL import Image as PILImage
 
 from pptx import Presentation
 from pptx.errors import PaperRefusal, TargetNotFoundError, UnsupportedStructureError
+from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 
 from . import corpus
 from .contract import (
@@ -241,26 +242,21 @@ def test_replace_image_refuses_a_deleted_picture_without_adding_relationships():
     assert tuple(slide.part.rels) == relationships_before
 
 
-def test_replace_image_refuses_a_picture_on_a_deleted_but_reachable_slide():
-    prs = _open(GAUNTLET)
-    slide = prs.slides[2]
-    picture = _cropped_picture(prs)
-    prs.slides[0].part.relate_to(
-        slide.part, "https://paper.design/relationships/keep-deleted-slide-reachable"
-    )
-    sldId = next(
-        entry
-        for entry in prs.part._element.sldIdLst.sldId_lst
-        if prs.part.rels[entry.rId].target_part is slide.part
-    )
-    prs.part._element.sldIdLst.remove(sldId)
-    prs.part.drop_rel(sldId.rId)
-    relationships_before = tuple(slide.part.rels)
+def test_replace_image_supports_a_picture_on_a_reachable_layout():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    picture = slide.shapes.add_picture(io.BytesIO(_png_bytes()), 0, 0)
+    image_part = picture.part.related_part(picture._pic.blip_rId)
+    layout = slide.slide_layout
+    layout_rId = layout.part.relate_to(image_part, RT.IMAGE)
+    picture._pic.blipFill.blip.rEmbed = layout_rId
+    layout._element.cSld.spTree.append(picture._element)
+    layout_picture = next(shape for shape in layout.shapes if shape.name == picture.name)
+    replacement = _png_bytes((200, 10, 10))
 
-    with pytest.raises(TargetNotFoundError, match="no longer enrolled"):
-        picture.replace_image(io.BytesIO(_png_bytes()))
+    layout_picture.replace_image(io.BytesIO(replacement))
 
-    assert tuple(slide.part.rels) == relationships_before
+    assert layout_picture.image.blob == replacement
 
 
 def test_replace_image_rolls_back_after_a_late_relationship_failure(monkeypatch):
@@ -281,7 +277,7 @@ def test_replace_image_rolls_back_after_a_late_relationship_failure(monkeypatch)
     with pytest.raises(RuntimeError, match="forced late image failure"):
         picture.replace_image(io.BytesIO(_png_bytes((200, 10, 10))))
 
-    assert save_to_bytes(prs) == before
+    assert zip_member_map(save_to_bytes(prs)) == zip_member_map(before)
     assert picture._pic.blip_rId == original_rId
     assert picture.image.blob == original_blob
 

--- a/tests/paper/test_import.py
+++ b/tests/paper/test_import.py
@@ -20,6 +20,7 @@ from pptx.errors import (
     TargetNotFoundError,
     UnsupportedStructureError,
 )
+from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 
 from . import corpus
 from .contract import (
@@ -32,6 +33,22 @@ from .contract import (
 from .idlists import dangling_section_slide_ids, duplicate_section_slide_ids
 from .lo import lo_load_smoke
 from .relint import dangling_relationship_targets, missing_relationship_references
+
+
+def test_import_refuses_a_source_relationship_target_owned_by_another_package():
+    dest = Presentation()
+    dest.slides.add_slide(dest.slide_layouts[6])
+    source = _open("self_generated/minimal_clean.pptx")
+    foreign = _open("self_generated/gauntlet.pptx")
+    foreign_picture = foreign.slides[1].shapes.picture_by_name("gauntlet_img_1")
+    foreign_image = foreign_picture.part.related_part(foreign_picture._pic.blip_rId)
+    source.slides[0].part.relate_to(foreign_image, RT.IMAGE)
+    before = zip_member_map(save_to_bytes(dest))
+
+    with pytest.raises(RelationshipPolicyError, match="owned by another package"):
+        dest.import_slide(source, 0, mode="adopt_theme")
+
+    assert zip_member_map(save_to_bytes(dest)) == before
 
 ALPHA = "self_generated/template_alpha.pptx"
 BETA = "self_generated/template_beta.pptx"

--- a/tests/paper/test_import.py
+++ b/tests/paper/test_import.py
@@ -86,9 +86,7 @@ def test_keep_appearance_dedupes_master_across_three_imports():
     saved = save_to_bytes(dest)
     zip_map = zip_member_map(saved)
     masters = [
-        m
-        for m in zip_map
-        if m.startswith("ppt/slideMasters/slideMaster") and m.endswith(".xml")
+        m for m in zip_map if m.startswith("ppt/slideMasters/slideMaster") and m.endswith(".xml")
     ]
     themes = [m for m in zip_map if m.startswith("ppt/theme/") and m.endswith(".xml")]
     assert sorted(masters) == [
@@ -143,9 +141,7 @@ def test_adopt_theme_unmatched_layout_refuses_and_explicit_target_recovers():
         dest.import_slide(source, 2, mode="adopt_theme")
     assert_changed_parts(before, save_to_bytes(dest))  # -- empty budget
 
-    report = dest.import_slide(
-        source, 2, mode="adopt_theme", target_layout=dest.slide_layouts[5]
-    )
+    report = dest.import_slide(source, 2, mode="adopt_theme", target_layout=dest.slide_layouts[5])
     assert report.layout_binding_method == "explicit"
     saved = save_to_bytes(dest)
     _assert_clean(saved)
@@ -204,6 +200,37 @@ def test_source_is_never_mutated_and_imported_chart_is_independent():
     source_chart = reopened_source.slides[2].shapes.chart_by_name("beta_chart")
     values = [pt for series in source_chart.plots[0].series for pt in series.values]
     assert values == [12.5, 8.75]  # -- source data untouched
+
+
+def test_import_remaps_copied_document_identity_without_mutating_source():
+    from lxml import etree
+
+    source = _open(BETA)
+    dest = _open(ALPHA)
+    identity_tag = "{http://schemas.microsoft.com/office/drawing/2014/main}creationId"
+    source_id = "{22222222-2222-2222-2222-222222222222}"
+    etree.SubElement(source.slides[0]._element, identity_tag, id=source_id)
+
+    dest.import_slide(source, 0, mode="adopt_theme")
+    imported_id = dest.slides[-1]._element.find(".//" + identity_tag).get("id")
+
+    assert imported_id != source_id
+    assert source.slides[0]._element.find(".//" + identity_tag).get("id") == source_id
+
+
+def test_import_refuses_a_deleted_source_slide_proxy():
+    source = _open(BETA)
+    stale = source.slides[0]
+    source.slides.delete(0)
+    dest = _open(ALPHA)
+
+    raised = assert_refusal_atomic(
+        dest,
+        lambda p: p.import_slide(source, stale, mode="adopt_theme"),
+        TargetNotFoundError,
+    )
+
+    assert "source slide" in str(raised)
 
 
 def test_media_always_copies_never_shared_across_packages():
@@ -265,15 +292,11 @@ def test_section_enrollment_named_and_adjacent():
     presentation = etree.fromstring(zip_member_map(saved2)["ppt/presentation.xml"])
     P14 = "http://schemas.microsoft.com/office/powerpoint/2010/main"
     intro = next(
-        s
-        for s in presentation.findall(".//{%s}section" % P14)
-        if s.get("name") == "Intro"
+        s for s in presentation.findall(".//{%s}section" % P14) if s.get("name") == "Intro"
     )
     intro_ids = [e.get("id") for e in intro.findall(".//{%s}sldId" % P14)]
     P = "http://schemas.openxmlformats.org/presentationml/2006/main"
-    deck_ids = [
-        e.get("id") for e in presentation.findall(".//{%s}sldIdLst/{%s}sldId" % (P, P))
-    ]
+    deck_ids = [e.get("id") for e in presentation.findall(".//{%s}sldIdLst/{%s}sldId" % (P, P))]
     # -- section order mirrors deck order: [slide 1's id, the imported slide's id]
     assert intro_ids == [deck_ids[0], deck_ids[1]]
 
@@ -352,13 +375,9 @@ def test_argument_validation():
     with pytest.raises(ValueError, match="does not belong"):
         dest.import_slide(source, dest.slides[0], mode="bake")
     with pytest.raises(ValueError, match="target_layout does not apply"):
-        dest.import_slide(
-            source, 0, mode="keep_appearance", target_layout=dest.slide_layouts[0]
-        )
+        dest.import_slide(source, 0, mode="keep_appearance", target_layout=dest.slide_layouts[0])
     with pytest.raises(ValueError, match="destination"):
-        dest.import_slide(
-            source, 0, mode="adopt_theme", target_layout=source.slide_layouts[0]
-        )
+        dest.import_slide(source, 0, mode="adopt_theme", target_layout=source.slide_layouts[0])
 
 
 def test_alternate_content_refuses_for_reconciling_modes_only():
@@ -387,9 +406,7 @@ def test_import_report_matches_frozen_golden():
     """Deterministic report, byte-identical to the reviewed golden."""
     dest = _open(ALPHA)
     report = dest.import_slide(_open(BETA), 0, mode="keep_appearance")
-    actual = (
-        json.dumps(report.to_dict(), indent=2, ensure_ascii=False) + "\n"
-    ).encode("utf-8")
+    actual = (json.dumps(report.to_dict(), indent=2, ensure_ascii=False) + "\n").encode("utf-8")
     golden_path = corpus.FIXTURES_DIR.parent / "goldens" / "import_beta_keep.import.json"
     assert actual == golden_path.read_bytes()
 
@@ -477,18 +494,14 @@ def test_import_placeholder_picture_slide_under_reconciling_modes():
         blobs = [
             shape.image.blob
             for shape in reopened.slides[3].shapes
-            if isinstance(shape, Picture) or (
-                shape.is_placeholder and hasattr(shape, "image")
-            )
+            if isinstance(shape, Picture) or (shape.is_placeholder and hasattr(shape, "image"))
         ]
         assert any(blob == png.getvalue() for blob in blobs)
 
 
 def test_append_deck_corrupt_source_refuses_typed():
     dest = _open(ALPHA)
-    corrupt = Presentation(
-        str(corpus.fixture_path("self_generated/corrupt_dangling_sldid.pptx"))
-    )
+    corrupt = Presentation(str(corpus.fixture_path("self_generated/corrupt_dangling_sldid.pptx")))
     before = save_to_bytes(dest)
     with pytest.raises(UnsupportedStructureError, match="relationship graph is broken"):
         dest.append_deck(corrupt, mode="bake")

--- a/tests/paper/test_inspect_text.py
+++ b/tests/paper/test_inspect_text.py
@@ -1,0 +1,44 @@
+"""Focused text-inspection regressions for promised visible content."""
+
+from __future__ import annotations
+
+from pptx import Presentation
+from pptx.inspect import inspect_text
+
+from . import corpus
+
+
+def _open(relpath):
+    return Presentation(str(corpus.fixture_path(relpath)))
+
+
+def test_chart_frame_is_reported_as_a_typed_blind_region():
+    slide = _open("self_generated/chart_notes.pptx").slides[0]
+    chart_shape = next(shape for shape in slide.shapes if shape.has_chart)
+
+    marker = next(
+        block for block in inspect_text(slide).blocks if block.container == "chart"
+    )
+
+    assert marker.shape_id == chart_shape.shape_id
+    assert marker.shape_name == chart_shape.name
+    assert marker.blind is True
+    assert marker.text == ""
+    assert marker.runs == ()
+
+
+def test_fields_are_reported_in_document_position_without_cached_display_text():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    paragraph = slide.shapes.add_textbox(
+        0, 0, 914400, 914400
+    ).text_frame.paragraphs[0]
+    paragraph.add_run().text = "Page "
+    paragraph.add_slide_number_field()
+
+    block = inspect_text(slide).blocks[0]
+
+    assert block.text == "Page "
+    assert block.fields == ("slidenum",)
+    assert [run.field_type for run in block.runs] == [None, "slidenum"]
+    assert block.to_dict()["runs"][1]["field_type"] == "slidenum"

--- a/tests/paper/test_inspect_text.py
+++ b/tests/paper/test_inspect_text.py
@@ -42,3 +42,19 @@ def test_fields_are_reported_in_document_position_without_cached_display_text():
     assert block.fields == ("slidenum",)
     assert [run.field_type for run in block.runs] == [None, "slidenum"]
     assert block.to_dict()["runs"][1]["field_type"] == "slidenum"
+
+
+def test_hard_line_breaks_remain_visible_text_boundaries():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    paragraph = slide.shapes.add_textbox(
+        0, 0, 914400, 914400
+    ).text_frame.paragraphs[0]
+    paragraph.add_run().text = "alpha"
+    paragraph.add_line_break()
+    paragraph.add_run().text = "beta"
+
+    block = inspect_text(slide).blocks[0]
+
+    assert block.text == "alpha\vbeta"
+    assert [run.text for run in block.runs] == ["alpha", "\v", "beta"]

--- a/tests/paper/test_package_io_hardening.py
+++ b/tests/paper/test_package_io_hardening.py
@@ -150,6 +150,31 @@ def test_path_save_failure_preserves_existing_file_and_mode(tmp_path, monkeypatc
     assert not list(tmp_path.glob(".existing.pptx.*.partial"))
 
 
+def test_stream_save_failure_restores_existing_bytes_and_position():
+    class FailingOnceStream(io.BytesIO):
+        def __init__(self, initial):
+            super().__init__(initial)
+            self._fail_next_write = True
+
+        def write(self, data):
+            if self._fail_next_write:
+                self._fail_next_write = False
+                super().write(data[: min(16, len(data))])
+                raise OSError("forced destination write failure")
+            return super().write(data)
+
+    presentation = Presentation(_minimal_path())
+    original = b"ORIGINAL STREAM CONTENT"
+    destination = FailingOnceStream(original)
+    destination.seek(7)
+
+    with pytest.raises(OSError, match="forced destination write failure"):
+        presentation.save(destination)
+
+    assert destination.getvalue() == original
+    assert destination.tell() == 7
+
+
 def test_successful_path_save_preserves_existing_mode(tmp_path):
     presentation = Presentation(_minimal_path())
     destination = tmp_path / "existing.pptx"

--- a/tests/paper/test_package_io_hardening.py
+++ b/tests/paper/test_package_io_hardening.py
@@ -175,6 +175,52 @@ def test_stream_save_failure_restores_existing_bytes_and_position():
     assert destination.tell() == 7
 
 
+def test_oversized_stream_save_refusal_restores_position():
+    from pptx._zipguard import MAX_COMPRESSED_BYTES
+
+    class OversizedDestination(io.BytesIO):
+        def __init__(self, initial):
+            super().__init__(initial)
+            self._at_reported_end = False
+
+        def seek(self, offset, whence=os.SEEK_SET):
+            self._at_reported_end = whence == os.SEEK_END
+            return super().seek(offset, whence)
+
+        def tell(self):
+            if self._at_reported_end:
+                return MAX_COMPRESSED_BYTES + 1
+            return super().tell()
+
+    presentation = Presentation(_minimal_path())
+    original = b"ORIGINAL STREAM CONTENT"
+    destination = OversizedDestination(original)
+    destination.seek(7)
+
+    with pytest.raises(PackageLimitError, match="destination stream exceeds"):
+        presentation.save(destination)
+
+    assert destination.getvalue() == original
+    assert destination.tell() == 7
+
+
+def test_stream_snapshot_failure_restores_position():
+    class UnreadableDestination(io.BytesIO):
+        def read(self, size=-1):
+            raise OSError("forced snapshot read failure")
+
+    presentation = Presentation(_minimal_path())
+    original = b"ORIGINAL STREAM CONTENT"
+    destination = UnreadableDestination(original)
+    destination.seek(7)
+
+    with pytest.raises(PaperRefusal, match="readable, seekable, truncatable"):
+        presentation.save(destination)
+
+    assert destination.getvalue() == original
+    assert destination.tell() == 7
+
+
 def test_successful_path_save_preserves_existing_mode(tmp_path):
     presentation = Presentation(_minimal_path())
     destination = tmp_path / "existing.pptx"

--- a/tests/paper/test_rebind.py
+++ b/tests/paper/test_rebind.py
@@ -152,14 +152,16 @@ def test_bake_geometry_falls_back_through_inheritance():
     """The baked orphan's xfrm is materialized from the resolved inheritance chain."""
     prs = _open(GAUNTLET)
     body = next(s for s in prs.slides[0].shapes if s.element.ph_idx == 1)
-    assert body._element.spPr.find(
-        "{http://schemas.openxmlformats.org/drawingml/2006/main}xfrm"
-    ) is None  # -- precondition: geometry lives on the layout, not the slide
+    assert (
+        body._element.spPr.find("{http://schemas.openxmlformats.org/drawingml/2006/main}xfrm")
+        is None
+    )  # -- precondition: geometry lives on the layout, not the slide
     prs.slides[0].rebind_layout(prs.slide_layouts[5], orphan_policy="bake")
     baked = next(s for s in prs.slides[0].shapes if s.name == "Content Placeholder 2")
-    assert baked._element.spPr.find(
-        "{http://schemas.openxmlformats.org/drawingml/2006/main}xfrm"
-    ) is not None
+    assert (
+        baked._element.spPr.find("{http://schemas.openxmlformats.org/drawingml/2006/main}xfrm")
+        is not None
+    )
 
 
 def test_bake_refuses_field_bearing_placeholder():
@@ -195,16 +197,18 @@ def test_bake_localizes_transformed_scheme_color_without_losing_transform():
 
     prs.slides[0].rebind_layout(prs.slide_layouts[5], orphan_policy="bake")
     reopened = save_reopen(prs)
-    baked = next(
-        s for s in reopened.slides[0].shapes if s.name == "Content Placeholder 2"
+    baked = next(s for s in reopened.slides[0].shapes if s.name == "Content Placeholder 2")
+    color = (
+        baked.text_frame.paragraphs[0]
+        .runs[0]
+        ._r.get_or_add_rPr()
+        .find("{http://schemas.openxmlformats.org/drawingml/2006/main}solidFill")[0]
     )
-    color = baked.text_frame.paragraphs[0].runs[0]._r.get_or_add_rPr().find(
-        "{http://schemas.openxmlformats.org/drawingml/2006/main}solidFill"
-    )[0]
     assert color.tag.endswith("srgbClr")
-    assert color.find(
-        "{http://schemas.openxmlformats.org/drawingml/2006/main}lumMod"
-    ).get("val") == "50000"
+    assert (
+        color.find("{http://schemas.openxmlformats.org/drawingml/2006/main}lumMod").get("val")
+        == "50000"
+    )
 
 
 def test_post_mutation_report_failure_rolls_rebind_back(monkeypatch):
@@ -239,9 +243,7 @@ def test_explicit_map_overrides_auto():
     report = prs.slides[0].rebind_layout(prs.slide_layouts[3], placeholder_map={1: 2})
     assert (1, 2) in report.placeholder_map_used
     reopened = save_reopen(prs)
-    ph_idx_set = {
-        s.element.ph_idx for s in reopened.slides[0].shapes if s.is_placeholder
-    }
+    ph_idx_set = {s.element.ph_idx for s in reopened.slides[0].shapes if s.is_placeholder}
     assert ph_idx_set == {0, 2}
 
 
@@ -274,9 +276,7 @@ def test_exact_matches_settle_before_lower_idx_placeholders_can_steal_slots():
     target = prs.slide_layouts[3]  # -- "Two Content": TITLE@0, OBJECT@1, OBJECT@2
     # -- make the target's OBJECT@1 slot a CHART slot: OBJECT@2 is now the only content
     # -- slot, and it is ph@2's EXACT match
-    target_obj1 = next(
-        ph for ph in target.placeholders if ph.element.ph_idx == 1
-    )
+    target_obj1 = next(ph for ph in target.placeholders if ph.element.ph_idx == 1)
     target_obj1.element.ph.type = PP_PLACEHOLDER.CHART
 
     # -- slide: BODY@1 (family-matches OBJECT only) plus an OBJECT@2 copy (exact match)
@@ -348,8 +348,23 @@ def test_rebound_output_reopens_and_text_intact():
     prs = _open(GAUNTLET)
     prs.slides[0].rebind_layout(prs.slide_layouts[5], orphan_policy="bake")
     reopened = Presentation(io.BytesIO(save_to_bytes(prs)))
-    texts = sorted(
-        s.text_frame.text for s in reopened.slides[0].shapes if s.has_text_frame
-    )
+    texts = sorted(s.text_frame.text for s in reopened.slides[0].shapes if s.has_text_frame)
     assert "Gauntlet: branded" in texts
     assert any("Inherited body level one" in t for t in texts)
+
+
+def test_rebind_refuses_deleted_slide_and_layout_targets():
+    prs = _open(GAUNTLET)
+    stale_slide = prs.slides[0]
+    target = prs.slide_layouts[3]
+    prs.slides.delete(0)
+
+    with pytest.raises(PaperRefusal, match="stale or no longer enrolled"):
+        stale_slide.rebind_layout(target)
+
+    live_slide = prs.slides[0]
+    stale_layout = next(layout for layout in prs.slide_layouts if not layout.used_by_slides)
+    stale_layout.slide_master.slide_layouts.remove(stale_layout)
+
+    with pytest.raises(PaperRefusal, match="stale or no longer enrolled"):
+        live_slide.rebind_layout(stale_layout)

--- a/tests/paper/test_rebind.py
+++ b/tests/paper/test_rebind.py
@@ -114,6 +114,18 @@ def test_rebind_report_is_deterministic():
     assert report_a == report_b
 
 
+def test_rebind_report_run_indices_include_hard_line_breaks():
+    prs = _open(GAUNTLET)
+    body = next(shape for shape in prs.slides[0].shapes if shape.element.ph_idx == 1)
+    body.text_frame.paragraphs[0].text = "Before\vAfter"
+
+    report = prs.slides[0].rebind_layout(prs.slide_layouts[3])
+
+    shifts = {shift.text: shift for shift in report.run_shifts}
+    assert shifts["Before"].run_index == 0
+    assert shifts["After"].run_index == 2
+
+
 # ------------------------------------------------------------------------------ orphans
 
 

--- a/tests/paper/test_scrub.py
+++ b/tests/paper/test_scrub.py
@@ -368,6 +368,27 @@ def test_notes_master_retained_reports_false_when_none_exists():
     assert report.notes_master_retained is False
 
 
+def test_late_report_failure_restores_live_scrub_state(monkeypatch):
+    import pptx.scrub as scrub_module
+
+    prs = Presentation()
+    prs.slides.add_slide(prs.slide_layouts[6])
+    core = prs.core_properties
+    core.author = "Original author"
+    before = zip_member_map(save_to_bytes(prs))
+
+    def fail_report(*args, **kwargs):
+        raise RuntimeError("forced report failure")
+
+    monkeypatch.setattr(scrub_module, "ScrubReport", fail_report)
+    with pytest.raises(RuntimeError, match="forced report failure"):
+        prs.scrub(metadata=True)
+
+    assert prs.core_properties is core
+    assert core.author == "Original author"
+    assert zip_member_map(save_to_bytes(prs)) == before
+
+
 # --------------------------------------------------------------------------------- lo_smoke
 
 

--- a/tests/paper/test_scrub.py
+++ b/tests/paper/test_scrub.py
@@ -126,6 +126,31 @@ def test_noop_scrub_changes_nothing():
     assert report.parts_modified == ()
 
 
+def test_noop_scrub_accepts_a_signed_deck_but_still_validates_toggles():
+    from pptx.opc.constants import CONTENT_TYPE as CT
+    from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+    from pptx.opc.package import Part
+    from pptx.opc.packuri import PackURI
+
+    prs = Presentation()
+    package = prs.part.package
+    signature_origin = Part(
+        PackURI("/_xmlsignatures/origin.sigs"),
+        CT.OPC_DIGITAL_SIGNATURE_ORIGIN,
+        package,
+        b"signed",
+    )
+    signature_rId = package.relate_to(signature_origin, RT.ORIGIN)
+
+    report = prs.scrub()
+
+    assert report.parts_removed == ()
+    assert report.parts_modified == ()
+    assert package._rels[signature_rId].target_part is signature_origin
+    with pytest.raises(ValueError, match="notes must be True or False"):
+        prs.scrub(notes=1)
+
+
 # ------------------------------------------------------------------- individual toggles
 
 

--- a/tests/paper/test_shape_surgery.py
+++ b/tests/paper/test_shape_surgery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 
 import pytest
+from lxml import etree
 
 from pptx import Presentation
 from pptx.errors import (
@@ -204,6 +205,35 @@ def test_move_rejects_bad_indices_and_foreign_shapes():
 
 
 # --------------------------------------------------------------------------------- add_copy
+
+
+def test_add_copy_remaps_document_wide_shape_creation_identity():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    source = slide.shapes.add_textbox(0, 0, Emu(914400), Emu(914400))
+    cNvPr = source._element.find(
+        ".//{http://schemas.openxmlformats.org/presentationml/2006/main}cNvPr"
+    )
+    extLst = etree.SubElement(
+        cNvPr, "{http://schemas.openxmlformats.org/drawingml/2006/main}extLst"
+    )
+    ext = etree.SubElement(
+        extLst,
+        "{http://schemas.openxmlformats.org/drawingml/2006/main}ext",
+        uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}",
+    )
+    creation = etree.SubElement(
+        ext,
+        "{http://schemas.microsoft.com/office/drawing/2014/main}creationId",
+    )
+    creation.set("id", "{11111111-1111-1111-1111-111111111111}")
+
+    copied = slide.shapes.add_copy(source)
+
+    copied_creation = copied._element.find(
+        ".//{http://schemas.microsoft.com/office/drawing/2014/main}creationId"
+    )
+    assert copied_creation.get("id") != creation.get("id")
 
 
 def test_add_copy_of_chart_shape_deep_copies_chart_and_workbook():

--- a/tests/paper/test_shape_surgery.py
+++ b/tests/paper/test_shape_surgery.py
@@ -125,6 +125,44 @@ def test_delete_refuses_dangling_shape_relationship_before_removal():
     assert "rId404" in str(raised)
 
 
+@pytest.mark.parametrize("operation", ["delete", "move", "add_copy"])
+def test_shape_mutators_refuse_a_publicly_deleted_target_slide(operation):
+    prs = Presentation()
+    target_slide = prs.slides.add_slide(prs.slide_layouts[6])
+    target_shape = target_slide.shapes.add_textbox(0, 0, Emu(914400), Emu(914400))
+    target_shapes = target_slide.shapes
+    source_slide = prs.slides.add_slide(prs.slide_layouts[6])
+    source_shape = source_slide.shapes.add_textbox(0, 0, Emu(914400), Emu(914400))
+    prs.slides.delete(target_slide)
+
+    with pytest.raises(TargetNotFoundError, match="target shape tree is stale"):
+        if operation == "delete":
+            target_shapes.delete(target_shape)
+        elif operation == "move":
+            target_shapes.move(target_shape, 0)
+        else:
+            target_shapes.add_copy(source_shape)
+
+
+def test_delete_rolls_back_when_relationship_cleanup_fails(monkeypatch):
+    prs = _open(GAUNTLET)
+    slide = prs.slides[2]
+    shape = slide.shapes.shape_by_name("real_bullet_box")
+    before = save_to_bytes(prs)
+
+    def fail_drop_rel(rId):
+        raise RuntimeError("forced relationship cleanup failure")
+
+    shape.text_frame.paragraphs[0].add_run().hyperlink.address = "https://example.com"
+    before = save_to_bytes(prs)
+    monkeypatch.setattr(slide.part, "drop_rel", fail_drop_rel)
+    with pytest.raises(RuntimeError, match="forced relationship cleanup failure"):
+        slide.shapes.delete(shape)
+
+    assert_changed_parts(before, save_to_bytes(prs))
+    assert shape._element.getparent() is slide.shapes._spTree
+
+
 # ------------------------------------------------------------------------------------- move
 
 

--- a/tests/paper/test_slide_ops.py
+++ b/tests/paper/test_slide_ops.py
@@ -63,6 +63,34 @@ def test_delete_refuses_when_another_slide_shares_the_notes_part():
     assert zip_member_map(save_to_bytes(prs)) == before
 
 
+@pytest.mark.parametrize(("operation", "method_name"), [("move", "insert"), ("reorder", "append")])
+def test_slide_reordering_rolls_back_a_late_xml_failure(monkeypatch, operation, method_name):
+    prs = _open(GAUNTLET)
+    slides = prs.slides
+    before = zip_member_map(save_to_bytes(prs))
+    list_type = type(slides._sldIdLst)
+    original = getattr(list_type, method_name)
+    failed = False
+
+    def fail_after_write(element, *args):
+        nonlocal failed
+        result = original(element, *args)
+        if element is slides._sldIdLst and not failed:
+            failed = True
+            raise RuntimeError("forced late slide-order failure")
+        return result
+
+    monkeypatch.setattr(list_type, method_name, fail_after_write)
+    with pytest.raises(RuntimeError, match="forced late slide-order failure"):
+        if operation == "move":
+            slides.move(3, 0)
+        else:
+            slides.reorder([3, 2, 1, 0])
+
+    assert zip_member_map(save_to_bytes(prs)) == before
+    assert slides is prs.slides
+
+
 def _assert_relationship_integrity(pptx_bytes):
     zip_map = zip_member_map(pptx_bytes)
     assert dangling_relationship_targets(zip_map) == []

--- a/tests/paper/test_slide_ops.py
+++ b/tests/paper/test_slide_ops.py
@@ -16,7 +16,13 @@ from lxml import etree
 from pptx import Presentation
 from pptx.chart.data import CategoryChartData
 from pptx.enum.chart import XL_CHART_TYPE
-from pptx.errors import PaperRefusal, RelationshipPolicyError, TargetNotFoundError
+from pptx.errors import (
+    PaperRefusal,
+    RelationshipPolicyError,
+    TargetNotFoundError,
+    UnsupportedStructureError,
+)
+from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 from pptx.slide import SlideClonePolicy
 from pptx.util import Inches
 
@@ -41,6 +47,20 @@ _RELS_NS = "{http://schemas.openxmlformats.org/package/2006/relationships}"
 
 def _open(relpath):
     return Presentation(str(corpus.fixture_path(relpath)))
+
+
+def test_delete_refuses_when_another_slide_shares_the_notes_part():
+    prs = Presentation()
+    first = prs.slides.add_slide(prs.slide_layouts[6])
+    second = prs.slides.add_slide(prs.slide_layouts[6])
+    notes_part = first.notes_slide.part
+    second.part.relate_to(notes_part, RT.NOTES_SLIDE)
+    before = zip_member_map(save_to_bytes(prs))
+
+    with pytest.raises(UnsupportedStructureError, match="notes part is shared"):
+        prs.slides.delete(first)
+
+    assert zip_member_map(save_to_bytes(prs)) == before
 
 
 def _assert_relationship_integrity(pptx_bytes):

--- a/tests/paper/test_slide_ops.py
+++ b/tests/paper/test_slide_ops.py
@@ -224,9 +224,7 @@ def test_clone_with_two_charts_allocates_distinct_partnames():
     prs.slides.clone(0)
     saved = save_to_bytes(prs)
     zip_map = zip_member_map(saved)  # -- asserts no duplicate member names by itself
-    charts = sorted(
-        n for n in zip_map if n.startswith("ppt/charts/chart") and n.endswith(".xml")
-    )
+    charts = sorted(n for n in zip_map if n.startswith("ppt/charts/chart") and n.endswith(".xml"))
     workbooks = sorted(n for n in zip_map if n.startswith("ppt/embeddings/"))
     assert len(charts) == 4
     assert len(workbooks) == 4
@@ -267,9 +265,7 @@ def test_clone_with_two_unshared_images_allocates_distinct_partnames():
 
     reopened = _reopen(saved)
     clone_blobs = {
-        s.image.blob
-        for s in reopened.slides[1].shapes
-        if s.shape_type.name == "PICTURE"
+        s.image.blob for s in reopened.slides[1].shapes if s.shape_type.name == "PICTURE"
     }
     assert clone_blobs == {png((250, 0, 0)), png((0, 250, 0))}
 
@@ -292,10 +288,7 @@ def test_clone_refuses_chart_with_unsupported_child_relationship():
     chart_part = next(s for s in prs.slides[0].shapes if s.has_chart).chart.part
     image_part = prs.slides[0].part.package.get_or_add_image_part(
         io.BytesIO(
-            Presentation(str(corpus.fixture_path(SHARED_MEDIA)))
-            .slides[0]
-            .shapes[0]
-            .image.blob
+            Presentation(str(corpus.fixture_path(SHARED_MEDIA))).slides[0].shapes[0].image.blob
         )
     )
     chart_part.relate_to(image_part, "http://example.com/relationships/bogus")
@@ -408,9 +401,7 @@ def test_reorder_permutes_slides_and_round_trips():
     after = save_to_bytes(prs)
     assert_changed_parts(before, after, expect_changed=["ppt/presentation.xml"])
 
-    titles_after = [
-        s.shapes.title.text if s.shapes.title else None for s in _reopen(after).slides
-    ]
+    titles_after = [s.shapes.title.text if s.shapes.title else None for s in _reopen(after).slides]
     assert titles_after == [titles_before[i] for i in [2, 0, 3, 1]]
 
 
@@ -549,6 +540,66 @@ def test_delete_error_paths_leave_the_deck_untouched():
     with pytest.raises(TargetNotFoundError):
         prs.slides.delete(other.slides[0])
     assert_changed_parts(before, save_to_bytes(prs))  # -- empty budget
+
+
+def test_delete_refuses_an_additional_relationship_alias_atomically():
+    prs = _open(MINIMAL)
+    target = prs.slides[0]
+    prs.part.rels._add_relationship(
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+        target.part,
+    )
+
+    raised = assert_refusal_atomic(prs, lambda p: p.slides.delete(0), PaperRefusal)
+
+    assert "additional inbound relationship aliases" in str(raised)
+
+
+def test_clone_rolls_back_late_failure_and_preserves_live_shape_proxy(monkeypatch):
+    from pptx import slideops
+
+    prs = _open(MINIMAL)
+    shape = prs.slides[0].shapes[0]
+
+    def fail_after_clone(*args):
+        raise RuntimeError("forced late clone failure")
+
+    monkeypatch.setattr(slideops, "enroll_clone_in_section", fail_after_clone)
+    assert_refusal_atomic(prs, lambda p: p.slides.clone(0), RuntimeError)
+
+    shape.text = "proxy remains live"
+    assert prs.slides[0].shapes[0].text == "proxy remains live"
+
+
+def test_clone_allocates_fresh_document_identity_for_each_copy():
+    prs = _open(MINIMAL)
+    identity_tag = "{http://schemas.microsoft.com/office/drawing/2014/main}creationId"
+    etree.SubElement(
+        prs.slides[0]._element,
+        identity_tag,
+        id="{11111111-1111-1111-1111-111111111111}",
+    )
+
+    first = prs.slides.clone(0)
+    second = prs.slides.clone(0)
+    ids = [slide._element.find(".//" + identity_tag).get("id") for slide in prs.slides]
+
+    assert first is not second
+    assert len(ids) == len(set(ids))
+
+
+def test_layout_delete_refuses_an_additional_relationship_alias_atomically():
+    prs = _open(MINIMAL)
+    layout = next(layout for layout in prs.slide_layouts if not layout.used_by_slides)
+    master = layout.slide_master
+    master.part.rels._add_relationship(
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout",
+        layout.part,
+    )
+
+    raised = assert_refusal_atomic(prs, lambda p: master.slide_layouts.remove(layout), PaperRefusal)
+
+    assert "additional inbound relationship aliases" in str(raised)
 
 
 # --------------------------------------------------------------------------------- lo_smoke

--- a/tests/paper/test_table_ops.py
+++ b/tests/paper/test_table_ops.py
@@ -427,6 +427,49 @@ def test_column_surgery_refuses_a_ragged_table_before_mutation():
     assert table._tbl.xml == before
 
 
+@pytest.mark.parametrize(
+    ("operation", "notification"),
+    [
+        (lambda table: table.insert_row(2), "notify_height_changed"),
+        (lambda table: table.delete_row(1), "notify_height_changed"),
+        (lambda table: table.insert_column(2), "notify_width_changed"),
+        (lambda table: table.delete_column(1), "notify_width_changed"),
+    ],
+)
+def test_table_surgery_rolls_back_late_extent_failure(monkeypatch, operation, notification):
+    from pptx.table import Table
+
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    rows = table.rows
+    columns = table.columns
+    before = save_to_bytes(prs)
+
+    def fail_extent_update(self):
+        raise RuntimeError("forced late table failure")
+
+    monkeypatch.setattr(Table, notification, fail_extent_update)
+    with pytest.raises(RuntimeError, match="forced late table failure"):
+        operation(table)
+
+    assert_changed_parts(before, save_to_bytes(prs))
+    assert table.rows is rows
+    assert table.columns is columns
+
+
+def test_table_surgery_refuses_a_table_on_a_deleted_shape():
+    from pptx.errors import TargetNotFoundError
+
+    prs = _open(GAUNTLET)
+    slide = prs.slides[2]
+    shape = slide.shapes.shape_by_name("gauntlet_table")
+    table = shape.table
+    slide.shapes.delete(shape)
+
+    with pytest.raises(TargetNotFoundError, match="table shape is stale"):
+        table.insert_row(0)
+
+
 # --------------------------------------------------------------------------------- lo_smoke
 
 

--- a/tests/paper/test_transaction.py
+++ b/tests/paper/test_transaction.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import io
 
 import pytest
+from lxml import etree
 
 from pptx import Presentation
 from pptx._transaction import PackageTransaction
 from pptx.errors import UnsupportedStructureError
 from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+from pptx.opc.package import Part, XmlPart
+from pptx.opc.packuri import PackURI
 from pptx.util import Inches
 
 from .contract import save_to_bytes, zip_member_map
@@ -98,3 +101,28 @@ def test_successful_transaction_commits_a_reopenable_candidate():
     reopened = Presentation(io.BytesIO(save_to_bytes(prs)))
     assert shape.text == "After"
     assert reopened.slides[0].shapes[-1].text == "After"
+
+
+def test_failure_restores_custom_xml_nodes_and_binary_payloads():
+    prs = Presentation()
+    package = prs.part.package
+    binary = Part(
+        PackURI("/custom/payload.bin"), "application/octet-stream", package, b"original"
+    )
+    root = etree.fromstring(b"<paper-state><child/></paper-state>")
+    child = root[0]
+    xml = XmlPart(PackURI("/custom/state.xml"), "application/xml", package, root)
+    package.relate_to(binary, "https://paper.example/relationships/binary")
+    package.relate_to(xml, "https://paper.example/relationships/xml")
+
+    with pytest.raises(RuntimeError, match="forced failure"):
+        with PackageTransaction(package):
+            binary._blob = b"dirty"
+            root.set("dirty", "1")
+            root.remove(child)
+            raise RuntimeError("forced failure")
+
+    assert binary.blob == b"original"
+    assert xml._element is root
+    assert root.get("dirty") is None
+    assert root[0] is child

--- a/tests/paper/test_transaction.py
+++ b/tests/paper/test_transaction.py
@@ -1,0 +1,100 @@
+"""Focused contracts for package-level mutation rollback."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from pptx import Presentation
+from pptx._transaction import PackageTransaction
+from pptx.errors import UnsupportedStructureError
+from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+from pptx.util import Inches
+
+from .contract import save_to_bytes, zip_member_map
+
+
+def _presentation_with_textbox(text="Before"):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    shape = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(3), Inches(1))
+    shape.text = text
+    return prs, slide, shape
+
+
+def test_failure_restores_live_proxies_relationships_and_saved_package():
+    prs, slide, shape = _presentation_with_textbox()
+    package = prs.part.package
+    relationships = slide.part.rels
+    before = zip_member_map(save_to_bytes(prs))
+    refusal = UnsupportedStructureError("forced refusal")
+
+    with pytest.raises(UnsupportedStructureError) as exc_info:
+        with PackageTransaction(package, prs, slide, shape):
+            shape.text = "Dirty"
+            relationships.get_or_add_ext_rel(RT.HYPERLINK, "https://example.invalid")
+            raise refusal
+
+    assert exc_info.value is refusal
+    assert shape.text == "Before"
+    assert slide.part.rels is relationships
+    assert all(rel.target_ref != "https://example.invalid" for rel in relationships.values())
+    assert zip_member_map(save_to_bytes(prs)) == before
+
+
+def test_nested_failure_restores_to_inner_entry_state():
+    prs, _slide, shape = _presentation_with_textbox()
+    package = prs.part.package
+
+    with PackageTransaction(package, shape):
+        shape.text = "Outer"
+        with pytest.raises(ValueError, match="inner failed"):
+            with PackageTransaction(package, shape):
+                shape.text = "Inner"
+                raise ValueError("inner failed")
+        assert shape.text == "Outer"
+
+    assert shape.text == "Outer"
+
+
+def test_preconstructed_nested_transaction_snapshots_context_entry():
+    prs, _slide, shape = _presentation_with_textbox()
+    package = prs.part.package
+    inner = PackageTransaction(package, shape)
+
+    with PackageTransaction(package, shape):
+        shape.text = "Outer"
+        with pytest.raises(ValueError, match="inner failed"):
+            with inner:
+                shape.text = "Inner"
+                raise ValueError("inner failed")
+        assert shape.text == "Outer"
+
+
+def test_candidate_validation_failure_rolls_back_live_state(monkeypatch):
+    prs, _slide, shape = _presentation_with_textbox()
+    package = prs.part.package
+    before = zip_member_map(save_to_bytes(prs))
+
+    def refuse_candidate(_transaction):
+        raise UnsupportedStructureError("candidate refused")
+
+    monkeypatch.setattr(PackageTransaction, "_validate_candidate", refuse_candidate)
+    with pytest.raises(UnsupportedStructureError, match="candidate refused"):
+        with PackageTransaction(package, shape):
+            shape.text = "Dirty"
+
+    assert shape.text == "Before"
+    assert zip_member_map(save_to_bytes(prs)) == before
+
+
+def test_successful_transaction_commits_a_reopenable_candidate():
+    prs, _slide, shape = _presentation_with_textbox()
+
+    with PackageTransaction(prs.part.package, shape):
+        shape.text = "After"
+
+    reopened = Presentation(io.BytesIO(save_to_bytes(prs)))
+    assert shape.text == "After"
+    assert reopened.slides[0].shapes[-1].text == "After"

--- a/tests/paper/test_transaction.py
+++ b/tests/paper/test_transaction.py
@@ -18,6 +18,19 @@ from pptx.util import Inches
 from .contract import save_to_bytes, zip_member_map
 
 
+class _MutatingBlobPart(Part):
+    """Custom part whose serialization mutates an unrelated live XML tree."""
+
+    def __init__(self, partname, content_type, package, blob, target_root):
+        super().__init__(partname, content_type, package, blob)
+        self._target_root = target_root
+
+    @property
+    def blob(self):
+        self._target_root.set("validation-dirty", "1")
+        return self._blob
+
+
 def _presentation_with_textbox(text="Before"):
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[6])
@@ -101,6 +114,40 @@ def test_successful_transaction_commits_a_reopenable_candidate():
     reopened = Presentation(io.BytesIO(save_to_bytes(prs)))
     assert shape.text == "After"
     assert reopened.slides[0].shapes[-1].text == "After"
+
+
+def test_candidate_without_presentation_root_refuses_and_rolls_back():
+    prs = Presentation()
+    package = prs.part.package
+    office_rId = next(
+        rId for rId, rel in package._rels.items() if rel.reltype == RT.OFFICE_DOCUMENT
+    )
+    office_part = package._rels[office_rId].target_part
+
+    with pytest.raises(UnsupportedStructureError, match="not a reopenable"):
+        with PackageTransaction(package):
+            package.drop_rel(office_rId)
+
+    assert package._rels[office_rId].target_part is office_part
+    Presentation(io.BytesIO(save_to_bytes(prs)))
+
+
+def test_successful_validation_restores_serialization_side_effects():
+    prs = Presentation()
+    root = prs.part._element
+    custom = _MutatingBlobPart(
+        PackURI("/custom/mutating.bin"),
+        "application/octet-stream",
+        prs.part.package,
+        b"payload",
+        root,
+    )
+    prs.part.package.relate_to(custom, "https://paper.example/relationships/mutating")
+
+    with PackageTransaction(prs.part.package):
+        pass
+
+    assert root.get("validation-dirty") is None
 
 
 def test_failure_restores_custom_xml_nodes_and_binary_payloads():


### PR DESCRIPTION
## Summary

Prepare `paper-pptx 0.1.2` as a focused correctness and safety release for editing existing presentations.

- add proxy-preserving package transactions for multi-part mutations
- restore live XML nodes, relationships, mutable binary parts, and proxy caches after failures
- reject stale Paper mutation targets, shared chart/workbook state, relationship aliases, and foreign source-package ownership
- preserve document-wide creation and field identities during cloning and composition
- make slide movement, deletion, cloning, import, rebind, scrub, chart/image replacement, table surgery, fields, bullets, and footer application refusal-atomic
- make path and seekable-stream saves restore their original destination after failed writes
- correct inherited formatting provenance, layout color-map handling, fields, hard line breaks, exact-package comparisons, stream restoration, and formatting-shift alignment
- bump the distribution and fork sentinel to `0.1.2`

## Why

The defining contract of `paper-pptx` is that an operation either completes correctly or refuses without leaving partial document state behind. Review found practical cases where late failures could leave live proxies detached from restored XML, where shared chart data could contaminate another chart, and where verification output could omit or misalign meaningful changes.

This release closes those concrete gaps without adding new authoring features.

## Developer impact

Applications can safely catch a typed refusal and continue using the same presentation for the hardened Paper operations. Slide deletion and composition validate ownership before changing the package, chart updates refuse shared mutable state, and inspection/diff output is safer to use in automated review workflows.

The frozen import remains unchanged:

```python
from pptx import Presentation
```

Scope remains limited to the Paper mutation APIs covered by the proposal. Arbitrary inherited `python-pptx` setters used through proxies retained after a successful deletion are not globally intercepted by this release.

## Validation

- `3545 passed` across the complete inherited and Paper test suite
- focused transaction, ownership, relationship, inspection, diff, stream-save, and release regressions
- LibreOffice load smoke coverage
- scoped Ruff and `git diff --check`
- wheel and source distribution build
- strict Twine metadata checks
- isolated wheel version/sentinel identity check
- isolated `paper-pptx-doctor`

## Release

After this PR merges, push tag `v0.1.2` from the merged commit. The tag-triggered release workflow will rebuild, verify, and publish the exact artifacts to PyPI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core OPC mutation, rollback, relationship graph validation, and many public edit paths; rollback failure surfaces as `TransactionRollbackError` when restoration cannot be proven exact.
> 
> **Overview**
> **paper-pptx 0.1.2** is a correctness release: failed edits should leave the same in-memory presentation and on-disk package as before, and inspection/diff should match what actually changed.
> 
> The centerpiece is **`PackageTransaction`**, which snapshots XML trees (preserving original node identity for proxies), part/package state, binary payloads, and `pptx` proxy caches, rolls back on refusal, and validates reopenable candidates on successful outer commits. That boundary now wraps deck-wide text replace, footers, scrub, rebind, compose/import, slide clone/move/delete/reorder, shape copy/delete/move, picture swap, chart data replacement, and table row/column surgery—replacing ad hoc deepcopy rollback (e.g. on charts).
> 
> **Stale-target and relationship integrity** checks expand: slides/layouts must stay enrolled; shapes/charts/trees must remain attached and package-reachable; chart updates refuse shared workbooks or multiply referenced chart parts; slide/layout deletion refuses shared notes parts and extra inbound relationship aliases; import/clone paths refuse internal targets owned by another package.
> 
> **Copy/compose identity** uses `_CopySession` to remap document-wide `a16:creationId` and field IDs so clones/imports do not collide or alias source package parts.
> 
> **Inspection and diff** gain field markers and hard line breaks (`\v`), stricter placeholder inheritance (exact layout idx, ambiguous master/layout refusal, layout-aware `clrMapOvr`), blind regions for charts/graphic frames, `diff_decks` comparing the supplied path/stream bytes (with stream position restore), package-level deltas from exact inputs, and content-aligned effective-formatting shifts for rebind/import reports.
> 
> **Saves** to seekable streams are refusal-atomic like path saves. Version/sentinel bump to **0.1.2** plus changelog and a hardening proposal doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84443987a13f57b958b800c5dab3ac128c989dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->