### PR TITLE
fix: refuse parts with no content type, accept parts nothing references

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,11 +374,15 @@ corruption prevention:
 
 - **Guarded package intake.** Opening a `.pptx` now rejects ambiguous or unsafe
   ZIP archives — duplicate or case-colliding member names, path traversal,
-  encrypted or exotically-compressed members, lying size headers — with a typed
-  `PackageLimitError` *before* any editable object exists. A permissive reader
-  "successfully" opens an ambiguous archive and then faithfully edits the wrong
-  interpretation of it. Some odd-but-consumer-readable files that upstream
-  accepted are now refused.
+  encrypted or exotically-compressed members, lying size headers, an archive that
+  does not span its file exactly, and any member that resolves to no content type
+  — with a typed `PackageLimitError` *before* any editable object exists. A
+  permissive reader "successfully" opens an ambiguous archive and then faithfully
+  edits the wrong interpretation of it. Some odd-but-consumer-readable files that
+  upstream accepted are now refused; each such refusal was checked by opening the
+  file in PowerPoint first, and matches what PowerPoint does. A part that nothing
+  references is *not* refused — PowerPoint opens that package and drops the part
+  on its next save, and so does `save()`.
 - **Atomic save.** `save()` keeps its signature, but saving to a path now
   writes a sibling temporary file and atomically replaces the destination only
   after serialization succeeds, preserving the existing file's permission bits;

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -41,8 +41,13 @@ The refusals form a small hierarchy rooted at |PaperRefusal| (see :ref:`errors_a
         ...                                 # document is untouched; handle or report exc
 
 Normal package intake uses the same refusal boundary. It rejects ambiguous or unsafe ZIP
-members before parsing XML. A path-based ``save()`` writes beside the destination and replaces
-it atomically only after serialization succeeds; stream saves retain normal stream semantics.
+members before parsing XML, and refuses a package in which any member resolves to no content
+type — no ``Default`` for its extension and no ``Override`` for its name in
+``[Content_Types].xml`` — because PowerPoint refuses that package too. A part that nothing
+references is accepted: PowerPoint opens such a package and drops the part on its next save,
+which is also what ``save()`` does. A path-based ``save()`` writes beside the destination and
+replaces it atomically only after serialization succeeds; stream saves retain normal stream
+semantics.
 
 Validation runs per mutating call by default. :meth:`~pptx.presentation.Presentation.batch`
 trades that granularity for speed: inside the block the whole-deck check runs once, at exit,

--- a/src/pptx/_zipguard.py
+++ b/src/pptx/_zipguard.py
@@ -14,6 +14,14 @@ bytes in front of its first member. No Python reader reproduces this -- stdlib `
 upstream python-pptx and LibreOffice accept all three -- so these refusals look like
 over-strictness until measured. Declared trailing data is legitimate and is accepted.
 
+Every member must also resolve to a content type, through an ``Override`` naming the part
+or a ``Default`` matching its extension. A member with neither has no type at all, and
+PowerPoint refuses the package whatever the part is for -- measured on a thumbnail it never
+renders, a slide it must load, an image it draws, and a part nothing references. The rule
+therefore keys on physical membership rather than on what the loader would otherwise read.
+A part nothing references is *not* refused: PowerPoint opens that package and drops the
+part on its next save, which is what ``save()`` does too.
+
 Only the two compression methods permitted by the OPC ZIP mapping (stored and
 deflated) are accepted. Every member is inflated from its raw compressed bytes
 rather than through ``ZipFile.read()``. This allows actual output length, CRC, and

--- a/src/pptx/_zipguard.py
+++ b/src/pptx/_zipguard.py
@@ -499,7 +499,27 @@ class GuardedZipReader:
         return parts
 
     def _validate_content_types(self, content_types: bytes) -> None:
-        _parse_content_types(content_types)
+        defaults, overrides = _parse_content_types(content_types)
+
+        # -- OPC gives every part a content type, by an Override naming the part or a
+        # -- Default matching its extension. A member with neither has no type at all, and
+        # -- PowerPoint refuses such a package whatever the part is for -- a slide, an image
+        # -- it draws, or a thumbnail it never reads. Keys are normalized exactly as
+        # -- `_parse_content_types` stored them.
+        undeclared = sorted(
+            info.filename
+            for info in self._infos
+            if info.filename != _CONTENT_TYPES_NAME
+            and ("/" + info.filename).casefold() not in overrides
+            and _member_extension(info.filename) not in defaults
+        )
+        if undeclared:
+            raise PackageLimitError(
+                "ZIP members have no content type, so their parts cannot be interpreted: "
+                "%s. [Content_Types].xml declares no Default for their extension and no "
+                "Override for their name; add the missing declaration or re-save the "
+                "package from PowerPoint" % ", ".join(repr(name) for name in undeclared)
+            )
 
     def _validate_local_header(self, info: ZipInfo, boundary: int) -> int:
         stream = self._zip_file.fp
@@ -682,6 +702,15 @@ class GuardedZipReader:
         if crc & 0xFFFFFFFF != info.CRC:
             raise PackageLimitError(f"ZIP member {info.filename!r} fails its CRC check")
         return b"".join(chunks)
+
+
+def _member_extension(name: str) -> str:
+    """Return `name`'s extension keyed as ``Default`` declarations are stored.
+
+    Empty when the final segment carries no period, which no ``Default`` can match.
+    """
+    leaf = name.rsplit("/", 1)[-1]
+    return leaf.rsplit(".", 1)[-1].lower() if "." in leaf else ""
 
 
 def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:

--- a/src/pptx/opc/package.py
+++ b/src/pptx/opc/package.py
@@ -468,21 +468,10 @@ class _PackageLoader:
                 load_rels(target_partname, self._xml_rels_for(target_partname))
 
         load_rels(PACKAGE_URI, self._xml_rels_for(PACKAGE_URI))
-        physical_names = None if self._pkg_file is None else self._package_reader.partnames
-        if physical_names is not None:
-            physical_parts = {
-                partname
-                for partname in physical_names
-                if partname != CONTENT_TYPES_URI and not partname.membername.endswith(".rels")
-            }
-            unreachable = sorted(physical_parts - (visited_partnames - {PACKAGE_URI}))
-            if unreachable:
-                from pptx.errors import PackageLimitError
-
-                raise PackageLimitError(
-                    "ZIP package contains unreachable parts that ordinary save would drop: %s"
-                    % ", ".join(str(partname) for partname in unreachable)
-                )
+        # -- a part no relationship reaches is not refused: PowerPoint opens such a package
+        # -- and drops the part on its own next save, which is what `save()` does too.
+        # -- `_zipguard` refuses the shape PowerPoint actually rejects, a part with no
+        # -- declared content type, reachable or not.
         return xml_rels
 
     def _xml_rels_for(self, partname: PackURI) -> CT_Relationships:

--- a/src/pptx/package.py
+++ b/src/pptx/package.py
@@ -441,7 +441,7 @@ def patch_save(original_path: str, document, out_path: str) -> PackageDiff:
     nothing changed at all, `out_path` is written as an exact byte copy of `original_path`
     (the no-op round trip is byte-identical).
 
-    Not interchangeable with |Presentation.save|, which is also atomic on a path:
+    Not interchangeable with :meth:`.Presentation.save`, which is also atomic on a path:
     atomicity is how the bytes land, narrowness is which bytes get written. `save()`
     re-serializes every part, so even an unchanged part gets new bytes; `patch_save`
     restores the original bytes for every part that is semantically identical.

--- a/tests/paper/test_content_type_coverage.py
+++ b/tests/paper/test_content_type_coverage.py
@@ -1,0 +1,205 @@
+"""Every part in a package must have a declared content type.
+
+OPC gives each part a content type through an `Override` naming the part or a `Default`
+matching its extension. A member with neither has no type at all, and PowerPoint refuses
+such a package — measured in the application across every role a part can play:
+
+    the part renamed to an undeclared extension        role                PowerPoint
+    docProps/thumbnail.xyz                             never rendered      Repair
+    ppt/slides/slide2.abc, its Override removed        slide 2 needs it    Repair
+    ppt/media/image1.qqq                               drawn on slide 1    Repair
+    ppt/media/orphan.png, nothing references it        unreachable         Repair
+
+and the counterpart, an unreferenced part whose type IS declared, opens. So the rule keys
+on physical membership, not on whether the loader would otherwise read the part. Verdicts
+live in the `verifying-against-powerpoint` skill's ledger.
+
+Neither stdlib `zipfile`, upstream python-pptx, nor LibreOffice enforces any of this;
+LibreOffice renders all four shapes to identical text.
+"""
+
+from __future__ import annotations
+
+import re
+import zipfile
+
+import pytest
+
+from pptx import Presentation
+from pptx.errors import PackageLimitError, PaperRefusal
+
+from . import corpus
+
+_CONTENT_TYPES = "[Content_Types].xml"
+
+
+def _minimal_path():
+    return corpus.fixture_path("self_generated/minimal_clean.pptx")
+
+
+def _rebuild(target, *, rename=None, edit=None, extra=None):
+    """Copy the minimal deck into `target`, applying one mutation."""
+    source = _minimal_path()
+    with zipfile.ZipFile(source) as incoming, zipfile.ZipFile(target, "w") as outgoing:
+        for info in incoming.infolist():
+            data = incoming.read(info.filename)
+            if edit is not None:
+                data = edit(info.filename, data)
+            outgoing.writestr(rename(info.filename) if rename else info.filename, data)
+        if extra is not None:
+            extra(outgoing)
+    return target
+
+
+def _refuses(target, fragment):
+    """Assert the typed refusal fires and leaves the file byte-identical."""
+    before = target.read_bytes()
+    assert issubclass(PackageLimitError, PaperRefusal)
+    with pytest.raises(PackageLimitError, match=fragment):
+        Presentation(target)
+    assert target.read_bytes() == before
+
+
+def test_an_unreferenced_member_with_no_declared_type_refuses(tmp_path):
+    target = _rebuild(
+        tmp_path / "orphan-undeclared.pptx",
+        extra=lambda z: z.writestr("ppt/media/orphan.qqq", b"no content type declares this"),
+    )
+
+    _refuses(target, "orphan.qqq")
+
+
+def test_a_referenced_member_with_no_declared_type_refuses(tmp_path):
+    """PowerPoint refuses this too, so reachability must not narrow the rule."""
+
+    def rename(name):
+        return "docProps/thumbnail.xyz" if name == "docProps/thumbnail.jpeg" else name
+
+    def edit(name, data):
+        return data.replace(b"thumbnail.jpeg", b"thumbnail.xyz") if name == "_rels/.rels" else data
+
+    target = _rebuild(tmp_path / "referenced-undeclared.pptx", rename=rename, edit=edit)
+
+    _refuses(target, "thumbnail.xyz")
+
+
+def test_a_core_part_with_its_override_removed_refuses(tmp_path):
+    """Slides carry an Override rather than a Default; removing it leaves no type."""
+
+    def rename(name):
+        return "ppt/slides/slide1.abc" if name == "ppt/slides/slide1.xml" else name
+
+    def edit(name, data):
+        if name == _CONTENT_TYPES:
+            return re.sub(rb'<Override PartName="/ppt/slides/slide1\.xml"[^>]*/>', b"", data)
+        if name == "ppt/_rels/presentation.xml.rels":
+            return data.replace(b"slides/slide1.xml", b"slides/slide1.abc")
+        return data
+
+    target = _rebuild(tmp_path / "core-undeclared.pptx", rename=rename, edit=edit)
+
+    _refuses(target, "slide1.abc")
+
+
+def test_the_refusal_names_every_unresolved_member(tmp_path):
+    def extra(outgoing):
+        outgoing.writestr("ppt/media/one.qqq", b"first")
+        outgoing.writestr("ppt/media/two.zzz", b"second")
+
+    target = _rebuild(tmp_path / "two-undeclared.pptx", extra=extra)
+
+    with pytest.raises(PackageLimitError) as excinfo:
+        Presentation(target)
+    assert "one.qqq" in str(excinfo.value)
+    assert "two.zzz" in str(excinfo.value)
+
+
+def test_the_refusal_states_a_remedy(tmp_path):
+    target = _rebuild(
+        tmp_path / "remedy.pptx",
+        extra=lambda z: z.writestr("ppt/media/orphan.qqq", b"x"),
+    )
+
+    with pytest.raises(PackageLimitError) as excinfo:
+        Presentation(target)
+    message = str(excinfo.value)
+    assert "Default" in message
+    assert "Override" in message
+    assert "re-save" in message
+
+
+def _retyped_thumbnail(target, new_leaf, *, declaration=None):
+    """Rename the referenced thumbnail, keeping the relationship pointed at it.
+
+    Uses a referenced part rather than an added one so these cases exercise content-type
+    resolution alone, independent of any rule about parts nothing points at.
+    """
+
+    def rename(name):
+        return "docProps/" + new_leaf if name == "docProps/thumbnail.jpeg" else name
+
+    def edit(name, data):
+        if name == "_rels/.rels":
+            return data.replace(b"thumbnail.jpeg", new_leaf.encode())
+        if name == _CONTENT_TYPES and declaration is not None:
+            return data.replace(b"</Types>", declaration + b"</Types>")
+        return data
+
+    return _rebuild(target, rename=rename, edit=edit)
+
+
+def test_a_member_resolved_by_a_default_opens(tmp_path):
+    """`.bin` is a declared Default in the minimal deck."""
+    target = _retyped_thumbnail(tmp_path / "declared-default.pptx", "thumbnail.bin")
+
+    assert len(Presentation(target).slides) == len(Presentation(_minimal_path()).slides)
+
+
+def test_a_member_resolved_only_by_an_override_opens(tmp_path):
+    """An extension nothing declares, rescued by an Override on the part's name."""
+    target = _retyped_thumbnail(
+        tmp_path / "declared-override.pptx",
+        "thumbnail.qqq",
+        declaration=b'<Override PartName="/docProps/thumbnail.qqq" ContentType="image/jpeg"/>',
+    )
+
+    Presentation(target)
+
+
+def test_extension_matching_ignores_case(tmp_path):
+    target = _retyped_thumbnail(tmp_path / "upper-extension.pptx", "thumbnail.BIN")
+
+    Presentation(target)
+
+
+def test_override_matching_ignores_case(tmp_path):
+    target = _retyped_thumbnail(
+        tmp_path / "override-case.pptx",
+        "thumbnail.qqq",
+        declaration=b'<Override PartName="/docProps/THUMBNAIL.QQQ" ContentType="image/jpeg"/>',
+    )
+
+    Presentation(target)
+
+
+def test_the_content_types_part_itself_never_triggers_the_refusal(tmp_path):
+    """It is not a part and carries no content type; no deck declares one for it."""
+    target = _rebuild(tmp_path / "untouched.pptx")
+
+    with zipfile.ZipFile(target) as archive:
+        assert _CONTENT_TYPES in archive.namelist()
+    Presentation(target)
+
+
+def test_every_corpus_fixture_still_resolves():
+    """A regression net: the rule must not refuse any deck the repo already ships."""
+    refused = []
+    for path in sorted(corpus.FIXTURES_DIR.rglob("*.pptx")):
+        try:
+            Presentation(path)
+        except PackageLimitError as exc:  # pragma: no cover - only on regression
+            if "no content type" in str(exc):
+                refused.append(path.name)
+        except PaperRefusal:
+            continue  # -- corrupt-by-construction fixtures refuse for their own reasons
+    assert refused == []

--- a/tests/paper/test_content_type_coverage.py
+++ b/tests/paper/test_content_type_coverage.py
@@ -61,12 +61,25 @@ def _refuses(target, fragment):
 
 
 def test_an_unreferenced_member_with_no_declared_type_refuses(tmp_path):
+    """The composition guard for deleting the unreachable-parts refusal.
+
+    An unreferenced part is no longer refused for being unreferenced. This one is still
+    refused, because it has no content type — the distinction PowerPoint draws, and the
+    reason the two changes had to land together.
+    """
     target = _rebuild(
         tmp_path / "orphan-undeclared.pptx",
         extra=lambda z: z.writestr("ppt/media/orphan.qqq", b"no content type declares this"),
     )
 
     _refuses(target, "orphan.qqq")
+    assert "unreachable" not in _refusal_message(target)
+
+
+def _refusal_message(target) -> str:
+    with pytest.raises(PackageLimitError) as excinfo:
+        Presentation(target)
+    return str(excinfo.value)
 
 
 def test_a_referenced_member_with_no_declared_type_refuses(tmp_path):

--- a/tests/paper/test_package_io_hardening.py
+++ b/tests/paper/test_package_io_hardening.py
@@ -102,14 +102,27 @@ def test_normal_open_refuses_a_missing_relationship_target(tmp_path):
         Presentation(target)
 
 
-def test_normal_open_refuses_an_unreachable_part(tmp_path):
+def test_normal_open_accepts_an_unreachable_part_and_drops_it_on_save(tmp_path):
+    """PowerPoint opens this package and drops the orphan on its own next save.
+
+    Refusing to open it would refuse a deck PowerPoint accepts, so `save()` matching that
+    behaviour is the whole of the contract. `.bin` is a declared Default here, so the part
+    has a content type; one without a declared type is refused, in
+    `test_content_type_coverage.py`.
+    """
     target = tmp_path / "unreachable.pptx"
     _rewrite_package(_minimal_path(), target, lambda _name, blob: blob)
     with zipfile.ZipFile(target, "a") as archive:
         archive.writestr("ppt/orphan.bin", b"would be dropped on save")
 
-    with pytest.raises(PackageLimitError, match="unreachable parts"):
-        Presentation(target)
+    presentation = Presentation(target)
+    assert len(presentation.slides) == len(Presentation(_minimal_path()).slides)
+
+    saved = tmp_path / "resaved.pptx"
+    presentation.save(saved)
+    with zipfile.ZipFile(saved) as archive:
+        assert "ppt/orphan.bin" not in archive.namelist()
+    Presentation(saved)
 
 
 def test_normal_open_refuses_duplicate_relationship_ids(tmp_path):

--- a/tests/paper/test_zipguard_structural.py
+++ b/tests/paper/test_zipguard_structural.py
@@ -262,7 +262,11 @@ def test_the_unmutated_archive_builder_output_is_accepted(tmp_path):
     """Guard the guard: each refusal above must come from its mutation, not from `_zip_bytes`."""
     target = tmp_path / "honest.pptx"
     target.write_bytes(
-        _zip_bytes(_member("[Content_Types].xml", _content_types()), _member("a.xml"))
+        _zip_bytes(
+            # -- an honest archive declares a content type for every part it carries
+            _member("[Content_Types].xml", _content_types(_OVERRIDE)),
+            _member("a.xml"),
+        )
     )
 
     _zipguard.preflight_zip(str(target))
@@ -283,13 +287,14 @@ def test_normal_open_refuses_structurally_ambiguous_archive(tmp_path, build, fra
 
 
 def test_zipguard_structural_refusal_population_is_pinned():
-    """`_zipguard.py` has 83 `raise PackageLimitError` sites, every one structural.
+    """`_zipguard.py` has 84 `raise PackageLimitError` sites, every one structural.
 
-    The twelve policy sites that enforced the six numeric resource ceilings are gone, and
-    one site was added for a package carrying bytes in front of its first member, a shape
-    PowerPoint refuses. Any movement from 83 means a structural or ambiguity refusal was
-    added or dropped, so a mismatch here is a prompt to check which.
+    The twelve policy sites that enforced the six numeric resource ceilings are gone. Two
+    sites were added, each for a shape PowerPoint refuses: a package carrying bytes in
+    front of its first member, and a package whose members do not all resolve to a
+    declared content type. Any movement from 84 means a structural or ambiguity refusal
+    was added or dropped, so a mismatch here is a prompt to check which.
     """
     source = Path(_zipguard.__file__).read_text(encoding="utf-8")
 
-    assert source.count("raise PackageLimitError") == 83
+    assert source.count("raise PackageLimitError") == 84


### PR DESCRIPTION
Stacked on #23. Three commits, two source files, +280/−26.

Replaces one load-time refusal with the one PowerPoint actually applies. Both halves had to land together — see the ordering note below.

## What changed

**Deleted:** the refusal for a package holding a part no relationship reaches. PowerPoint opens such a package and, on Save As, drops the part itself — 41 members in, 39 out on both decks tested. The refusal blocked files PowerPoint accepts in order to prevent a data loss PowerPoint performs, `save()` performs, and upstream performs.

**Added:** a refusal when any ZIP member resolves to no content type — no `Default` for its extension, no `Override` for its name. `_parse_content_types` already computed the declarations and `_validate_content_types` threw them away, so `[Content_Types].xml` was checked for internal consistency but never against the members present. The only enforcement was incidental: a bare `KeyError` from `_ContentTypeMap.__getitem__`, and only for parts relationship traversal reaches.

## Why both, and in this order

The deleted refusal was accidentally masking the missing one — an orphan part usually has an undeclared type too. Deleting it alone makes paper-pptx open a deck PowerPoint refuses; that was measured before writing any code. Phase 1 is purely additive and phase 2 purely subtractive, so no commit in this branch accepts an undeclared orphan.

## Evidence

Every expectation traces to opening the file in the PowerPoint application, not to inference. Neither stdlib `zipfile`, upstream python-pptx, nor LibreOffice enforces any of this — LibreOffice renders all the undeclared shapes to identical text.

| shape | PowerPoint | before | after |
|---|---|---|---|
| unreferenced part, type **declared** | opens, drops on re-save | refused | **opens** |
| unreferenced part, type undeclared | Repair | refused (wrong reason) | refused (named) |
| thumbnail, undeclared — never rendered | Repair | raw `KeyError` | refused (typed) |
| slide part, `Override` removed | Repair | raw `KeyError` | refused (typed) |
| displayed image, undeclared | Repair | raw `KeyError` | refused (typed) |

The rule is role-independent: PowerPoint refuses an undeclared part whether it renders it, must load it, or never touches it. So the check keys on physical membership, not on what the loader would otherwise read.

## Regression safety

- Ran the rule statically against **104 packages** in the repo — corpus fixtures, bundled templates, upstream test files — **zero** members fail to resolve.
- `tests/paper`: 927 passed, 1 skipped (916 before).
- `tests/opc` + `tests/parts` + `tests/test_package.py`: 307 passed, unmodified. The `KeyError` at `opc/package.py:606` is deliberately untouched — pinned verbatim by `tests/opc/test_package.py:598-604`.
- Re-probed every PowerPoint-verified deck from the earlier rounds; paper-pptx now matches PowerPoint on all of them.

## Notes for review

- **One test archive was corrected, not accommodated.** The synthetic happy-path builder emitted an empty `<Types>`, so its `a.xml` never had a content type. Its own docstring calls it the honest archive; it now declares one.
- **One fix outside this change's scope.** `patch_save`'s docstring references `|Presentation.save|`, which `docs/conf.py` never defines. CI runs `sphinx-build -W`, so the docs job is currently red on #23. Fixed here because this branch would otherwise inherit it — happy to move it if you'd rather it went in #23.
- The refusal uses `PackageLimitError` for consistency with every other `_zipguard` refusal. Whether that type suits a structural defect is C-1's question and is deliberately left alone.
- No corpus fixture was added; package-structure tests here build in `tmp_path` via `_rewrite_package`, which the existing test for this shape already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which `.pptx` files open at all (stricter on undeclared types, looser on orphan parts); behavior is well-tested but affects every package load path.
> 
> **Overview**
> **Package intake now matches PowerPoint on orphan parts and missing content types.**
> 
> `_zipguard` refuses any ZIP member that has no `Default` or `Override` in `[Content_Types].xml`, raising `PackageLimitError` at open with the member names and remediation hints. That replaces incidental `KeyError` lookups for relationship-reachable parts only.
> 
> The loader **no longer** refuses packages that contain relationship-unreachable parts. Decks with declared but unreferenced members open normally; `save()` drops those orphans like PowerPoint does.
> 
> README and user docs describe the split. Tests add `test_content_type_coverage.py`, flip unreachable-part behavior in `test_package_io_hardening.py`, and bump the pinned `_zipguard` refusal count to 84. A small `patch_save` Sphinx cross-ref fix is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f2968514eaa8a23bcc13a39b74e5241b9a4bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses packages when any ZIP member lacks a declared content type and accepts unreferenced parts that do. Previously we rejected packages with unreferenced parts and often crashed with KeyError for undeclared types; now `_zipguard` raises `PackageLimitError` naming the members, and declared-orphan parts open and are dropped on save.

- Enforcement runs in `_zipguard` before any part is constructed: compares `Default`/`Override` against every member, ignores case, and never applies to `[Content_Types].xml`.
- Removes the unreachable-part refusal in `opc.package`; a normal `save()` drops orphans.
- Migration: If you generate packages, ensure every member resolves via a `Default` or an `Override`, or re-save from PowerPoint.
- Tests/docs: adds `tests/paper/test_content_type_coverage.py`, flips the unreachable-part test to open-then-drop, bumps the `_zipguard` structural refusal count to 84, updates README/user docs, and fixes the `:meth:\`.Presentation.save\`` cross-ref.

<sup>Written for commit 43f2968514eaa8a23bcc13a39b74e5241b9a4bd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

