### PR TITLE
fix: refuse packages carrying bytes in front of the archive

### DIFF
--- a/src/pptx/_zipguard.py
+++ b/src/pptx/_zipguard.py
@@ -6,6 +6,14 @@ end-of-central-directory records, member counts and offsets that disagree, dupli
 case-equivalent member names, local headers that contradict the central directory, and
 data that overlaps or trails a member's declared extent.
 
+The archive must also span its file exactly, beginning at the first byte and ending with
+an end record that accounts for every byte after it. Both halves are PowerPoint's rule,
+established by opening each shape in the application: it refuses a package carrying
+undeclared trailing bytes, one whose end record declares an absent comment, and one with
+bytes in front of its first member. No Python reader reproduces this -- stdlib ``zipfile``,
+upstream python-pptx and LibreOffice accept all three -- so these refusals look like
+over-strictness until measured. Declared trailing data is legitimate and is accepted.
+
 Only the two compression methods permitted by the OPC ZIP mapping (stored and
 deflated) are accepted. Every member is inflated from its raw compressed bytes
 rather than through ``ZipFile.read()``. This allows actual output length, CRC, and
@@ -186,6 +194,21 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
         if total_entries and central_size < total_entries * _CENTRAL_HEADER.size:
             raise PackageLimitError("ZIP central directory is too small for its member count")
 
+        # -- The archive must also START where the file does. Bytes in front of the first
+        # -- member leave readers disagreeing about where the archive begins: PowerPoint
+        # -- refuses such a package, LibreOffice renders something other than the deck, and
+        # -- a permissive reader edits whichever reading it happened to take. An archive
+        # -- declaring no members has no first member and legitimately begins with its own
+        # -- end record.
+        if total_entries:
+            stream.seek(0, os.SEEK_SET)
+            if stream.read(len(_LOCAL_HEADER_SIGNATURE)) != _LOCAL_HEADER_SIGNATURE:
+                raise PackageLimitError(
+                    "ZIP package does not begin with a member record, so bytes precede the "
+                    "archive and readers disagree about where it starts; remove the leading "
+                    "bytes or re-save the package from PowerPoint"
+                )
+
         _scan_central_directory(
             stream,
             central_offset,
@@ -219,9 +242,18 @@ def _find_end_record(stream: BinaryIO, archive_size: int) -> Tuple[int, Tuple[in
             candidates.append((archive_size - tail_size + index, fields))
 
     if not candidates:
-        raise PackageLimitError("ZIP package has no valid end-of-central-directory record")
+        raise PackageLimitError(
+            "ZIP package has no end-of-central-directory record accounting for the end of "
+            "the file: either bytes were appended after the archive, or the record declares "
+            "an archive comment that is not there; PowerPoint refuses a package in this "
+            "state, so remove the trailing bytes or re-save the package"
+        )
     if len(candidates) != 1:
-        raise PackageLimitError("ZIP package has ambiguous end-of-central-directory records")
+        raise PackageLimitError(
+            "ZIP package has more than one end-of-central-directory record accounting for "
+            "the end of the file, so its member list has no single reading; re-save the "
+            "package from PowerPoint to rewrite one unambiguous record"
+        )
     return candidates[0]
 
 

--- a/tests/paper/test_zipguard_end_record.py
+++ b/tests/paper/test_zipguard_end_record.py
@@ -1,0 +1,228 @@
+"""End-of-central-directory handling, pinned against the real PowerPoint application.
+
+PowerPoint requires the ZIP to span its file exactly: nothing before the first local
+header, and the footer's declared comment length accounting for every byte after the
+footer. A package that breaks either half opens in stdlib `zipfile`, in upstream
+python-pptx, and in LibreOffice, and is refused by PowerPoint with a repair prompt.
+
+That makes these refusals the fork's core case rather than over-strictness: a deck that
+opens in python-pptx but not in PowerPoint is the silent-corruption class named in
+`PLAN-paper-pptx.md`. The tests below pin each half, and record where paper-pptx and
+PowerPoint still disagree.
+
+Measured by opening each shape in PowerPoint (macOS) and recording the result:
+
+    shape                                   PowerPoint  upstream  paper-pptx
+    unmutated deck                          opens       opens     opens
+    archive comment, declared correctly     opens       opens     opens
+    trailing bytes, declared in the footer  opens       opens     opens
+    stray footer signature inside a member  opens       opens     opens
+    bytes appended, undeclared              REFUSES     opens     refuses
+    one newline appended                    REFUSES     opens     refuses
+    comment length declared, no comment     REFUSES     opens     refuses
+    two packages concatenated               REFUSES     opens     refuses
+    prefix data before the archive          REFUSES     opens     refuses
+    ZIP directory entries ("ppt/")          opens       opens     refuses  <- still too strict
+
+The prefix-data row was the one shape where this package was more permissive than the
+application it protects; it is refused as of this file's companion change. The remaining
+disagreement is `directory_entries`, which is a member-name question rather than a footer
+one and is handled elsewhere.
+"""
+
+from __future__ import annotations
+
+import struct
+import zipfile
+
+import pytest
+
+from pptx import Presentation
+from pptx.errors import PackageLimitError
+
+from . import corpus
+
+#: end-of-central-directory record: signature, disk, cd-disk, entries here, entries total,
+#: central-directory size, central-directory offset, comment length
+_END_RECORD = struct.Struct("<4s4H2LH")
+_CENTRAL_HEADER = struct.Struct("<4s6H3L5H2L")
+_END_SIGNATURE = b"PK\x05\x06"
+
+_FIXTURE = "self_generated/minimal_clean.pptx"
+
+
+def _source_bytes() -> bytes:
+    return corpus.fixture_path(_FIXTURE).read_bytes()
+
+
+def _end_record(raw: bytes):
+    offset = raw.rfind(_END_SIGNATURE)
+    assert offset >= 0, "fixture carries no end-of-central-directory record"
+    return offset, _END_RECORD.unpack_from(raw, offset)
+
+
+# -- the footer must account for every byte after it --------------------------------------
+
+
+def test_undeclared_bytes_after_the_footer_refuse(tmp_path):
+    """A signing or watermarking tool appending in place. PowerPoint prompts to repair."""
+    target = tmp_path / "signed.pptx"
+    target.write_bytes(_source_bytes() + b"--SIGNATURE-BLOCK-APPENDED-BY-SOME-TOOL--")
+
+    with pytest.raises(
+        PackageLimitError, match="no end-of-central-directory record accounting for the end"
+    ):
+        Presentation(target)
+
+
+def test_a_single_appended_newline_refuses(tmp_path):
+    """`echo "" >> deck.pptx`. One byte is enough for PowerPoint to reject the deck."""
+    target = tmp_path / "newline.pptx"
+    target.write_bytes(_source_bytes() + b"\n")
+
+    with pytest.raises(
+        PackageLimitError, match="no end-of-central-directory record accounting for the end"
+    ):
+        Presentation(target)
+
+
+def test_a_declared_comment_length_with_no_comment_refuses(tmp_path):
+    """Observed on intact SEC EDGAR filings: one mangled byte in the footer.
+
+    Every member still inflates with a clean CRC, so the package reads fine in stdlib
+    `zipfile`. PowerPoint refuses it anyway, which is what makes refusing it correct here.
+    """
+    raw = bytearray(_source_bytes())
+    offset, _ = _end_record(bytes(raw))
+    struct.pack_into("<H", raw, offset + 20, 2560)  # -- the only byte that differs
+
+    target = tmp_path / "bogus_comment_length.pptx"
+    target.write_bytes(bytes(raw))
+
+    with pytest.raises(
+        PackageLimitError, match="no end-of-central-directory record accounting for the end"
+    ):
+        Presentation(target)
+
+
+def test_trailing_bytes_declared_as_a_comment_open(tmp_path):
+    """The same trailing bytes, declared in the footer, are legitimate and must open.
+
+    This is the boundary: the objection is to *undeclared* trailing data, not to trailing
+    data. PowerPoint opens this shape.
+    """
+    raw = _source_bytes()
+    offset, fields = _end_record(raw)
+    trailer = b"--SIGNATURE-BLOCK-APPENDED-BY-SOME-TOOL--"
+    declared = list(fields)
+    declared[-1] = len(trailer)
+
+    target = tmp_path / "declared.pptx"
+    target.write_bytes(raw[:offset] + _END_RECORD.pack(*declared) + trailer)
+
+    assert len(Presentation(target).slides) == len(
+        Presentation(corpus.fixture_path(_FIXTURE)).slides
+    )
+
+
+def test_a_comment_written_through_the_zip_api_opens(tmp_path):
+    """The spec-correct way to attach a comment; PowerPoint opens it."""
+    target = tmp_path / "commented.pptx"
+    target.write_bytes(_source_bytes())
+    with zipfile.ZipFile(target, "a") as archive:
+        archive.comment = b"produced by an internal build pipeline"
+
+    Presentation(target)
+
+
+def test_an_archive_with_no_footer_refuses(tmp_path):
+    raw = _source_bytes()
+    offset, _ = _end_record(raw)
+
+    target = tmp_path / "footerless.pptx"
+    target.write_bytes(raw[:offset] + b"\x00" * 40)
+
+    with pytest.raises(Exception) as excinfo:
+        Presentation(target)
+    assert type(excinfo.value).__name__ in {"PackageNotFoundError", "PackageLimitError"}
+
+
+def test_a_stray_footer_signature_inside_a_member_is_ignored(tmp_path):
+    """Four bytes of binary media may match the signature. PowerPoint is untroubled."""
+    stray = _END_SIGNATURE + struct.pack("<4H2LH", 0, 0, 5, 5, 1234, 5678, 0)
+    source = corpus.fixture_path(_FIXTURE)
+    target = tmp_path / "stray.pptx"
+    with zipfile.ZipFile(source) as incoming, zipfile.ZipFile(target, "w") as outgoing:
+        for info in incoming.infolist():
+            data = incoming.read(info.filename)
+            if info.filename.endswith(".jpeg"):
+                # -- stored, so the signature bytes appear literally in the archive
+                outgoing.writestr(info.filename, data + stray, zipfile.ZIP_STORED)
+            else:
+                outgoing.writestr(info.filename, data)
+
+    Presentation(target)
+
+
+# -- the archive must start at byte zero ---------------------------------------------------
+
+
+def test_two_concatenated_packages_refuse(tmp_path):
+    """`cat a.pptx b.pptx` leaves two footers and two documents in one file.
+
+    Upstream opens it, silently reads whichever document the last footer names, and drops
+    the other on save. PowerPoint refuses it. The refusal here comes from the
+    central-directory bounds check rather than the footer search.
+    """
+    raw = _source_bytes()
+    target = tmp_path / "concatenated.pptx"
+    target.write_bytes(raw + raw)
+
+    with pytest.raises(PackageLimitError, match="unambiguous region"):
+        Presentation(target)
+
+
+def test_prefix_data_before_the_archive_refuses(tmp_path):
+    """A stub before the first local header, every offset rebased: the self-extracting shape.
+
+    Three readers, three different documents: paper-pptx used to open this and show the
+    correct two slides, LibreOffice renders four pages of binary garbage rather than the
+    deck, and PowerPoint prompts to repair. A permissive reader here edits whichever
+    reading it happened to take, which is the hazard the package exists to prevent.
+    """
+    raw = _source_bytes()
+    offset, fields = _end_record(raw)
+    prefix = b"#!/bin/sh\n# self-extracting stub\n" + b"P" * 100
+    central_size, central_offset = fields[5], fields[6]
+
+    body = bytearray(prefix + raw)
+    cursor, end = central_offset + len(prefix), central_offset + central_size + len(prefix)
+    while cursor < end:
+        record = _CENTRAL_HEADER.unpack_from(body, cursor)
+        struct.pack_into("<L", body, cursor + 42, record[16] + len(prefix))
+        cursor += _CENTRAL_HEADER.size + record[10] + record[11] + record[12]
+    shifted = list(fields)
+    shifted[6] = central_offset + len(prefix)
+    _END_RECORD.pack_into(body, offset + len(prefix), *shifted)
+
+    target = tmp_path / "prefixed.pptx"
+    target.write_bytes(bytes(body))
+
+    with pytest.raises(PackageLimitError, match="does not begin with a member record"):
+        Presentation(target)
+
+
+def test_an_empty_archive_is_not_mistaken_for_prefixed(tmp_path):
+    """A zero-member archive is 22 bytes of end record and has no first member to lead with.
+
+    Six such files turned up in a 52,941-file scan, all of them `empty.zip` test data. They
+    are not packages, so the refusal below is about the missing part rather than the shape
+    of the archive, and it must not be the prefix refusal.
+    """
+    target = tmp_path / "empty.pptx"
+    with zipfile.ZipFile(target, "w"):
+        pass
+
+    with pytest.raises(Exception) as excinfo:
+        Presentation(target)
+    assert "does not begin with a member record" not in str(excinfo.value)

--- a/tests/paper/test_zipguard_structural.py
+++ b/tests/paper/test_zipguard_structural.py
@@ -283,12 +283,13 @@ def test_normal_open_refuses_structurally_ambiguous_archive(tmp_path, build, fra
 
 
 def test_zipguard_structural_refusal_population_is_pinned():
-    """`_zipguard.py` has 82 `raise PackageLimitError` sites, every one structural.
+    """`_zipguard.py` has 83 `raise PackageLimitError` sites, every one structural.
 
-    The twelve policy sites that enforced the six numeric resource ceilings are gone. Any
-    movement from 82 means a structural or ambiguity refusal was added or dropped, so a
-    mismatch here is a prompt to check which.
+    The twelve policy sites that enforced the six numeric resource ceilings are gone, and
+    one site was added for a package carrying bytes in front of its first member, a shape
+    PowerPoint refuses. Any movement from 83 means a structural or ambiguity refusal was
+    added or dropped, so a mismatch here is a prompt to check which.
     """
     source = Path(_zipguard.__file__).read_text(encoding="utf-8")
 
-    assert source.count("raise PackageLimitError") == 82
+    assert source.count("raise PackageLimitError") == 83


### PR DESCRIPTION
Stacked on #17. Closes the remaining work on `PROPOSAL-over-strict-input-guards.md` **Part 2**.

## What Part 2 asked for, and why it was wrong

Part 2 proposed relaxing the end-of-central-directory rule in `_find_end_record`, on evidence that was entirely true: 52,807 real zip-family files surveyed, five genuinely-intact SEC EDGAR filings refused, every member CRC-clean, byte-identical part hashes, stdlib and upstream python-pptx both opening the files, LibreOffice rendering them to identical text.

Then the decks were opened in PowerPoint. It refuses them.

| shape | stdlib | upstream | LibreOffice | **PowerPoint** | paper-pptx |
|---|---|---|---|---|---|
| control | opens | opens | renders | **opens** | opens |
| trailing bytes **declared** in the footer | opens | opens | renders | **opens** | opens |
| archive comment, spec-correct | opens | opens | renders | **opens** | opens |
| stray footer signature inside a member | opens | opens | renders | **opens** | opens |
| undeclared bytes after the footer | opens | opens | renders | **REPAIR** | refuses |
| a single appended newline | opens | opens | renders | **REPAIR** | refuses |
| declared comment length, absent comment | opens | opens | renders | **REPAIR** | refuses |
| two packages concatenated | opens | opens deck 2 only | fails | **REPAIR** | refuses |
| **prefix data before the archive** | opens | opens | **4 pages of garbage** | **REPAIR** | **opens** ← fixed here |

PowerPoint's rule: the archive spans its file exactly. `_find_end_record` already enforced the tail half — reached independently, with no tests and no recorded reason, which is exactly why an audit against Python readers concluded it was arbitrary. **It stays unchanged.**

## What this PR does

**1. Closes the head half.** A package with bytes in front of its first member is now refused. This was the one shape where paper-pptx was *more permissive* than the application it protects, and it is a genuine ambiguity: three readers produced three different documents from that one file. paper-pptx showed the correct two slides; LibreOffice rendered four pages of binary garbage rather than the deck, reporting no error; PowerPoint refused.

Keyed on the first member record rather than a minimum member offset, so ZIP64 packages are unaffected. Archives declaring no members are exempt — six turned up in a 52,941-file scan, all `empty.zip` test data, none of them a package.

**2. Rewrites both end-record messages** to name cause and remedy. `"ZIP package has no valid end-of-central-directory record"` was what you got for appending a newline to a deck; it named neither the appended bytes nor the fix.

**3. Pins every verdict** in `tests/paper/test_zipguard_end_record.py`, including the boundary that keeps the rule narrow (declared trailing data opens) and the concatenation refusal, which had no coverage at all.

## Verification

Against the exact fixtures a human opened in PowerPoint: the prefix deck is now refused, the four shapes PowerPoint opens still open.

`tests/paper`: 906 passed, 1 skipped. Two pre-existing `E501`s in `tests/paper/idlists.py` and `relint.py` are untouched and present at the base commit.

## Notes

- The pinned refusal count moves 82 → 83. The in-flight directory-entry work moves it 82 → 81; whichever lands second should read 82.
- `directory_entries` remains the one shape where paper-pptx is still stricter than PowerPoint. That is a member-name question, not a footer one — Part 1's territory, already in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package-open validation on a security-sensitive path; behavior is narrower (more refusals) and covered by new tests, but any deck with a leading stub will now fail to open.
> 
> **Overview**
> Aligns ZIP preflight with PowerPoint’s rule that the archive must span the file exactly: **packages with bytes before the first local header are now refused** via a new check in `_preflight_zip_stream` (skipped for zero-member archives).
> 
> **End-of-central-directory** error messages are rewritten to explain undeclared trailing data, bogus comment lengths, and ambiguous footers, with guidance to re-save from PowerPoint.
> 
> Adds **`tests/paper/test_zipguard_end_record.py`** to pin PowerPoint-aligned behavior (undeclared trailers, declared comments, prefix stubs, concatenation, empty-archive edge case) and bumps the pinned `PackageLimitError` site count **82 → 83**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1118a9f2a77db54cd256c4c81df6ae1fc4b13fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->