### PR TITLE
fix(zipguard): remove resource ceilings that refused files paper-pptx writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,11 @@ corruption prevention:
 
 - **Guarded package intake.** Opening a `.pptx` now rejects ambiguous or unsafe
   ZIP archives — duplicate or case-colliding member names, path traversal,
-  encrypted or exotically-compressed members, lying size headers,
-  resource-exhaustion bombs — with a typed `PackageLimitError` *before* any
-  editable object exists. A permissive reader "successfully" opens an ambiguous
-  archive and then faithfully edits the wrong interpretation of it. Some
-  odd-but-consumer-readable files that upstream accepted are now refused.
+  encrypted or exotically-compressed members, lying size headers — with a typed
+  `PackageLimitError` *before* any editable object exists. A permissive reader
+  "successfully" opens an ambiguous archive and then faithfully edits the wrong
+  interpretation of it. Some odd-but-consumer-readable files that upstream
+  accepted are now refused.
 - **Atomic save.** `save()` keeps its signature, but saving to a path now
   writes a sibling temporary file and atomically replaces the destination only
   after serialization succeeds, preserving the existing file's permission bits;

--- a/src/pptx/_zipguard.py
+++ b/src/pptx/_zipguard.py
@@ -1,22 +1,14 @@
-"""Bounded, unambiguous ZIP reads for OPC packages.
+"""Unambiguous ZIP reads for OPC packages.
 
-These limits are a safety envelope, not OOXML validity rules. They are
-deliberately generous for ordinary PowerPoint presentations while keeping one package
-from consuming unbounded CPU, memory, or disk-backed input:
-
-* 256 MiB compressed package size;
-* 4,096 members;
-* 64 MiB for one XML member and 256 MiB for one binary member; and
-* 512 MiB expanded across the package.
-
-There is deliberately no expanded-to-compressed ratio limit: legitimate machine-generated
-decks (thousands of near-identical paragraphs or rows) routinely exceed any ratio a zip
-bomb would need, and every expansion is already capped absolutely by the member and
-package limits above. A ratio rule would refuse files this package itself saves.
+An OPC package must have exactly one interpretation. Archives whose structure admits
+more than one are refused rather than resolved by guesswork: ambiguous or multi-disk
+end-of-central-directory records, member counts and offsets that disagree, duplicate or
+case-equivalent member names, local headers that contradict the central directory, and
+data that overlaps or trails a member's declared extent.
 
 Only the two compression methods permitted by the OPC ZIP mapping (stored and
 deflated) are accepted. Every member is inflated from its raw compressed bytes
-rather than through ``ZipFile.read()``. This allows actual output length and
+rather than through ``ZipFile.read()``. This allows actual output length, CRC, and
 deflate end-of-stream to be checked even when central-directory sizes lie.
 """
 
@@ -34,21 +26,6 @@ from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile, ZipInfo
 from lxml import etree
 
 from pptx.errors import PackageLimitError
-
-_MIB = 1024 * 1024
-
-#: Maximum physical size of a ZIP package before any member is expanded.
-MAX_COMPRESSED_BYTES = 256 * _MIB
-#: Maximum number of central-directory records in one package.
-MAX_MEMBER_COUNT = 4_096
-#: Maximum bytes occupied by central-directory records.
-MAX_CENTRAL_DIRECTORY_BYTES = 16 * _MIB
-#: Maximum expanded size of one XML or relationships part.
-MAX_XML_MEMBER_BYTES = 64 * _MIB
-#: Maximum expanded size of one non-XML part, such as an image or embedding.
-MAX_BINARY_MEMBER_BYTES = 256 * _MIB
-#: Maximum expanded bytes across all members in one package.
-MAX_TOTAL_EXPANDED_BYTES = 512 * _MIB
 
 _READ_CHUNK_BYTES = 64 * 1024
 _LOCAL_HEADER = struct.Struct("<4s5H3L2H")
@@ -126,47 +103,15 @@ def compressed_size(source: object) -> Optional[int]:
     return size if isinstance(size, int) and not isinstance(size, bool) else None
 
 
-def enforce_compressed_size(source: object) -> Optional[int]:
-    """Refuse `source` when its physical size exceeds the package bound."""
-    size = compressed_size(source)
-    if size is not None and size > MAX_COMPRESSED_BYTES:
-        raise PackageLimitError(
-            "ZIP package compressed size "
-            f"{size} bytes exceeds the {MAX_COMPRESSED_BYTES}-byte limit"
-        )
-    return size
-
-
-def read_compressed_bytes(path: Union[str, "os.PathLike[str]"]) -> bytes:
-    """Read a package file in chunks while enforcing its actual byte count."""
-    enforce_compressed_size(path)
-    chunks: List[bytes] = []
-    total = 0
-    with open(path, "rb") as stream:
-        while True:
-            chunk = stream.read(min(_READ_CHUNK_BYTES, MAX_COMPRESSED_BYTES - total + 1))
-            if not chunk:
-                break
-            total += len(chunk)
-            if total > MAX_COMPRESSED_BYTES:
-                raise PackageLimitError(
-                    "ZIP package actual compressed size exceeds the "
-                    f"{MAX_COMPRESSED_BYTES}-byte limit"
-                )
-            chunks.append(chunk)
-    return b"".join(chunks)
-
-
 def preflight_zip(source: object) -> None:
-    """Validate bounded central-directory metadata before ``ZipFile`` opens.
+    """Validate central-directory metadata before ``ZipFile`` parses it.
 
-    ``zipfile.ZipFile`` creates one ``ZipInfo`` object per central-directory
-    record. A forged but physically small archive can otherwise force an
-    unbounded allocation before the ordinary member-count guard runs. This
-    preflight reads only fixed-size records and skips variable fields without
-    retaining them.
+    An archive must declare one unambiguous central-directory region: a single
+    end-of-central-directory record, no multi-disk structure, and member counts,
+    offsets, and sizes that agree with each other and with the records actually
+    present. This preflight reads only fixed-size records and skips variable
+    fields without retaining them.
     """
-    enforce_compressed_size(source)
     if isinstance(source, (str, os.PathLike)):
         path = cast(Union[str, "os.PathLike[str]"], source)
         with open(path, "rb") as stream:
@@ -197,11 +142,6 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
             # ZipFile's central-directory parser with this result type.
             return
         archive_size = archive_size_value
-        if archive_size > MAX_COMPRESSED_BYTES:
-            raise PackageLimitError(
-                "ZIP package compressed size "
-                f"{archive_size} bytes exceeds the {MAX_COMPRESSED_BYTES}-byte limit"
-            )
 
         end_offset, end_fields = _find_end_record(stream, archive_size)
         (
@@ -235,16 +175,6 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
 
         if disk_entries != total_entries:
             raise PackageLimitError("ZIP central-directory counts disagree across disks")
-        if total_entries > MAX_MEMBER_COUNT:
-            raise PackageLimitError(
-                f"ZIP member count {total_entries} exceeds the "
-                f"{MAX_MEMBER_COUNT}-member limit"
-            )
-        if central_size > MAX_CENTRAL_DIRECTORY_BYTES:
-            raise PackageLimitError(
-                f"ZIP central directory size {central_size} bytes exceeds the "
-                f"{MAX_CENTRAL_DIRECTORY_BYTES}-byte limit"
-            )
         if central_offset < 0 or central_size < 0:
             raise PackageLimitError("ZIP central-directory metadata is negative")
         if central_offset + central_size != central_end:
@@ -394,10 +324,6 @@ def _scan_central_directory(
             raise PackageLimitError("ZIP central-directory member record exceeds its region")
         cursor += record_size
         actual_count += 1
-        if actual_count > MAX_MEMBER_COUNT:
-            raise PackageLimitError(
-                f"ZIP member count exceeds the {MAX_MEMBER_COUNT}-member limit"
-            )
         if actual_count > expected_count:
             raise PackageLimitError("ZIP central-directory member count exceeds its end record")
 
@@ -408,18 +334,14 @@ def _scan_central_directory(
 class GuardedZipReader:
     """Validate and stream every member of an already-open ``ZipFile``.
 
-    Construction fully validates the archive and caches bounded member bytes.
+    Construction fully validates the archive and caches every member's bytes.
     This makes ordinary ``Document()`` opens and package-kernel reads share the
     same validation, including for members not reachable from OPC relationships.
     """
 
     def __init__(self, zip_file: ZipFile):
         self._zip_file = zip_file
-        enforce_compressed_size(zip_file.fp)
         self._infos = tuple(zip_file.infolist())
-        self._member_limits = {
-            info.filename: _member_limit(info.filename) for info in self._infos
-        }
         self._validate_metadata()
         self._parts = self._read_all_members()
 
@@ -437,15 +359,9 @@ class GuardedZipReader:
         return dict(self._parts), list(self.order)
 
     def _validate_metadata(self) -> None:
-        if len(self._infos) > MAX_MEMBER_COUNT:
-            raise PackageLimitError(
-                f"ZIP member count {len(self._infos)} exceeds the {MAX_MEMBER_COUNT}-member limit"
-            )
-
         seen_names: set[str] = set()
         seen_equivalent_names: set[str] = set()
         seen_offsets: set[int] = set()
-        expanded_total = 0
         for info in self._infos:
             name = info.orig_filename
             if name != info.filename:
@@ -490,17 +406,6 @@ class GuardedZipReader:
 
             if info.file_size < 0 or info.compress_size < 0:
                 raise PackageLimitError(f"ZIP member {name!r} has a negative size")
-            member_limit = self._limit_for(name)
-            if info.file_size > member_limit:
-                raise PackageLimitError(
-                    f"ZIP member {name!r} expanded size {info.file_size} bytes "
-                    f"exceeds the {member_limit}-byte limit"
-                )
-            expanded_total += info.file_size
-            if expanded_total > MAX_TOTAL_EXPANDED_BYTES:
-                raise PackageLimitError(
-                    f"ZIP total expanded size exceeds the {MAX_TOTAL_EXPANDED_BYTES}-byte limit"
-                )
             if info.compress_type == ZIP_STORED and info.file_size != info.compress_size:
                 raise PackageLimitError(
                     f"stored ZIP member {name!r} has inconsistent size metadata"
@@ -536,7 +441,6 @@ class GuardedZipReader:
             original_position = None
 
         parts: Dict[str, bytes] = {}
-        actual_total = 0
         try:
             content_types_info = next(
                 (info for info in self._infos if info.filename == _CONTENT_TYPES_NAME),
@@ -547,49 +451,23 @@ class GuardedZipReader:
                     content_types_info,
                     boundaries[content_types_info.header_offset],
                 )
-                content_types, actual_total = self._inflate_member(
-                    content_types_info,
-                    data_start,
-                    actual_total,
-                )
+                content_types = self._inflate_member(content_types_info, data_start)
                 parts[content_types_info.filename] = content_types
-                self._apply_content_type_limits(content_types)
-                self._validate_declared_member_limits()
+                self._validate_content_types(content_types)
 
             for info in self._infos:
                 if info is content_types_info:
                     continue
                 data_start = self._validate_local_header(info, boundaries[info.header_offset])
-                blob, actual_total = self._inflate_member(info, data_start, actual_total)
-                parts[info.filename] = blob
+                parts[info.filename] = self._inflate_member(info, data_start)
         finally:
             if original_position is not None:
                 with suppress(AttributeError, OSError, TypeError, ValueError):
                     stream.seek(original_position, os.SEEK_SET)
         return parts
 
-    def _apply_content_type_limits(self, content_types: bytes) -> None:
-        defaults, overrides = _parse_content_types(content_types)
-        for info in self._infos:
-            name = info.filename
-            content_type = overrides.get(f"/{name}".casefold())
-            if content_type is None and "." in name.rsplit("/", 1)[-1]:
-                extension = name.rsplit(".", 1)[-1].lower()
-                content_type = defaults.get(extension)
-            if content_type is not None and _is_xml_content_type(content_type):
-                self._member_limits[name] = MAX_XML_MEMBER_BYTES
-
-    def _validate_declared_member_limits(self) -> None:
-        for info in self._infos:
-            member_limit = self._limit_for(info.filename)
-            if info.file_size > member_limit:
-                raise PackageLimitError(
-                    f"ZIP member {info.filename!r} expanded size {info.file_size} bytes "
-                    f"exceeds the {member_limit}-byte limit"
-                )
-
-    def _limit_for(self, name: str) -> int:
-        return self._member_limits[name]
+    def _validate_content_types(self, content_types: bytes) -> None:
+        _parse_content_types(content_types)
 
     def _validate_local_header(self, info: ZipInfo, boundary: int) -> int:
         stream = self._zip_file.fp
@@ -698,9 +576,7 @@ class GuardedZipReader:
                 f"ZIP member {info.filename!r} has inconsistent data-descriptor metadata"
             )
 
-    def _inflate_member(
-        self, info: ZipInfo, data_start: int, actual_total: int
-    ) -> Tuple[bytes, int]:
+    def _inflate_member(self, info: ZipInfo, data_start: int) -> bytes:
         stream = self._zip_file.fp
         if stream is None:
             raise PackageLimitError("ZIP package stream is closed")
@@ -709,24 +585,12 @@ class GuardedZipReader:
         chunks: List[bytes] = []
         actual_size = 0
         crc = 0
-        member_limit = self._limit_for(info.filename)
 
         def consume(data: bytes) -> None:
-            nonlocal actual_size, actual_total, crc
+            nonlocal actual_size, crc
             if not data:
                 return
             actual_size += len(data)
-            actual_total += len(data)
-            if actual_size > member_limit:
-                raise PackageLimitError(
-                    f"ZIP member {info.filename!r} actual expanded size exceeds the "
-                    f"{member_limit}-byte limit"
-                )
-            if actual_total > MAX_TOTAL_EXPANDED_BYTES:
-                raise PackageLimitError(
-                    "ZIP actual total expanded size exceeds the "
-                    f"{MAX_TOTAL_EXPANDED_BYTES}-byte limit"
-                )
             crc = zlib.crc32(data, crc)
             chunks.append(data)
 
@@ -756,10 +620,7 @@ class GuardedZipReader:
                             raise PackageLimitError(
                                 f"ZIP member {info.filename!r} has trailing compressed data"
                             )
-                        output = decompressor.decompress(
-                            pending,
-                            self._next_output_size(member_limit, actual_size, actual_total),
-                        )
+                        output = decompressor.decompress(pending, _READ_CHUNK_BYTES)
                         pending = decompressor.unconsumed_tail
                         consume(output)
                         if decompressor.unused_data:
@@ -768,9 +629,7 @@ class GuardedZipReader:
                             )
 
                 while not decompressor.eof:
-                    output = decompressor.decompress(
-                        b"", self._next_output_size(member_limit, actual_size, actual_total)
-                    )
+                    output = decompressor.decompress(b"", _READ_CHUNK_BYTES)
                     consume(output)
                     if not output:
                         break
@@ -790,13 +649,7 @@ class GuardedZipReader:
             )
         if crc & 0xFFFFFFFF != info.CRC:
             raise PackageLimitError(f"ZIP member {info.filename!r} fails its CRC check")
-        return b"".join(chunks), actual_total
-
-    @staticmethod
-    def _next_output_size(member_limit: int, member_size: int, total_size: int) -> int:
-        member_remaining = member_limit - member_size + 1
-        total_remaining = MAX_TOTAL_EXPANDED_BYTES - total_size + 1
-        return max(1, min(_READ_CHUNK_BYTES, member_remaining, total_remaining))
+        return b"".join(chunks)
 
 
 def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
@@ -861,18 +714,6 @@ def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
             "[Content_Types].xml contains an unsupported declaration"
         )
     return defaults, overrides
-
-
-def _is_xml_content_type(content_type: str) -> bool:
-    media_type = content_type.partition(";")[0].strip().lower()
-    return media_type in ("application/xml", "text/xml") or media_type.endswith("+xml")
-
-
-def _member_limit(name: str) -> int:
-    lower_name = name.lower()
-    if lower_name.endswith(".xml") or lower_name.endswith(".rels"):
-        return MAX_XML_MEMBER_BYTES
-    return MAX_BINARY_MEMBER_BYTES
 
 
 def _validate_member_name(name: str) -> None:

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -303,29 +303,21 @@ def _source_package_map(source, prs, label: str) -> dict:
 
 
 def _read_stream_package_bytes(source, label: str) -> bytes:
-    """Read a package stream in bounded chunks with typed I/O failures."""
-    from pptx._zipguard import MAX_COMPRESSED_BYTES
-    from pptx.errors import PackageLimitError, UnsupportedStructureError
+    """Read a package stream in fixed-size chunks, with typed I/O failures."""
+    from pptx.errors import UnsupportedStructureError
 
     chunks = []
-    total = 0
     try:
         while True:
-            chunk = source.read(min(1024 * 1024, MAX_COMPRESSED_BYTES - total + 1))
+            chunk = source.read(1024 * 1024)
             if not isinstance(chunk, bytes):
                 raise UnsupportedStructureError(
                     "diff_decks refused: %s input stream must return bytes" % label
                 )
             if not chunk:
                 return b"".join(chunks)
-            total += len(chunk)
-            if total > MAX_COMPRESSED_BYTES:
-                raise PackageLimitError(
-                    "diff_decks refused: %s input stream exceeds the compressed package limit"
-                    % label
-                )
             chunks.append(chunk)
-    except (PackageLimitError, UnsupportedStructureError):
+    except UnsupportedStructureError:
         raise
     except (OSError, TypeError, ValueError) as exc:
         raise UnsupportedStructureError(

--- a/src/pptx/errors.py
+++ b/src/pptx/errors.py
@@ -29,7 +29,7 @@ class PaperRefusal(Exception):
 
 
 class PackageLimitError(PaperRefusal):
-    """The package archive is too large, ambiguous, or unsafe to expand."""
+    """The package archive is ambiguous or unsafe to expand."""
 
 
 class AmbiguousTargetError(PaperRefusal):

--- a/src/pptx/opc/package.py
+++ b/src/pptx/opc/package.py
@@ -165,8 +165,7 @@ class OpcPackage(_RelatableMixin):
 
     def _save_stream_atomically(self, stream: IO[bytes], parts: tuple[Part, ...]) -> None:
         """Stage output and restore a seekable destination if publishing fails."""
-        from pptx._zipguard import MAX_COMPRESSED_BYTES
-        from pptx.errors import PackageLimitError, UnsupportedStructureError
+        from pptx.errors import UnsupportedStructureError
 
         with tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024, mode="w+b") as staged:
             PackageWriter.write(staged, self._rels, parts)
@@ -177,10 +176,6 @@ class OpcPackage(_RelatableMixin):
                 original_position = stream.tell()
                 stream.seek(0, os.SEEK_END)
                 original_size = stream.tell()
-                if original_size > MAX_COMPRESSED_BYTES:
-                    raise PackageLimitError(
-                        "existing package destination stream exceeds the compressed package limit"
-                    )
                 stream.seek(0)
                 original = stream.read(original_size)
                 if not isinstance(original, bytes) or len(original) != original_size:
@@ -198,8 +193,6 @@ class OpcPackage(_RelatableMixin):
                             "package stream setup failed and the original position could not "
                             "be restored"
                         ) from restore_error
-                if isinstance(setup_error, PackageLimitError):
-                    raise
                 if isinstance(setup_error, (AttributeError, OSError, TypeError, ValueError)):
                     raise UnsupportedStructureError(
                         "saving to a stream requires readable, seekable, truncatable "

--- a/src/pptx/opc/serialized.py
+++ b/src/pptx/opc/serialized.py
@@ -7,7 +7,7 @@ import posixpath
 import zipfile
 from typing import IO, TYPE_CHECKING, Any, Container, Sequence
 
-from pptx._zipguard import GuardedZipReader, enforce_compressed_size, preflight_zip
+from pptx._zipguard import GuardedZipReader, preflight_zip
 from pptx.exc import PackageNotFoundError
 from pptx.opc.constants import CONTENT_TYPE as CT
 from pptx.opc.oxml import CT_Types, serialize_part_xml
@@ -145,8 +145,6 @@ class _PhysPkgReader(Container[PackURI]):
         if os.path.isdir(path):
             return _DirPkgReader(path)
 
-        if os.path.isfile(path):
-            enforce_compressed_size(path)
         if zipfile.is_zipfile(path):
             return _ZipPkgReader(path)
 
@@ -205,7 +203,6 @@ class _ZipPkgReader(_PhysPkgReader):
     @lazyproperty
     def _blobs(self) -> dict[PackURI, bytes]:
         """dict mapping partname to package part binaries."""
-        enforce_compressed_size(self._pkg_file)
         preflight_zip(self._pkg_file)
         with zipfile.ZipFile(self._pkg_file, "r") as z:
             guarded = GuardedZipReader(z)

--- a/tests/paper/conftest.py
+++ b/tests/paper/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from pptx.opc.package import PartFactory
@@ -12,6 +14,12 @@ from .clock import FrozenClock
 # -- import-time registration state established by pptx/__init__.py.
 _CANONICAL_PART_TYPES = dict(PartFactory.part_type_for)
 
+_BIG_IO_MARK = "big_io"
+_BIG_IO_SKIP_REASON = (
+    "big_io: writes and reads a package larger than 256 MiB; enable with PAPER_BIG_IO=1 or "
+    "`pytest -m big_io`"
+)
+
 
 def pytest_configure(config):
     # -- registered here (not in pyproject.toml) so no upstream config file changes; the
@@ -21,6 +29,21 @@ def pytest_configure(config):
         "lo_smoke: independent-loader smoke via headless LibreOffice; skipped when soffice "
         "is unavailable",
     )
+    config.addinivalue_line(
+        "markers",
+        "big_io: package intake at a size that costs real disk I/O (>256 MiB written and "
+        "read); skipped unless PAPER_BIG_IO=1 or selected with `-m big_io`",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip `big_io` tests unless the caller opted in, by env var or by `-m` selector."""
+    if os.environ.get("PAPER_BIG_IO") or _BIG_IO_MARK in (config.getoption("-m") or ""):
+        return
+    skip = pytest.mark.skip(reason=_BIG_IO_SKIP_REASON)
+    for item in items:
+        if _BIG_IO_MARK in item.keywords:
+            item.add_marker(skip)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/paper/test_package_io_hardening.py
+++ b/tests/paper/test_package_io_hardening.py
@@ -1,4 +1,4 @@
-"""Adversarial coverage for bounded package reads and atomic ordinary saves."""
+"""Adversarial coverage for guarded package reads and atomic ordinary saves."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from lxml import etree
 
 from pptx import Presentation
 from pptx.errors import PackageLimitError, PaperRefusal
+from pptx.exc import PackageNotFoundError
 from pptx.opc import serialized
 
 from . import corpus
@@ -51,9 +52,10 @@ def test_saved_repetitive_deck_reopens(tmp_path):
     """Regression: the save -> reopen covenant must hold for this package's OWN output.
 
     Machine-generated decks (thousands of near-identical paragraphs) legitimately
-    exceed any expanded-to-compressed ratio a zip bomb would need. A ratio guard once
-    refused such files at reopen; the absolute member and package byte limits are the
-    safety envelope instead.
+    exceed any expanded-to-compressed ratio a hostile archive would need. A ratio guard once
+    refused such files at reopen. No resource ceiling gates intake now: whatever this
+    package writes, it reads. `test_package_round_trip.py` asserts that covenant at the
+    scales the deleted numeric ceilings used to refuse.
     """
     from pptx.util import Inches
 
@@ -175,33 +177,14 @@ def test_stream_save_failure_restores_existing_bytes_and_position():
     assert destination.tell() == 7
 
 
-def test_oversized_stream_save_refusal_restores_position():
-    from pptx._zipguard import MAX_COMPRESSED_BYTES
+def test_huge_non_zip_path_raises_package_not_found(tmp_path, monkeypatch):
+    """Upstream parity: size never gates intake; a non-zip path is simply not a package."""
+    target = tmp_path / "huge.bin"
+    target.write_bytes(b"not a zip")
+    monkeypatch.setattr(os.path, "getsize", lambda _path: 1 << 40)
 
-    class OversizedDestination(io.BytesIO):
-        def __init__(self, initial):
-            super().__init__(initial)
-            self._at_reported_end = False
-
-        def seek(self, offset, whence=os.SEEK_SET):
-            self._at_reported_end = whence == os.SEEK_END
-            return super().seek(offset, whence)
-
-        def tell(self):
-            if self._at_reported_end:
-                return MAX_COMPRESSED_BYTES + 1
-            return super().tell()
-
-    presentation = Presentation(_minimal_path())
-    original = b"ORIGINAL STREAM CONTENT"
-    destination = OversizedDestination(original)
-    destination.seek(7)
-
-    with pytest.raises(PackageLimitError, match="destination stream exceeds"):
-        presentation.save(destination)
-
-    assert destination.getvalue() == original
-    assert destination.tell() == 7
+    with pytest.raises(PackageNotFoundError):
+        Presentation(target)
 
 
 def test_stream_snapshot_failure_restores_position():

--- a/tests/paper/test_package_round_trip.py
+++ b/tests/paper/test_package_round_trip.py
@@ -1,0 +1,225 @@
+"""The round-trip covenant at scale: anything paper-pptx can write, it can read.
+
+`pptx._zipguard` once enforced six numeric resource ceilings on package intake, so a deck this
+library saved without complaint could be refused when reopened: 2,100 slides is 4,236 ZIP
+members, and the 4,096-member ceiling refused exactly that file. Those ceilings are gone, and
+these tests are the standing proof -- one per ceiling, at the scale that used to refuse it.
+
+The invariant is general, not a threshold: whatever `save()` writes, `Presentation()` reads.
+Every case asserts its own PRECONDITION, that the artifact really does exceed the deleted
+ceiling, because a test that quietly stops being large is worse than no test.
+
+The upstream-parity half of the change -- an oversized non-`.pptx` path raising
+`PackageNotFoundError` rather than `PackageLimitError` -- is covered by
+`test_package_io_hardening.py::test_huge_non_zip_path_raises_package_not_found` and is not
+duplicated here. The surviving structural refusals are pinned in `test_zipguard_structural.py`.
+
+Opt-in: the `big_io` cases write and read a package larger than 256 MiB and are skipped by
+default. Enable them with `PAPER_BIG_IO=1 uv run pytest tests/paper` or
+`uv run pytest tests/paper -m big_io`.
+
+Runtime of this module: about 8 s by default, about 10 s with `big_io` enabled.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+import re
+import zipfile
+
+import pytest
+from PIL import Image
+
+from pptx import Presentation, _zipguard
+from pptx.opc import serialized
+from pptx.util import Inches
+
+from . import contract
+
+_MIB = 1 << 20
+
+# -- the deleted ceilings, kept as the scale each case must exceed. Their only remaining
+# -- purpose is to be surpassed; nothing in `src/` defines them anymore.
+_OLD_MEMBER_COUNT_CEILING = 4_096
+_OLD_XML_MEMBER_CEILING = 64 * _MIB
+_OLD_BINARY_MEMBER_CEILING = 256 * _MIB
+_OLD_TOTAL_EXPANDED_CEILING = 512 * _MIB
+_OLD_COMPRESSED_CEILING = 256 * _MIB
+
+_BIG_MEMBER_COUNT_DECK = 2_100
+_IMAGE_COUNT = 6
+
+# -- ~192 KiB of highly compressible filler: lets a member expand past a ceiling without
+# -- costing the disk (deflated) or the wall clock (stored).
+_FILLER = b"<row>expansion accounting placeholder row</row>" * 4096
+
+
+def _deck(slide_count: int) -> Presentation:
+    """Return a presentation of `slide_count` blank slides, each carrying one textbox.
+
+    Two ZIP members per slide (the slide part and its rels item), so 2,100 slides clears the
+    old 4,096-member ceiling.
+    """
+    presentation = Presentation()
+    blank = presentation.slide_layouts[6]
+    for index in range(slide_count):
+        slide = presentation.slides.add_slide(blank)
+        box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+        box.text_frame.text = "slide %d" % index
+    return presentation
+
+
+def _noise_png(seed: int) -> bytes:
+    """Return a distinct, incompressible 64x64 PNG.
+
+    Distinctness is load-bearing: python-pptx hashes image bytes and collapses duplicates into
+    a single media part, so repeating one image would add no bytes and measure nothing.
+    """
+    pixels = random.Random(seed).randbytes(64 * 64 * 3)
+    buf = io.BytesIO()
+    Image.frombytes("RGB", (64, 64), pixels).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _build_zip(path, names, member_bytes: int, compress: int = zipfile.ZIP_DEFLATED) -> None:
+    """Write a ZIP at `path` holding one `member_bytes`-long member per name in `names`.
+
+    Built directly rather than through `Presentation.save()` because these sizes are only
+    reachable as raw archive shapes; the read path under test is the same either way.
+    """
+    with zipfile.ZipFile(path, "w", compress, compresslevel=1) as archive:
+        for name in names:
+            with archive.open(name, "w") as member:
+                written = 0
+                while written < member_bytes:
+                    block = _FILLER[: member_bytes - written]
+                    member.write(block)
+                    written += len(block)
+
+
+def _guarded_open(path):
+    """Open `path` through real guarded package intake; return its member names.
+
+    This is `preflight_zip` plus `GuardedZipReader` over every member -- the exact read path
+    the deleted ceilings gated -- without requiring a well-formed OPC part graph.
+    """
+    return serialized._PhysPkgReader.factory(str(path)).partnames
+
+
+# ------------------------------------------------------------------- round-trip invariant
+
+
+@pytest.mark.parametrize("slide_count", [1, 100, _BIG_MEMBER_COUNT_DECK])
+def test_saved_deck_reopens_at_any_slide_count(slide_count):
+    reopened = contract.save_reopen(_deck(slide_count))
+
+    assert len(reopened.slides) == slide_count
+
+
+def test_saved_deck_of_distinct_images_reopens():
+    presentation = Presentation()
+    blank = presentation.slide_layouts[6]
+    for seed in range(_IMAGE_COUNT):
+        slide = presentation.slides.add_slide(blank)
+        slide.shapes.add_picture(io.BytesIO(_noise_png(seed)), Inches(1), Inches(1))
+    media = sorted(
+        name
+        for name in contract.zip_member_map(contract.save_to_bytes(presentation))
+        if name.startswith("ppt/media/")
+    )
+    assert len(media) == _IMAGE_COUNT, "images collapsed; they are not distinct after all"
+
+    reopened = contract.save_reopen(presentation)
+
+    assert len(reopened.slides) == _IMAGE_COUNT
+    assert media == sorted(
+        name
+        for name in contract.zip_member_map(contract.save_to_bytes(reopened))
+        if name.startswith("ppt/media/")
+    )
+
+
+# ------------------------------------------------------------- one case per deleted ceiling
+
+
+def test_saved_deck_past_the_member_count_ceiling_reopens():
+    """The ceiling that actually shipped broken: this deck saved fine and refused to reopen.
+
+    Also the central-directory case: a 4,236-member directory is far past trivial, though it
+    stays well under the 16 MiB that ceiling named -- no cheap artifact reaches that, and the
+    same arithmetic is deleted either way.
+    """
+    blob = contract.save_to_bytes(_deck(_BIG_MEMBER_COUNT_DECK))
+    members = contract.zip_member_map(blob)
+    assert len(members) > _OLD_MEMBER_COUNT_CEILING, (
+        "fixture lost its bite; %d slides no longer exceed %d ZIP members"
+        % (_BIG_MEMBER_COUNT_DECK, _OLD_MEMBER_COUNT_CEILING)
+    )
+    with zipfile.ZipFile(io.BytesIO(blob)) as archive:
+        central_directory_bytes = len(blob) - archive.start_dir
+    assert central_directory_bytes > 128 * 1024
+
+    reopened = Presentation(io.BytesIO(blob))
+
+    assert len(reopened.slides) == _BIG_MEMBER_COUNT_DECK
+
+
+def test_package_past_the_xml_member_ceiling_opens(tmp_path):
+    """One XML part expanding past 64 MiB -- ~0.5 MiB on disk, because it is repetitive."""
+    target = tmp_path / "big-part.pptx"
+    _build_zip(target, ["ppt/slides/slide1.xml"], 68 * _MIB)
+    with zipfile.ZipFile(target) as archive:
+        (info,) = archive.infolist()
+    assert info.file_size > _OLD_XML_MEMBER_CEILING
+
+    assert len(_guarded_open(target)) == 1
+
+
+def test_package_past_the_expanded_total_ceiling_opens(tmp_path):
+    """540 MiB expanded across nine members, none individually past the per-member ceiling.
+
+    Keeping every member under 64 MiB isolates the total from the per-member ceiling: this
+    package was refused for its sum alone. Compressible XML keeps it a few MiB on disk.
+    """
+    target = tmp_path / "expanded.pptx"
+    names = ["ppt/slides/slide%d.xml" % index for index in range(9)]
+    _build_zip(target, names, 60 * _MIB)
+    with zipfile.ZipFile(target) as archive:
+        infos = archive.infolist()
+    assert max(info.file_size for info in infos) < _OLD_XML_MEMBER_CEILING
+    assert sum(info.file_size for info in infos) > _OLD_TOTAL_EXPANDED_CEILING
+
+    assert len(_guarded_open(target)) == len(names)
+
+
+@pytest.mark.big_io
+def test_package_past_the_compressed_and_binary_member_ceilings_opens(tmp_path):
+    """264 MiB of genuinely-on-disk bytes in one member: the two ceilings that cost real I/O.
+
+    Stored rather than deflated, so the archive really is that large on disk (the compressed
+    ceiling) and its single member really does expand past 256 MiB (the binary-member ceiling).
+    """
+    target = tmp_path / "huge.pptx"
+    _build_zip(target, ["ppt/media/image1.bin"], 264 * _MIB, compress=zipfile.ZIP_STORED)
+    assert target.stat().st_size > _OLD_COMPRESSED_CEILING
+    with zipfile.ZipFile(target) as archive:
+        (info,) = archive.infolist()
+    assert info.file_size > _OLD_BINARY_MEMBER_CEILING
+
+    assert len(_guarded_open(target)) == 1
+
+
+# --------------------------------------------------------------------- guard against regrowth
+
+
+def test_zipguard_exposes_no_policy_ceiling_constant():
+    """`_MAX_END_COMMENT_BYTES` is the ZIP *format*'s 16-bit comment-length field maximum.
+
+    It is a structural fact about the container, not a policy about how much a caller may
+    open, so it is the one survivor. Asserted by introspecting the imported module rather than
+    grepping its source: what matters is that no ceiling is reachable at runtime.
+    """
+    ceilings = sorted(name for name in vars(_zipguard) if re.fullmatch(r"_?MAX_\w+", name))
+
+    assert ceilings == ["_MAX_END_COMMENT_BYTES"]

--- a/tests/paper/test_zipguard_structural.py
+++ b/tests/paper/test_zipguard_structural.py
@@ -1,0 +1,294 @@
+"""Characterization of the structural ZIP refusals in `pptx._zipguard`.
+
+These pin behavior that must survive the removal of the six numeric resource ceilings.
+Every case here targets a refusal living inside a function that removal rewrites:
+`_preflight_zip_stream`, `_scan_central_directory`, `_validate_metadata`,
+`_inflate_member`, and `_parse_content_types`. The twelve *policy* raise sites (the
+ceilings themselves) are deliberately NOT pinned -- they are being deleted on purpose.
+
+Message fragments are copied verbatim from `_zipguard.py`, so these tests fail on message
+drift as well as behavior drift.
+
+Coverage map -- refusals covered elsewhere, deliberately not duplicated here:
+
+* duplicate member name -- `test_package_io_hardening.py`
+  `::test_normal_open_refuses_duplicate_members`
+* noncanonical member name -- `test_package_io_hardening.py`
+  `::test_normal_open_refuses_noncanonical_member_names`
+
+Refusals that are unreachable through `Presentation()` and therefore have no case below:
+
+* `_inflate_member` "has truncated stored data" and "has truncated compressed data" both
+  require `stream.read()` to return b"" inside a member's data region. `_validate_local_header`
+  already refuses any member whose `data_start + compress_size` runs past its boundary, and the
+  last member's boundary is `start_dir`, which `_read_all_members` refuses when it exceeds the
+  archive size. So the read position is always strictly inside the file and always yields bytes.
+* `_scan_central_directory` "ZIP central-directory member record is truncated" needs a short
+  read inside `[central_offset, central_end)`, and `central_end` is the EOCD offset, which is
+  inside the file by construction. "ends inside a member record" (pinned below) is the
+  reachable truncation refusal.
+"""
+
+from __future__ import annotations
+
+import re
+import struct
+import zipfile
+import zlib
+from pathlib import Path
+
+import pytest
+
+from pptx import Presentation, _zipguard
+from pptx.errors import PackageLimitError
+
+# -- ZIP record layouts, mirrored from `_zipguard` so a change there cannot silently
+# -- rewrite the archives these tests build.
+_LOCAL_HEADER = struct.Struct("<4s5H3L2H")
+_CENTRAL_HEADER = struct.Struct("<4s6H3L5H2L")
+_END_RECORD = struct.Struct("<4s4H2LH")
+_FLAG_UTF8 = 0x0800
+
+_BLOB = b"<paper-pptx characterization blob/>" * 8
+_CT_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
+
+
+def _deflate(blob: bytes) -> bytes:
+    compressor = zlib.compressobj(9, zlib.DEFLATED, -zlib.MAX_WBITS)
+    return compressor.compress(blob) + compressor.flush()
+
+
+def _member(name, blob=_BLOB, *, method=zipfile.ZIP_DEFLATED, data=None, **overrides):
+    """An honest local+central record pair for `blob`, with `overrides` replacing fields.
+
+    `overrides` are applied to BOTH headers, because `_validate_local_header` refuses any
+    local/central disagreement and would otherwise mask the refusal under test.
+    """
+    if data is None:
+        data = _deflate(blob) if method == zipfile.ZIP_DEFLATED else blob
+    spec = {
+        "name": name,
+        "data": data,
+        "method": method,
+        "flags": _FLAG_UTF8,
+        "crc": zlib.crc32(blob) & 0xFFFFFFFF,
+        "file_size": len(blob),
+        "compress_size": len(data),
+        "disk_start": 0,  # -- central-directory "disk number start" field
+        "offset": None,  # -- central-directory "relative offset of local header" field
+    }
+    spec.update(overrides)
+    return spec
+
+
+def _zip_bytes(
+    *members,
+    disk_number=0,
+    central_disk=0,
+    disk_entries=None,
+    total_entries=None,
+    central_size_delta=0,
+    central_gap=0,
+):
+    """Assemble a ZIP whose metadata is honest except where a keyword overrides it.
+
+    The keywords name end-of-central-directory fields; `central_gap` inserts filler bytes
+    after the last central-directory record but still inside the declared central region.
+    """
+    body = bytearray()
+    central = bytearray()
+    for spec in members:
+        offset = len(body) if spec["offset"] is None else spec["offset"]
+        raw_name = spec["name"].encode("utf-8")
+        shared = (
+            spec["flags"],
+            spec["method"],
+            0,  # -- mod time
+            0,  # -- mod date
+            spec["crc"],
+            spec["compress_size"],
+            spec["file_size"],
+        )
+        body += _LOCAL_HEADER.pack(b"PK\x03\x04", 20, *shared, len(raw_name), 0)
+        body += raw_name + spec["data"]
+        central += _CENTRAL_HEADER.pack(
+            b"PK\x01\x02",
+            20,  # -- version made by
+            20,  # -- version needed
+            *shared,
+            len(raw_name),
+            0,  # -- extra length
+            0,  # -- comment length
+            spec["disk_start"],
+            0,  # -- internal attributes
+            0,  # -- external attributes
+            offset,
+        )
+        central += raw_name
+    central += b"\x00" * central_gap
+
+    central_offset = len(body)
+    body += central
+    body += _END_RECORD.pack(
+        b"PK\x05\x06",
+        disk_number,
+        central_disk,
+        len(members) if disk_entries is None else disk_entries,
+        len(members) if total_entries is None else total_entries,
+        len(central) + central_size_delta,
+        central_offset,
+        0,  # -- comment length
+    )
+    return bytes(body)
+
+
+def _content_types(inner: bytes = b"", prologue: bytes = b"") -> bytes:
+    return b'%s<Types xmlns="%s">%s</Types>' % (prologue, _CT_NS.encode(), inner)
+
+
+_OVERRIDE = b'<Override PartName="/a.xml" ContentType="application/xml"/>'
+
+_CASES = [
+    # -- `_inflate_member` (the highest-risk function) ---------------------------------
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml", crc=0xDEADBEEF)),
+        "fails its CRC check",
+        id="inflate-crc-mismatch",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml", file_size=len(_BLOB) + 1)),
+        "does not match declared size",
+        id="inflate-expanded-size-mismatch",
+    ),
+    pytest.param(
+        # -- deflate stream cut short of its end-of-stream marker
+        lambda: _zip_bytes(_member("a.xml", data=_deflate(_BLOB)[:-2])),
+        "compressed data ends before deflate EOF",
+        id="inflate-deflate-truncated",
+    ),
+    pytest.param(
+        # -- complete deflate stream followed by bytes the decompressor never consumes
+        lambda: _zip_bytes(_member("a.xml", data=_deflate(_BLOB) + b"\x00\x00")),
+        "has trailing compressed data",
+        id="inflate-trailing-compressed-data",
+    ),
+    # -- `_validate_metadata` ----------------------------------------------------------
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), _member("A.xml")),
+        "case-ambiguous member name",
+        id="metadata-case-ambiguous-name",
+    ),
+    pytest.param(
+        # -- ZipInfo truncates its `filename` at the NUL while `orig_filename` keeps it
+        lambda: _zip_bytes(_member("a.xml\x00stowaway")),
+        "contains a noncanonical NUL suffix",
+        id="metadata-nul-suffix-name",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml", flags=_FLAG_UTF8 | 0x0001)),
+        "is encrypted",
+        id="metadata-encrypted-member",
+    ),
+    pytest.param(
+        # -- method 12 is bzip2: a real ZIP method the OPC ZIP mapping does not permit
+        lambda: _zip_bytes(_member("a.xml", method=12)),
+        "uses unsupported compression method",
+        id="metadata-unsupported-compression",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), _member("b.xml", offset=0)),
+        "has an invalid or shared local-header offset",
+        id="metadata-shared-header-offset",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml", method=zipfile.ZIP_STORED, file_size=len(_BLOB) + 1)),
+        "has inconsistent size metadata",
+        id="metadata-stored-size-disagreement",
+    ),
+    # -- `_preflight_zip_stream` -------------------------------------------------------
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), disk_number=1),
+        "multi-disk ZIP packages are not supported",
+        id="preflight-multi-disk-end-record",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), disk_entries=2),
+        "ZIP central-directory counts disagree across disks",
+        id="preflight-entry-counts-disagree",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), central_size_delta=1),
+        "do not identify one unambiguous region",
+        id="preflight-central-region-ambiguous",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), disk_entries=0, total_entries=0),
+        "empty ZIP package has a non-empty central directory",
+        id="preflight-empty-with-central-directory",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), disk_entries=3, total_entries=3),
+        "ZIP central directory is too small for its member count",
+        id="preflight-central-directory-too-small",
+    ),
+    # -- `_scan_central_directory` -----------------------------------------------------
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml"), central_gap=10),
+        "ZIP central directory ends inside a member record",
+        id="scan-region-ends-inside-record",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(_member("a.xml", disk_start=1)),
+        "multi-disk ZIP member records are not supported",
+        id="scan-member-record-nonzero-disk",
+    ),
+    # -- `_parse_content_types`, reached only through the `_read_all_members` call site --
+    pytest.param(
+        lambda: _zip_bytes(_member("[Content_Types].xml", _content_types(_OVERRIDE + _OVERRIDE))),
+        "[Content_Types].xml contains an ambiguous Override declaration",
+        id="content-types-duplicate-override",
+    ),
+    pytest.param(
+        lambda: _zip_bytes(
+            _member("[Content_Types].xml", _content_types(prologue=b"<!DOCTYPE Types>"))
+        ),
+        "[Content_Types].xml contains a prohibited DTD",
+        id="content-types-prohibited-dtd",
+    ),
+]
+
+
+def test_the_unmutated_archive_builder_output_is_accepted(tmp_path):
+    """Guard the guard: each refusal above must come from its mutation, not from `_zip_bytes`."""
+    target = tmp_path / "honest.pptx"
+    target.write_bytes(
+        _zip_bytes(_member("[Content_Types].xml", _content_types()), _member("a.xml"))
+    )
+
+    _zipguard.preflight_zip(str(target))
+    with zipfile.ZipFile(target) as archive:
+        reader = _zipguard.GuardedZipReader(archive)
+
+    assert reader.order == ("[Content_Types].xml", "a.xml")
+    assert reader.read("a.xml") == _BLOB
+
+
+@pytest.mark.parametrize(("build", "fragment"), _CASES)
+def test_normal_open_refuses_structurally_ambiguous_archive(tmp_path, build, fragment):
+    target = tmp_path / "adversarial.pptx"
+    target.write_bytes(build())
+
+    with pytest.raises(PackageLimitError, match=re.escape(fragment)):
+        Presentation(target)
+
+
+def test_zipguard_structural_refusal_population_is_pinned():
+    """`_zipguard.py` has 82 `raise PackageLimitError` sites, every one structural.
+
+    The twelve policy sites that enforced the six numeric resource ceilings are gone. Any
+    movement from 82 means a structural or ambiguity refusal was added or dropped, so a
+    mismatch here is a prompt to check which.
+    """
+    source = Path(_zipguard.__file__).read_text(encoding="utf-8")
+
+    assert source.count("raise PackageLimitError") == 82


### PR DESCRIPTION
### Stack

Merge bottom-up. Each PR targets the one beneath it, so its diff shows only its own change.

```
main
└─ #10  docs: readme and cleanup
   └─ #15  remove the ZIP resource ceilings   ◀ this PR
      └─ #14  remove Presentation.scrub()
         └─ #16  resolve inherited bullets
            └─ #17  expose Presentation.batch()
```

As each PR merges, retarget the one above it to the merged PR's base (`gh pr edit <n> --base <branch>`) and rebase.

---

## Summary

- Deletes the six numeric ZIP resource ceilings in `src/pptx/_zipguard.py` (`MAX_COMPRESSED_BYTES`, `MAX_MEMBER_COUNT`, `MAX_CENTRAL_DIRECTORY_BYTES`, `MAX_XML_MEMBER_BYTES`, `MAX_BINARY_MEMBER_BYTES`, `MAX_TOTAL_EXPANDED_BYTES`), their twelve enforcement sites, and the four consumer call sites in `opc/serialized.py`, `opc/package.py`, and `diff.py`. These were fork additions upstream python-pptx does not have, and they converted working operations into refusals: paper-pptx would save a 2,100-slide deck (4,236 ZIP members, 0.4 MiB) and then refuse to reopen it.
- **Keeps all 82 structural and ambiguity refusals** — duplicate and case-ambiguous member names, encryption, CRC mismatch, deflate end-of-stream, ambiguous EOCD records, `[Content_Types].xml` refusals, and the rest. `_zipguard.py` goes 909 → 750 lines; every surviving refusal keeps its exact trigger and message text.
- Adds the round-trip coverage whose absence let this ship: upstream's fixtures are tiny decks, so no test ever opened a file large enough to trip a ceiling.

## Plan

`reference/paper-pptx-audit/shipped/delete-zip-resource-ceilings/` — spec, build sequence, and five phase plans. The investigation is at `reference/paper-pptx-audit/shipped/delete-zip-resource-ceilings.md`. (The `reference/` tree is gitignored, so these are local-only.)

## Upstream compatibility

Verified against fork base `278b47b1`:

- `_zipguard.py`, `errors.py`, and `diff.py` are fork-only files. `opc/serialized.py` and `opc/package.py` are the only touched files that exist upstream, and **no upstream function signature changes** — `_PhysPkgReader.factory`, `_ZipPkgReader._blobs`, and `OpcPackage.save` keep their exact upstream signatures; only statements inside bodies were removed.
- One intended behavior change, which *restores* upstream: an oversized non-`.pptx` path now raises `PackageNotFoundError` instead of `PackageLimitError`, because the size check no longer preempts `zipfile.is_zipfile`.
- Fork additions unrelated to the ceilings are untouched: `os.PathLike` support, both `partnames` properties, atomic save, and the `_PackageLoader` relationship checks.

## Test plan

**Added** `tests/paper/test_zipguard_structural.py` (21 tests) — characterization coverage pinning the structural refusals inside every function this change rewrites, written *before* the removal. Verified it bites: commenting out the CRC check, the deflate-EOF check, the case-ambiguous-name check, or the prohibited-DTD check each produces exactly one targeted failure.

**Added** `tests/paper/test_package_round_trip.py` (9 tests) — the round-trip covenant at 1 / 100 / 2,100 slides and a distinct-media deck via `contract.save_reopen`, plus one case per deleted ceiling with its precondition asserted. Verified each artifact is refused by the pre-change source for its own reason, e.g. `ZIP member count 4236 exceeds the 4096-member limit`.

**Removed** `test_oversized_stream_save_refusal_restores_position`, which asserted the deleted check. Replaced with a cheap upstream-parity guard.

Verification run:

- `uv run pytest tests/paper -q` — 879 passed, 1 skipped
- `PAPER_BIG_IO=1 uv run pytest tests/paper -q` — 880 passed
- `uv run pytest tests/ --ignore=tests/paper -q -W ignore` — 2700 upstream tests passed
- `uv run --group docs make -C docs html` — clean, zero warnings
- Diffed every `PackageLimitError` message string before/after: all 19 removed fragments are ceiling messages, **zero** surviving refusals reworded

The `big_io` cases write and read a package over 256 MiB and are skipped by default; enable with `PAPER_BIG_IO=1` or `-m big_io`. The marker is registered in `tests/paper/conftest.py` rather than `pyproject.toml`, so upstream config stays untouched.

## Notes for review

- `MAX_CENTRAL_DIRECTORY_BYTES` is the one ceiling no test surpasses — a 16 MiB central directory needs ~180,000 members. The 2,100-slide case asserts a >128 KiB directory instead, and says so in its docstring rather than implying coverage it lacks.
- Two pre-existing lint findings in untouched code were left alone deliberately: `ruff format` wants to reflow two lines in `_zipguard.py` (one inside a surviving refusal), and `SIM401` flags `serialized.py:48`, which is verbatim upstream code. Fixing either would add divergence from upstream.
- Out of scope, per the spec: the `PAPER.md` deviation ledger, `OpcPackage.save`'s seekable-stream requirement, and the `_PackageLoader._xml_rels` unreachable-parts rejection.

## Checklist

- [x] Tests pass (`uv run pytest tests/paper -q` and `uv run pytest tests/ --ignore=tests/paper -q -W ignore`)
- [x] Lint clean on every touched file (`uv run ruff check`)
- [x] Docs build clean (`uv run --group docs make -C docs html`)
- [x] Docs updated — README guarded-intake bullet, `PackageLimitError` docstring (autodoc'd into the API reference), and `diff.py` docstring no longer claim a resource limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Package intake no longer caps memory/disk from hostile or huge archives; structural ZIP validation remains but opening untrusted `.pptx` files carries higher resource-exposure than before.
> 
> **Overview**
> **Removes fork-only numeric ZIP limits** from `pptx._zipguard` — compressed package size, member count, central-directory size, per-member XML/binary caps, and total expanded bytes — plus `enforce_compressed_size`, `read_compressed_bytes`, and all call sites in `opc/serialized.py`, `opc/package.py`, and `diff.py`. **`PackageLimitError` now means ambiguous/unsafe structure only** (duplicate names, CRC/deflate checks, EOCD ambiguity, etc.); docs and the README guarded-intake bullet no longer describe size-based refusal.
> 
> **Behavior change:** whatever this library writes should open again — including large member counts and expanded sizes that previously failed at reopen. **Upstream parity:** paths that are not ZIP files raise `PackageNotFoundError` again instead of being rejected on size before `zipfile.is_zipfile`.
> 
> **Tests:** adds `test_package_round_trip.py` (one case per removed ceiling, opt-in `big_io` for >256 MiB I/O), `test_zipguard_structural.py` (pins 82 structural refusals), drops stream-save size refusal test, registers `big_io` skip in `conftest.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12e5b68d587a41f882b09dd018a50c3c6b0071d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes fork-only ZIP resource ceilings that rejected valid decks on reopen. Old behavior: intake refused packages over compressed-size, member-count, central-directory, per-member, or total-expanded limits; new behavior: those numeric ceilings are gone while all structural and ambiguity guards remain. Side effects: oversized non-`.pptx` paths now raise `PackageNotFoundError` (not `PackageLimitError`); `diff_decks` stream reads and save-to-stream no longer enforce a compressed-size ceiling.

- **Review notes**
  - `pptx._zipguard`: delete six ceiling constants and all enforcement; keep all structural/ambiguity refusals (CRC, deflate EOF, duplicate/case-ambiguous names, EOCD/offset mismatches, encryption, unsupported methods, `[Content_Types].xml` checks). Remove member/total-size accounting and related chunk limiting; keep content-types parsing validation.
  - Call sites: drop size gates in `opc/serialized.py` (`factory`, `_ZipPkgReader._blobs`), `opc/package.py` (destination stream size check), and `diff.py` (bounded read).
  - Errors/docs: narrow `PackageLimitError` docstring to “ambiguous or unsafe”; README no longer claims “resource-exhaustion bombs.”
  - Tests: add structural characterization (`tests/paper/test_zipguard_structural.py`) and large round-trip coverage (`tests/paper/test_package_round_trip.py`); update hardening tests to assert `PackageNotFoundError` for huge non-zip paths; add `big_io` marker to optionally run >256 MiB cases.

<sup>Written for commit c12e5b68d587a41f882b09dd018a50c3c6b0071d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

