### PR TITLE
refactor(inspect): remove the group-depth guard that refused whole slides

### DIFF
--- a/src/pptx/inspect.py
+++ b/src/pptx/inspect.py
@@ -264,11 +264,6 @@ def effective_font(run: "_Run") -> EffectiveFont:
     return _FontResolver(part).effective_font(r, sp)
 
 
-#: Group nesting beyond this depth refuses: no real deck nests remotely this deep, and an
-#: unbounded recursion on hostile/malformed XML would be a fail-silent hazard.
-MAX_GROUP_DEPTH = 16
-
-
 @dataclass(frozen=True)
 class EffectiveParagraphFormat:
     """Effective alignment and line spacing of one paragraph (paper-pptx addition)."""
@@ -608,12 +603,11 @@ def inspect_text(slide: "Slide") -> TextInspection:
     """Return a |TextInspection| of every text block on `slide`, visibility-complete.
 
     Traversal is depth-first document order over the shape tree: top-level `p:sp` shapes,
-    `p:sp` shapes inside groups (recursively, to `MAX_GROUP_DEPTH`), and table cells
+    `p:sp` shapes inside groups (recursively, to any depth), and table cells
     (row-major within each table graphic-frame). `block_index` numbers blocks consecutively
     in that pinned order. Table-cell blocks report their text but are *blind regions* for
     effective values (see |TextBlock|); chart text lives in the chart part, not the slide
-    part, and is out of scope here. Group nesting deeper than `MAX_GROUP_DEPTH` raises
-    |UnsupportedStructureError|.
+    part, and is out of scope here.
     """
     part = slide.part
     partname = str(part.partname)
@@ -629,7 +623,7 @@ def iter_text_bodies(spTree):
     """Yield `(kind, owner_elm, txBody, group_path, cell_detail)` depth-first, document order.
 
     The single source of traversal truth shared by `inspect_text` and `pptx.edit`
-    (visibility-complete: top-level `p:sp`, grouped `p:sp` recursively to `MAX_GROUP_DEPTH`,
+    (visibility-complete: top-level `p:sp`, grouped `p:sp` recursively to any depth,
     table cells row-major). `kind` is "shape" | "group" | "table-cell"; `owner_elm` is the
     `p:sp` or `p:graphicFrame`; `cell_detail` is `"<frame-name>!r{row}c{col}"` for table
     cells, None otherwise.
@@ -643,11 +637,6 @@ _MC_ALTERNATE_CONTENT = (
 
 
 def _iter_container(container_elm, group_path):
-    if len(group_path) > MAX_GROUP_DEPTH:
-        raise UnsupportedStructureError(
-            "group shapes nested more than %d deep; refusing to traverse what no real deck"
-            " produces" % MAX_GROUP_DEPTH
-        )
     for child in container_elm:
         if child.tag == _MC_ALTERNATE_CONTENT:
             # -- markup-compatibility content renders one of several branches depending on

--- a/tests/paper/test_edit_text.py
+++ b/tests/paper/test_edit_text.py
@@ -259,19 +259,13 @@ def test_multiple_matches_in_one_paragraph_are_all_replaced_and_counted():
     assert box.text_frame.paragraphs[0].text == "baNANA"
 
 
-def _add_deep_group(slide, depth=17):
-    group = slide.shapes.add_group_shape()
-    for _ in range(depth):
-        group = group.shapes.add_group_shape()
-    box = group.shapes.add_textbox(0, 0, 914400, 914400)
-    box.text_frame.paragraphs[0].add_run().text = "unreachable target"
-
-
 def test_traversal_refusal_fires_before_any_write():
-    """Regression (review, two dimensions): the depth guard on a LATER slide used to fire
-    after earlier blocks were already rewritten — a refusal must leave zero edits behind."""
+    """Regression (review, two dimensions): a traversal refusal sourced from a LATER slide
+    used to fire after earlier blocks were already rewritten — a refusal must leave zero
+    edits behind. `mc:AlternateContent` is the refusal source; it is raised from the same
+    plan-building position the retired group-depth guard occupied."""
     prs = Presentation(str(corpus.fixture_path("self_generated/gauntlet.pptx")))
-    _add_deep_group(prs.slides[3])  # -- refusal source is on the LAST slide
+    _wrap_first_textbox_in_alternate_content(prs, slide_index=3)  # -- LAST slide
 
     def operation(p):
         replace_text(p, "Gauntlet", "REWRITTEN")  # -- would match on earlier slides
@@ -279,7 +273,7 @@ def test_traversal_refusal_fires_before_any_write():
     from .contract import assert_refusal_atomic
 
     raised = assert_refusal_atomic(prs, operation, UnsupportedStructureError)
-    assert "nested" in str(raised)
+    assert "AlternateContent" in str(raised)
 
 
 def test_broken_slide_relationship_graph_refuses_typed_before_any_write():
@@ -298,11 +292,11 @@ _MC = "http://schemas.openxmlformats.org/markup-compatibility/2006"
 _P = "http://schemas.openxmlformats.org/presentationml/2006/main"
 
 
-def _wrap_first_textbox_in_alternate_content(prs):
+def _wrap_first_textbox_in_alternate_content(prs, slide_index=0):
     """Wrap a new textbox's p:sp in mc:AlternateContent (Choice + Fallback branches)."""
     import copy as copy_module
 
-    slide = prs.slides[0]
+    slide = prs.slides[slide_index]
     box = slide.shapes.add_textbox(0, 0, 914400, 914400)
     box.text_frame.paragraphs[0].add_run().text = "mc content"
     sp = box._element

--- a/tests/paper/test_effective_inspect.py
+++ b/tests/paper/test_effective_inspect.py
@@ -401,16 +401,47 @@ def test_inspect_text_block_order_is_depth_first_document_order():
     assert [b.anchor.block_index for b in inspection.blocks] == list(range(len(texts)))
 
 
-def test_pathological_group_nesting_refuses_instead_of_recursing_forever():
+@pytest.mark.parametrize("depth", [17, 64, 248])
+def test_deeply_nested_groups_inspect_without_refusing(depth):
+    """A retired guard used to refuse the whole slide past depth 16, hiding ordinary shapes
+    alongside the nest. Depth 248 is the deepest a deck can be and still parse: libxml2 caps
+    document nesting at 256 elements, so no loadable deck exceeds it."""
     prs = _open("self_generated/minimal_clean.pptx")
-    shapes = prs.slides[0].shapes
-    group = shapes.add_group_shape()
-    for _ in range(17):
+    slide = prs.slides[0]
+    shallow_before = len(inspect_text(slide).blocks)
+
+    group = slide.shapes.add_group_shape()
+    for _ in range(depth - 1):
         group = group.shapes.add_group_shape()
     box = group.shapes.add_textbox(0, 0, 914400, 914400)
-    box.text_frame.paragraphs[0].add_run().text = "too deep"
-    with pytest.raises(UnsupportedStructureError, match="nested"):
-        inspect_text(prs.slides[0])
+    box.text_frame.paragraphs[0].add_run().text = "deep text"
+
+    blocks = inspect_text(slide).blocks
+    texts = [b.text for b in blocks]
+    # -- the deep block is reported, and every pre-existing shallow block survives with it
+    assert "deep text" in texts
+    assert len(blocks) == shallow_before + 1
+    deep = next(b for b in blocks if b.text == "deep text")
+    assert deep.container == "group"
+    assert deep.blind is False
+
+
+def test_deeply_nested_group_deck_round_trips_through_a_file():
+    """The nest must survive save -> load, not just in-memory inspection."""
+    import io
+
+    prs = _open("self_generated/minimal_clean.pptx")
+    group = prs.slides[0].shapes.add_group_shape()
+    for _ in range(247):
+        group = group.shapes.add_group_shape()
+    box = group.shapes.add_textbox(0, 0, 914400, 914400)
+    box.text_frame.paragraphs[0].add_run().text = "deep text"
+
+    buf = io.BytesIO()
+    prs.save(buf)
+    buf.seek(0)
+    reloaded = Presentation(buf)
+    assert "deep text" in [b.text for b in inspect_text(reloaded.slides[0]).blocks]
 
 
 def test_effective_font_resolves_runs_inside_groups():


### PR DESCRIPTION
## What

Deletes `MAX_GROUP_DEPTH = 16` and its enforcement in `_iter_container`, the single traversal
shared by `inspect_text`, `iter_text_bodies`, and `pptx.edit`.

## Why

The guard refused an **entire slide** when any `p:grpSp` nest exceeded 16 levels, taking
ordinary shallow shapes on that slide down with it. A slide with one deep nest and one normal
textbox returned no text at all — the same fail-silent class the grouped-shape descent was
built to eliminate, reached from the other side.

The hazard it named cannot be reached:

| | |
|---|---|
| libxml2 document-nesting cap | 256 elements → **no loadable deck exceeds 248 group levels** |
| `RecursionError` in this traversal | ~1500 levels |
| The guard | **16** |

Measured: a deck nested 249 deep fails at `Presentation(path)` with
`XMLSyntaxError: Excessive depth in document: 256` before `inspect_text` is ever reached, and
`replace_text` already refuses typed past that point (`transaction candidate is not a
reopenable PowerPoint presentation`). Raising the recursion limit to 200,000 and traversing
20,000 levels produces no crash — the recursion is pure Python, so there is no C-stack exposure.

It was also the **only** guard among four recursive group walks. With it in place, the same
deck produced `UnsupportedStructureError` from `inspect_text` at depth 17 while `inspect_deck`
walked depth 400 in 22 ms. Deleting it makes the traversals consistent.

Upstream python-pptx has no `inspect.py`, no `edit.py`, and no depth constant, with an
identical lxml parser config — so it shares the same 248 ceiling and never needed a guard.

## Why not raise the constant instead

An earlier proposal suggested raising it to 64 and degrading to a blind region. 64 leaves
depths 65–248 refused — decks that load and inspect fine. A constant pinned at 248 would
hardcode a ceiling that is libxml2's, not ours. Blind-region degradation would cost a schema
version bump to solve a problem that disappears once the depth is reachable.
`paper-text-inspection` stays at **schema version 2**; no payload field changes.

## Tests

- `test_deeply_nested_groups_inspect_without_refusing` — depths 17/64/248; asserts the deep
  block is reported **and** that pre-existing shallow blocks survive alongside it, which is the
  actual defect. Also pins `blind is False`, guarding against a future "fix" that reintroduces
  degradation.
- `test_deeply_nested_group_deck_round_trips_through_a_file` — proves the 248 claim against a
  real save/load.
- `test_traversal_refusal_fires_before_any_write` is **re-pointed, not deleted**. It used the
  depth guard as a trigger but guards a different invariant: a refusal sourced on the *last*
  slide must leave earlier matching slides unwritten. It now uses `mc:AlternateContent`, which
  raises from the same position in `_replacement_plan`. The existing AlternateContent atomicity
  test uses a single-slide deck, so deleting rather than re-pointing would have lost coverage.

## Verification

- `tests/paper`: 882 passed, 1 skipped
- `behave`: 54 features / 973 scenarios / 2914 steps, 0 failed
- `sphinx-build -W -a -E` (cold): build succeeded
- `ruff check`: clean
- Restack dry-run: #14, #16, #17 each rebase conflict-free with byte-identical diff content;
  `tests/paper` at the restacked tip goes 893 → 896, exactly the four new tests less the one retired
- The 39 `pytest tests` collection errors (`PyparsingDeprecationWarning` under
  `filterwarnings = ["error"]`) are pre-existing — identical count on the base branch

## Stack

```
#10 docs-readme
 └─ #15 delete-zip-resource-ceilings
     └─ THIS PR  delete-max-group-depth
         └─ #14 remove-scrub
             └─ #16 inherited-bullet-detection
                 └─ #17 batch-api
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized traversal behavior change with expanded tests; no API or schema changes, and practical depth is still bounded by XML parsing limits.
> 
> **Overview**
> Removes **`MAX_GROUP_DEPTH`** and the **`UnsupportedStructureError`** raised from **`_iter_container`** when group nesting exceeded 16 levels. **`inspect_text`**, **`iter_text_bodies`**, and **`pptx.edit`** now recurse through **`p:grpSp`** to any depth instead of failing the whole slide.
> 
> Docstrings are updated to describe unlimited group depth (no inspection schema bump).
> 
> Tests replace the old “refuse at depth 17” expectation with parametrized deep-nest inspection (17/64/248) plus save/load round-trip, and repoint **`test_traversal_refusal_fires_before_any_write`** to **`mc:AlternateContent`** on the last slide so atomic refusal coverage is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ca3743cf41636cd0a660ec910f33fe0c9d8ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the 16-level group-depth guard in text traversal so slides with deep p:grpSp nests no longer drop all text. Previously any slide exceeding 16 group levels was refused; now traversal recurses to any reachable depth, preserving shallow shapes and reporting deep blocks.

- Deletes `MAX_GROUP_DEPTH` and the raise in `_iter_container`; `inspect_text`, `iter_text_bodies`, and `pptx.edit` now descend without a project limit (practically capped by libxml2’s nesting limit).
- Updates traversal docstrings to reflect unlimited depth; no schema or payload changes, and no migrations required.
- Repoints the refusal-atomicity test to `mc:AlternateContent`; adds tests asserting success at depths 17/64/248 and a save/load round trip.

<sup>Written for commit 02ca3743cf41636cd0a660ec910f33fe0c9d8ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

