### PR TITLE
feat(inspect): resolve inherited bullets through the paragraph chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ for step in font.size.provenance:
         print("supplied by", step.level)   # e.g. "master txStyles titleStyle lvl1"
 ```
 
+`effective_paragraph_format()` resolves the paragraph's bullet the same way:
+which bullet actually renders, walked through the same chain, reported with
+the same provenance. On a branded template that is the common case — the
+master supplies the `•` and the paragraph's own markup says nothing. Two
+answers that look like absences are resolved answers: an explicit `a:buNone`
+at any rung is the positive statement "no bullet renders here", not a miss,
+and a chain carrying no bullet at any rung also resolves to no bullet rather
+than reporting unresolved. This is the read half of **Real bullets, not glyph
+hacks** below — that API writes genuine bullet markup onto a paragraph, this
+one reports the bullet the deck renders whether or not the paragraph sets
+one.
+
 **Visibility-complete text inspection.** Iterating top-level shapes misses text
 inside nested groups and table cells, and `shape.text` flattens slide-number
 fields and line breaks into plain characters. `pptx.inspect.inspect_text()`
@@ -489,6 +501,16 @@ path of this package. Known gaps, honestly:
 - **Deck diff assumes lineage.** `diff_decks` matches slides by permanent ID,
   which serves decks derived from a common ancestor (v4 saved from v3);
   matching independently-authored decks is out of scope today.
+- **Bullet typeface and size are not resolved.**
+  `effective_paragraph_format()` reports which bullet renders, but not the
+  typeface it renders in or the size it renders at: `a:buFont` and `a:buSzPct`
+  sit outside the bullet choice group and inherit on their own chains, so each
+  needs its own walk. Strictly additive when it lands.
+- **The deck diff does not report bullets.** `diff_decks` compares text and
+  field markers, not paragraph formatting, so a list changing from bulleted to
+  numbered — or a template losing its bullets across a rebind or compose —
+  produces no diff entry. That would be a new diff dimension rather than a new
+  field on an existing one.
 
 Deliberate non-goals: no rendering or layout-geometry computation (appearance
 verification belongs to a harness, not this library), no SmartArt authoring

--- a/docs/api/inspect.rst
+++ b/docs/api/inspect.rst
@@ -44,6 +44,11 @@ Resolved values and provenance
    :undoc-members:
    :member-order: bysource
 
+.. autoclass:: EffectiveBullet()
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
 .. autoclass:: EffectiveParagraphFormat()
    :members:
    :undoc-members:

--- a/docs/api/text.rst
+++ b/docs/api/text.rst
@@ -52,7 +52,10 @@ future other presentation text objects.
 *paper-pptx addition.* Read and set real bullet/numbering on a paragraph, accessed through the
 :attr:`._Paragraph.bullet` property. Retires the fake-glyph anti-pattern (a literal "•" typed
 into the text): these write genuine ``a:buChar`` / ``a:buAutoNum`` / ``a:buNone`` markup with
-hanging-indent control.
+hanging-indent control. This object reads and writes the paragraph's own markup; to see which
+bullet actually renders once the layout and master chain is taken into account, use the
+effective-style inspection API in :ref:`inspect_api` —
+:func:`~pptx.inspect.effective_paragraph_format` reports it as an |EffectiveBullet|.
 
 .. autoclass:: pptx.text.bullet.BulletFormat()
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -392,6 +392,8 @@ rst_epilog = """
 
 .. |EffectiveValue| replace:: :class:`.EffectiveValue`
 
+.. |EffectiveBullet| replace:: :class:`.EffectiveBullet`
+
 .. |EffectiveParagraphFormat| replace:: :class:`.EffectiveParagraphFormat`
 
 .. |EffectiveShapeFormat| replace:: :class:`.EffectiveShapeFormat`

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -71,6 +71,20 @@ its provenance intact. See :ref:`inspect_api` for
 :func:`~pptx.inspect.effective_paragraph_format` and
 :func:`~pptx.inspect.effective_shape_format` as well.
 
+:func:`~pptx.inspect.effective_paragraph_format` resolves alignment, line spacing, and the
+paragraph's **bullet** over that same inheritance walk, each reported with its own provenance. The
+bullet arrives as an :class:`~pptx.inspect.EffectiveBullet` naming which of the four kinds actually
+renders — ``"none"``, ``"character"``, ``"numbered"``, or ``"picture"`` — plus the glyph for a
+character bullet, or the numbering scheme and starting number for a numbered one. Two answers
+that read like absences are in fact resolved: a template that explicitly sets *no bullet* resolves
+to ``"none"``, attributed to the rung that set it, and a chain with no bullet anywhere also resolves
+to ``"none"``, through a closing ``rendering default`` provenance step. A paragraph inheriting the
+master's ``•`` is therefore distinguishable from one that renders nothing. The enclosing
+``.to_dict()`` payload is version 2 of ``paper-effective-paragraph-format``. ``"picture"`` is
+reported on read only; there is no picture-bullet writer. Writing bullets is a separate job, done
+with the |BulletFormat| authoring API described under **Edit one deck** below, which reads and
+writes the paragraph's own markup.
+
 Two functions emit deterministic, schema-versioned payloads (dataclasses with ``.to_dict()``)
 built for diffing, golden-file tests, and automation:
 

--- a/src/pptx/inspect.py
+++ b/src/pptx/inspect.py
@@ -143,6 +143,28 @@ class EffectiveFont:
 
 
 @dataclass(frozen=True)
+class EffectiveBullet:
+    """The bullet that actually renders on one paragraph, with its provenance chain."""
+
+    type: Optional[str]  #: "none", "character", "numbered", "picture"; |None| if unresolved
+    char: Optional[str]  #: the glyph, character bullets only
+    number_scheme: Optional[str]  #: ECMA autonumber token, e.g. "arabicPeriod"; numbered only
+    start_at: Optional[int]  #: first number of the sequence, numbered only
+    resolved: bool
+    provenance: Tuple[ProvenanceStep, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "type": self.type,
+            "char": self.char,
+            "number_scheme": self.number_scheme,
+            "start_at": self.start_at,
+            "resolved": self.resolved,
+            "provenance": [step.to_dict() for step in self.provenance],
+        }
+
+
+@dataclass(frozen=True)
 class BlockAnchor:
     """The pinned anchor shape: part + block index + content hash (detects staleness).
 
@@ -266,28 +288,31 @@ def effective_font(run: "_Run") -> EffectiveFont:
 
 @dataclass(frozen=True)
 class EffectiveParagraphFormat:
-    """Effective alignment and line spacing of one paragraph (paper-pptx addition)."""
+    """Effective alignment, line spacing, and bullet of one paragraph (paper-pptx addition)."""
 
     alignment: EffectiveValue  #: ECMA algn token, e.g. "l", "ctr", "r", "just"
     line_spacing: EffectiveValue  #: float lines (1.0 = single) or EMU |Length| for points
+    bullet: EffectiveBullet  #: the bullet that renders, resolved through the same chain
 
     def to_dict(self) -> dict:
         return {
             "schema": "paper-effective-paragraph-format",
-            "version": 1,
+            "version": 2,  # -- bullet added
             "alignment": self.alignment.to_dict(),
             "line_spacing": self.line_spacing.to_dict(),
+            "bullet": self.bullet.to_dict(),
         }
 
 
 def effective_paragraph_format(paragraph) -> EffectiveParagraphFormat:
-    """Return effective alignment/line-spacing for `paragraph`, with provenance.
+    """Return effective alignment/line-spacing/bullet for `paragraph`, with provenance.
 
     Same inheritance walk as `effective_font`, over paragraph-level properties: the
     paragraph's own `a:pPr`, the shape's `lstStyle` level entry, the placeholder chain (or
-    the presentation's `defaultTextStyle`), ending at the schema defaults (left-aligned,
-    single spacing) — which are explicit in ECMA-376, so exhaustion resolves rather than
-    reporting unresolved.
+    the presentation's `defaultTextStyle`). Exhaustion resolves rather than reporting
+    unresolved: to the ECMA-376 schema default for alignment (left), and to the rendering
+    conventions for line spacing (single) and bullet (no bullet), which the schema does not
+    define.
     """
     p = paragraph._p
     txBody = p.getparent()
@@ -315,6 +340,7 @@ def effective_paragraph_format(paragraph) -> EffectiveParagraphFormat:
     return EffectiveParagraphFormat(
         alignment=resolver.resolve_alignment(chain),
         line_spacing=resolver.resolve_line_spacing(chain),
+        bullet=resolver.resolve_bullet(chain),
     )
 
 
@@ -991,6 +1017,60 @@ class _FontResolver(object):
             ProvenanceStep("rendering default", None, "line spacing defaults to 100%", True)
         )
         return EffectiveValue(1.0, None, True, tuple(steps))
+
+    def resolve_bullet(self, chain) -> EffectiveBullet:
+        """Resolve the `EG_TextBullet` choice over a paragraph chain.
+
+        The first rung supplying any member wins outright — `a:buNone` is a positive answer
+        ("explicitly no bullet"), not an absence. There is no ECMA default bullet, so
+        exhaustion resolves to "none" through a rendering-default step. Attributes are read
+        raw: the generated descriptors are `RequiredAttribute` and would raise on exactly the
+        malformed input this reports honestly.
+        """
+        steps = []
+
+        def malformed(detail):
+            """Report a present-but-unusable member and stop, per `resolve_line_spacing`."""
+            steps.append(ProvenanceStep(label, partname, detail, False))
+            return EffectiveBullet(None, None, None, None, False, tuple(steps))
+
+        def supplied(detail, type_, char=None, scheme=None, start_at=None):
+            steps.append(ProvenanceStep(label, partname, detail, True))
+            return EffectiveBullet(type_, char, scheme, start_at, True, tuple(steps))
+
+        for label, partname, pPr in chain:
+            bullet = pPr.eg_bullet if pPr is not None else None
+            if bullet is None and pPr is not None:
+                bullet = pPr.find(qn("a:buBlip"))
+            if bullet is None:
+                steps.append(
+                    ProvenanceStep(label, partname, self._absence(pPr, "no bullet"), False)
+                )
+                continue
+            if bullet.tag == qn("a:buNone"):
+                return supplied("buNone", "none")
+            if bullet.tag == qn("a:buChar"):
+                char = bullet.get("char")
+                if char is None:
+                    return malformed("buChar with no char")
+                return supplied('buChar char="%s"' % char, "character", char=char)
+            if bullet.tag == qn("a:buAutoNum"):
+                scheme = bullet.get("type")
+                if scheme is None:
+                    return malformed("buAutoNum with no type")
+                raw_start = bullet.get("startAt")
+                try:
+                    start_at = 1 if raw_start is None else int(raw_start)
+                except ValueError:
+                    return malformed('buAutoNum with non-integer startAt="%s"' % raw_start)
+                return supplied(
+                    'buAutoNum type="%s"' % scheme, "numbered", scheme=scheme, start_at=start_at
+                )
+            return supplied("buBlip", "picture")
+        steps.append(
+            ProvenanceStep("rendering default", None, "no bullet renders by default", True)
+        )
+        return EffectiveBullet("none", None, None, None, True, tuple(steps))
 
     def resolve_container_fill(
         self, container, label, partname, style_ref, ref_label

--- a/tests/paper/test_effective_inspect.py
+++ b/tests/paper/test_effective_inspect.py
@@ -17,7 +17,7 @@ from pptx import Presentation
 from pptx.dml.color import RGBColor
 from pptx.enum.shapes import MSO_SHAPE
 from pptx.errors import UnsupportedStructureError
-from pptx.inspect import content_hash, effective_font, inspect_text
+from pptx.inspect import content_hash, effective_font, effective_paragraph_format, inspect_text
 from pptx.util import Emu
 
 from . import corpus
@@ -536,7 +536,6 @@ def test_bold_italic_underline_resolve_with_schema_defaults():
 
 def test_effective_paragraph_format_resolves_alignment_and_spacing():
     from pptx.enum.text import PP_ALIGN
-    from pptx.inspect import effective_paragraph_format
 
     prs = _open(BRANDED)
     paragraph = prs.slides[0].placeholders[1].text_frame.paragraphs[0]
@@ -555,7 +554,265 @@ def test_effective_paragraph_format_resolves_alignment_and_spacing():
 
     payload = fmt.to_dict()
     assert payload["schema"] == "paper-effective-paragraph-format"
-    assert payload["version"] == 1
+    assert payload["version"] == 2  # -- v2 added the `bullet` field
+
+
+# ----------------------------------------------------------- inherited bullet resolution
+
+
+def _bullet(paragraph):
+    return effective_paragraph_format(paragraph).bullet
+
+
+def _graft_lst_style_bullet(shape, lvl_tag, bullet_tag, **attrs):
+    """Add `a:lstStyle/<lvl_tag>/<bullet_tag>` to `shape`'s `a:txBody`, in memory only.
+
+    `get_or_add_lstStyle` places `a:lstStyle` at its schema position in `CT_TextBody`
+    (after `a:bodyPr`, before the first `a:p`); appending it would invalidate the fragment.
+    """
+    lst_style = shape.text_frame._txBody.get_or_add_lstStyle()
+    level_properties = etree.SubElement(lst_style, "{%s}%s" % (_A, lvl_tag))
+    bullet = etree.SubElement(level_properties, "{%s}%s" % (_A, bullet_tag))
+    for name, value in attrs.items():
+        bullet.set(name, value)
+    return bullet
+
+
+def _plain_textbox(prs):
+    """A non-placeholder shape: its chain takes the `presentation defaultTextStyle` branch."""
+    box = prs.slides[0].shapes.add_textbox(0, 0, Emu(914400 * 4), Emu(914400))
+    box.text_frame.paragraphs[0].add_run().text = "no bullet anywhere"
+    return box
+
+
+def test_bullet_resolves_the_inherited_character_bullet_from_the_master():
+    """The regression this feature exists for: `BulletFormat.type` reads |None| here."""
+    paragraph = _open(BRANDED).slides[0].placeholders[1].text_frame.paragraphs[0]
+    assert paragraph.bullet.type is None  # -- local state says nothing
+
+    bullet = _bullet(paragraph)
+
+    assert bullet.type == "character"
+    assert bullet.char == "•"
+    assert bullet.resolved is True
+    assert bullet.number_scheme is None
+    assert bullet.start_at is None
+    assert _supplied_levels(bullet) == ["master txStyles bodyStyle lvl1"]
+
+
+def test_bullet_resolves_per_indent_level_not_always_level_one():
+    """The lvl=1 paragraph must pick up bodyStyle lvl2's en dash, not lvl1's bullet."""
+    paragraph = _open(BRANDED).slides[0].placeholders[1].text_frame.paragraphs[1]
+
+    bullet = _bullet(paragraph)
+
+    assert bullet.type == "character"
+    assert bullet.char == "–"
+    assert _supplied_levels(bullet) == ["master txStyles bodyStyle lvl2"]
+
+
+def test_bullet_reports_master_bunone_as_a_positive_terminal():
+    """`buNone` is an answer, not an absence: the master supplies it, not the fallback."""
+    paragraph = _open(BRANDED).slides[0].shapes.title.text_frame.paragraphs[0]
+
+    bullet = _bullet(paragraph)
+
+    assert bullet.type == "none"
+    assert bullet.resolved is True
+    assert bullet.char is None
+    # -- a resolver that walked past the buNone would also say "none", but would land on the
+    # -- synthetic "rendering default" step instead; only the supplying rung tells them apart
+    assert _supplied_levels(bullet) == ["master txStyles titleStyle lvl1"]
+
+
+def test_bullet_resolves_a_local_numbered_override_at_the_first_rung():
+    paragraph = _open(BRANDED).slides[0].placeholders[1].text_frame.paragraphs[0]
+    paragraph.bullet.set_numbered("arabicPeriod", start_at=3)
+
+    bullet = _bullet(paragraph)
+
+    assert bullet.type == "numbered"
+    assert bullet.number_scheme == "arabicPeriod"
+    assert bullet.start_at == 3
+    assert bullet.char is None
+    assert _supplied_levels(bullet) == ["paragraph pPr"]
+
+
+def test_bullet_resolves_to_none_when_the_whole_chain_is_exhausted():
+    """Exhaustion resolves — there is no ECMA default bullet, so provenance says so."""
+    prs = _open(BRANDED)
+    paragraph = _plain_textbox(prs).text_frame.paragraphs[0]
+
+    bullet = _bullet(paragraph)
+
+    assert bullet.type == "none"
+    assert bullet.resolved is True
+    assert _supplied_levels(bullet) == ["rendering default"]
+    assert bullet.provenance[-1].part is None
+    assert bullet.provenance[-1].supplied is True
+
+
+def test_bullet_shape_lst_style_bunone_shadows_the_master_buchar():
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    _graft_lst_style_bullet(body, "lvl1pPr", "buNone")
+
+    bullet = _bullet(body.text_frame.paragraphs[0])
+
+    assert bullet.type == "none"
+    assert bullet.resolved is True
+    assert _supplied_levels(bullet) == ["shape lstStyle lvl1"]
+
+
+def test_bullet_sees_an_inherited_bublip_outside_the_choice_group():
+    """`a:buBlip` is not an `eg_bullet` member; reading only the descriptor would walk past."""
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    buBlip = _graft_lst_style_bullet(body, "lvl2pPr", "buBlip")
+    etree.SubElement(buBlip, "{%s}blip" % _A)
+
+    bullet = _bullet(body.text_frame.paragraphs[1])  # -- the lvl=1 paragraph
+
+    assert bullet.type == "picture"
+    assert bullet.resolved is True
+    assert bullet.char is None
+    assert bullet.number_scheme is None
+    assert bullet.start_at is None
+    assert _supplied_levels(bullet) == ["shape lstStyle lvl2"]
+
+
+@pytest.mark.parametrize(
+    ("bullet_tag", "attrs"),
+    [
+        ("buChar", {}),  # -- schema-required @char missing
+        ("buAutoNum", {}),  # -- schema-required @type missing
+        ("buAutoNum", {"type": "arabicPeriod", "startAt": "many"}),  # -- @startAt not an int
+    ],
+)
+def test_bullet_reports_a_malformed_member_as_unresolved(bullet_tag, attrs):
+    """Honest over plausible: no guessed value, and no walking on to the master's bullet.
+
+    Reading these through the generated `RequiredAttribute` descriptors would raise
+    `InvalidXmlError` instead, turning the honesty rule into a crash on malformed input.
+    """
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    _graft_lst_style_bullet(body, "lvl1pPr", bullet_tag, **attrs)
+
+    bullet = _bullet(body.text_frame.paragraphs[0])
+
+    assert bullet.resolved is False
+    assert bullet.type is None
+    assert (bullet.char, bullet.number_scheme, bullet.start_at) == (None, None, None)
+    assert _supplied_levels(bullet) == []
+    # -- provenance is intact up to and including the offending rung ...
+    offender = bullet.provenance[-1]
+    assert offender.supplied is False
+    assert bullet_tag in offender.detail
+    # -- ... and the walk stopped there rather than reporting the master's bullet
+    assert [step.level for step in bullet.provenance] == ["paragraph pPr", "shape lstStyle lvl1"]
+
+
+def test_bullet_resolves_an_inherited_numbered_bullet_and_defaults_start_at_to_one():
+    """`@startAt` is optional on `a:buAutoNum`; absent means the sequence starts at 1."""
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    _graft_lst_style_bullet(body, "lvl1pPr", "buAutoNum", type="romanUcParenR")
+
+    bullet = _bullet(body.text_frame.paragraphs[0])
+
+    assert bullet.type == "numbered"
+    assert bullet.number_scheme == "romanUcParenR"
+    assert bullet.start_at == 1
+    assert bullet.char is None
+    assert _supplied_levels(bullet) == ["shape lstStyle lvl1"]
+
+
+def test_bullet_provenance_lists_every_consulted_rung_in_walk_order():
+    prs = _open(BRANDED)
+    placeholder_bullet = _bullet(prs.slides[0].placeholders[1].text_frame.paragraphs[1])
+    assert [step.level for step in placeholder_bullet.provenance] == [
+        "paragraph pPr",
+        "shape lstStyle lvl2",
+        "layout placeholder lstStyle lvl2",
+        "master placeholder lstStyle lvl2",
+        "master txStyles bodyStyle lvl2",
+    ]
+    assert _supplied_levels(placeholder_bullet) == ["master txStyles bodyStyle lvl2"]
+    # -- a silent rung says which silence it is: rung absent, or rung present with no bullet
+    assert [step.detail for step in placeholder_bullet.provenance[:-1]] == [
+        "no bullet here",  # -- this paragraph does have an a:pPr; it carries only lvl="1"
+        "level not present",
+        "level not present",
+        "level not present",
+    ]
+
+    textbox_bullet = _bullet(_plain_textbox(prs).text_frame.paragraphs[0])
+    assert [step.level for step in textbox_bullet.provenance] == [
+        "paragraph pPr",
+        "shape lstStyle lvl1",
+        "presentation defaultTextStyle lvl1",
+        "rendering default",
+    ]
+    assert _supplied_levels(textbox_bullet) == ["rendering default"]
+
+
+def test_bullet_resolution_never_mutates_the_package():
+    """A `get_or_add_*` read would materialize an empty `a:pPr` and change the saved bytes."""
+    prs = _open(BRANDED)
+    paragraphs = [
+        paragraph
+        for shape in prs.slides[0].shapes  # -- title (buNone path) and body (buChar path)
+        if shape.has_text_frame
+        for paragraph in shape.text_frame.paragraphs
+    ]
+    before = snapshot_parts(prs)
+
+    resolved = [_bullet(paragraph) for paragraph in paragraphs]
+
+    assert [bullet.type for bullet in resolved] == ["none", "character", "character"]
+    assert snapshot_parts(prs) == before
+
+
+def test_bullet_payload_serializes_in_the_documented_shape():
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+
+    payload = effective_paragraph_format(body.text_frame.paragraphs[0]).to_dict()
+    assert payload["schema"] == "paper-effective-paragraph-format"
+    assert payload["version"] == 2
+    bullet = payload["bullet"]
+    assert sorted(bullet) == ["char", "number_scheme", "provenance", "resolved", "start_at", "type"]
+    assert bullet["type"] == "character"
+    assert bullet["char"] == "•"
+    assert bullet["number_scheme"] is None
+    assert bullet["start_at"] is None
+    assert bullet["resolved"] is True
+    assert bullet["provenance"][-1] == {
+        "level": "master txStyles bodyStyle lvl1",
+        "part": "/ppt/slideMasters/slideMaster1.xml",
+        "detail": 'buChar char="•"',
+        "supplied": True,
+    }
+
+    body.text_frame.paragraphs[0].bullet.set_numbered("arabicPeriod", start_at=3)
+    numbered = effective_paragraph_format(body.text_frame.paragraphs[0]).to_dict()["bullet"]
+    assert numbered["type"] == "numbered"
+    assert numbered["char"] is None  # -- char is populated for character bullets only
+    assert numbered["number_scheme"] == "arabicPeriod"
+    assert numbered["start_at"] == 3
+
+    title = prs.slides[0].shapes.title
+    none_bullet = effective_paragraph_format(title.text_frame.paragraphs[0]).to_dict()["bullet"]
+    assert none_bullet["type"] == "none"
+    assert (none_bullet["char"], none_bullet["number_scheme"], none_bullet["start_at"]) == (
+        None,
+        None,
+        None,
+    )
+
+
+# ------------------------------------------------------------------ shape-format resolution
 
 
 def test_effective_shape_format_resolves_explicit_fill_through_clrmap():


### PR DESCRIPTION
### Stack

Merge bottom-up. Each PR targets the one beneath it, so its diff shows only its own change.

```
main
└─ #10  docs: readme and cleanup
   └─ #15  remove the ZIP resource ceilings
      └─ #14  remove Presentation.scrub()
         └─ #16  resolve inherited bullets   ◀ this PR
            └─ #17  expose Presentation.batch()
```

As each PR merges, retarget the one above it to the merged PR's base (`gh pr edit <n> --base <branch>`) and rebase.

---

## Summary

- `effective_paragraph_format()` now resolves the paragraph's **bullet** through the same placeholder → layout → master walk that already resolves alignment and line spacing, with the same provenance chain. Adds `EffectiveBullet` and `_FontResolver.resolve_bullet()` in `src/pptx/inspect.py`.
- Previously a paragraph inheriting its bullet from the template reported `None` at every layer, indistinguishable from one that renders no bullet. On a branded deck that is the common case — the master supplies the `•` and the paragraph's own markup says nothing.
- Payload `paper-effective-paragraph-format` goes to **version 2** (new `bullet` field). `BulletFormat`, `PP_BULLET_TYPE`, and the `eg_bullet` choice group are untouched — the local-state-only read contract is unchanged.

### Behavior notes

- `a:buNone` resolves **positively** to `"none"`, attributed to the rung that set it — distinct from an exhausted chain, which also resolves to `"none"` but through a closing `rendering default` provenance step.
- An unresolved read reports `type: None`, not `"none"`. Reporting `"none"` would recreate the exact ambiguity this change removes; this matches `EffectiveValue`, whose `value` is `None` whenever `resolved` is `false`.
- Malformed members (`a:buChar` with no `@char`, `a:buAutoNum` with no `@type` or a non-integer `@startAt`) report `resolved: false` with provenance intact rather than raising. Attributes are read raw for this reason — the generated `RequiredAttribute` descriptors raise `InvalidXmlError` on exactly that input.
- Picture bullets are reported on **read only** (`type: "picture"`). No writer is added or planned.
- Resolution is strictly read-only: `src/pptx/inspect.py` still contains zero `get_or_add_*` / `get_or_change_to_*` calls.

### Deliberately out of scope

Both recorded in README's "Known gaps, honestly":

- **Bullet modifiers.** `a:buFont` / `a:buSzPct` sit outside the choice group and inherit on their own chains; each needs its own walk.
- **`diff.py` bullet reporting.** `_diff_text` compares text and field markers only, so this would be a new diff dimension rather than a new field.

## Plan

`reference/paper-pptx-audit/planned/inherited-bullet-resolution/` — spec, build sequence, and four phase plans.

Note: `reference/` is gitignored (`.gitignore:229`), so the plan folder is a local working note and is not part of this diff.

## Test plan

14 new contract tests in `tests/paper/test_effective_inspect.py`, all selectable with `-k bullet`. No new fixtures — every case is reachable from the frozen `self_generated/branded_template.pptx` by in-memory mutation, so the SHA-256-pinned corpus and the goldens are byte-identical.

Covered: inherited character bullet from the master; per-indent-level resolution (`bodyStyle lvl2`'s en dash, not `lvl1`'s bullet); `buNone` as a positive terminal; local numbered override winning at the first rung; inherited numbered bullet with `startAt` defaulting to 1; exhaustion to `rendering default`; a shape `lstStyle` `buNone` shadowing the master's `buChar`; an inherited `a:buBlip` seen despite sitting outside the `eg_bullet` choice group; three malformed-member cases reporting unresolved; ordered provenance completeness for both the placeholder and non-placeholder chains; a `snapshot_parts` proof that resolution dirties zero package parts; and the serialized payload shape.

Verification run on this branch:

```
uv run pytest -W ignore -q                            # 3564 passed (3550 baseline + 14)
uv run behave -q                                      # 54 features, 973 scenarios, 0 failed
uv run pytest -W ignore tests/paper/test_fixture_corpus.py -q   # 245 passed
uv run sphinx-build -W -b html docs docs/.build/html  # exit 0 (also cold -W -E -a)
uv run ruff check src/pptx/inspect.py tests/paper/test_effective_inspect.py
```

Two additional checks worth noting:

- **Falsifiability.** Reverting `src/pptx/inspect.py` to `HEAD` makes all new bullet tests fail — they exercise the resolver rather than restating it.
- **Mutation.** 12 in-memory mutants of `resolve_bullet` / `paragraph_chain` / `effective_paragraph_format` were all caught, including walking past `a:buBlip`, treating `buNone` as an absence, guessing a glyph on malformed input, and swapping `find()` for `get_or_add_pPr()`.

`-W ignore` is needed locally because a pre-existing pyparsing deprecation warning trips the repo's `filterwarnings = error`; CI applies the same ignore in its own pytest step.

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Upstream acceptance suite green (`uv run behave`)
- [x] Lint clean on changed files (`uv run ruff check`)
- [x] Docs build with warnings as errors (`uv run sphinx-build -W -b html docs docs/.build/html`)
- [x] Frozen fixture corpus and goldens unchanged (`tests/paper/fixtures`, `tests/paper/goldens`)
- [x] Docs updated — Sphinx API reference, `paper-additions` narrative, and README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only inspection on `pptx.inspect` with no authoring or diff behavior changes; the only consumer-facing break is accepting schema version 2 for `paper-effective-paragraph-format` payloads.
> 
> **Overview**
> **`effective_paragraph_format()`** now resolves the **bullet that actually renders** on a paragraph through the same placeholder → layout → master inheritance walk as alignment and line spacing, with full provenance. That closes the gap where inherited template bullets looked like `None` on both local `BulletFormat` and effective inspection.
> 
> Adds **`EffectiveBullet`** and **`_FontResolver.resolve_bullet()`**, which walk the paragraph chain for `a:buNone` / `a:buChar` / `a:buAutoNum` / `a:buBlip` (including `buBlip` outside the choice-group descriptor). Explicit **`buNone`** resolves to **`"none"`** at the supplying rung; an empty chain resolves to **`"none"`** via a **`rendering default`** step so those cases stay distinguishable. Malformed bullet XML reports **`resolved: false`** with **`type: None`** instead of raising or falling through to a lower rung.
> 
> The **`paper-effective-paragraph-format`** payload bumps to **version 2** with a new **`bullet`** field. **`BulletFormat`** is unchanged (local markup only). Docs and README note picture bullets are read-only and that bullet font/size and **`diff_decks`** bullets remain future work.
> 
> Fourteen contract tests cover inheritance, overrides, provenance, read-only behavior, and serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000f75f86122d292e67a5e2aa1fbec042b668acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves inherited paragraph bullets in `effective_paragraph_format()` and reports the bullet that actually renders with provenance. Previously, inherited bullets read as None and were indistinguishable from “no bullet”; the `paper-effective-paragraph-format` payload moves to version 2 with a new `bullet` field.

- Adds `EffectiveBullet` with `type` "none" | "character" | "numbered" | "picture", plus glyph/scheme/startAt and full provenance; implements `_FontResolver.resolve_bullet()` using the same placeholder → layout → master → default walk as alignment/spacing.
- `a:buNone` resolves positively to `"none"` at its supplying rung; chain exhaustion resolves to `"none"` via a final `"rendering default"` step so these cases stay distinguishable.
- Malformed members report unresolved (`type: None`) with provenance intact; attributes read raw to avoid raising.
- Read-only change: picture bullets are reported on read only; authoring APIs and `BulletFormat` remain unchanged.

**Migration**
- Consumers of `paper-effective-paragraph-format` must accept version 2 and may read the new `bullet` field.

<sup>Written for commit c08a27b40ae8252dfa2e81bd1e866334205ab74f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

