### PR TITLE
fix: accept ZIP directory entries instead of refusing them

### DIFF
--- a/src/pptx/_zipguard.py
+++ b/src/pptx/_zipguard.py
@@ -381,14 +381,20 @@ class GuardedZipReader:
 
     def __init__(self, zip_file: ZipFile):
         self._zip_file = zip_file
+        # -- every central-directory record, directory entries included: the physical-layout
+        # -- checks derive each member's boundary from the next record's offset, so they need
+        # -- the complete picture or a skipped record reads as an unexplained gap.
         self._infos = tuple(zip_file.infolist())
+        # -- the subset that can be an OPC part. A directory record carries no content and no
+        # -- part name can denote one, so it is ignored rather than treated as invalid input.
+        self._part_infos = tuple(i for i in self._infos if not _is_directory_entry(i))
         self._validate_metadata()
         self._parts = self._read_all_members()
 
     @property
     def order(self) -> Tuple[str, ...]:
         """Member names in central-directory order."""
-        return tuple(info.filename for info in self._infos)
+        return tuple(info.filename for info in self._part_infos)
 
     def read(self, name: str) -> bytes:
         """Return validated bytes for member `name`."""
@@ -408,7 +414,12 @@ class GuardedZipReader:
                 raise PackageLimitError(
                     f"ZIP member name {name!r} contains a noncanonical NUL suffix"
                 )
-            _validate_member_name(name)
+            # -- a directory record is not an OPC part, so the part-name rules below do not
+            # -- apply to it. It is still a physical record: the duplicate-name, offset,
+            # -- encryption and compression checks that follow cover it like any other.
+            directory_entry = _is_directory_entry(info)
+            if not directory_entry:
+                _validate_member_name(name)
 
             if name in seen_names:
                 raise PackageLimitError(f"ZIP contains duplicate member name {name!r}")
@@ -434,8 +445,8 @@ class GuardedZipReader:
                 raise PackageLimitError(
                     f"ZIP member {name!r} uses unsupported compression method {info.compress_type}"
                 )
-            if info.is_dir() or info.external_attr & 0x10:
-                raise PackageLimitError(f"ZIP member {name!r} is a directory entry")
+            if directory_entry:
+                continue
 
             unix_mode = (info.external_attr >> 16) & 0xFFFF
             file_type = stat.S_IFMT(unix_mode)
@@ -483,7 +494,7 @@ class GuardedZipReader:
         parts: Dict[str, bytes] = {}
         try:
             content_types_info = next(
-                (info for info in self._infos if info.filename == _CONTENT_TYPES_NAME),
+                (info for info in self._part_infos if info.filename == _CONTENT_TYPES_NAME),
                 None,
             )
             if content_types_info is not None:
@@ -495,11 +506,18 @@ class GuardedZipReader:
                 parts[content_types_info.filename] = content_types
                 self._validate_content_types(content_types)
 
-            for info in self._infos:
+            for info in self._part_infos:
                 if info is content_types_info:
                     continue
                 data_start = self._validate_local_header(info, boundaries[info.header_offset])
                 parts[info.filename] = self._inflate_member(info, data_start)
+
+            # -- a directory record yields no part, but its local header is still validated
+            # -- so the region it occupies cannot conceal undeclared bytes.
+            for info in self._infos:
+                if not _is_directory_entry(info):
+                    continue
+                self._validate_local_header(info, boundaries[info.header_offset])
         finally:
             if original_position is not None:
                 with suppress(AttributeError, OSError, TypeError, ValueError):
@@ -514,9 +532,13 @@ class GuardedZipReader:
         # -- PowerPoint refuses such a package whatever the part is for -- a slide, an image
         # -- it draws, or a thumbnail it never reads. Keys are normalized exactly as
         # -- `_parse_content_types` stored them.
+        #
+        # -- Iterate the part records, not every archive record: a directory record has no
+        # -- extension and no Override, so it resolves to no content type and would be
+        # -- refused here, even though PowerPoint opens packages that contain them.
         undeclared = sorted(
             info.filename
-            for info in self._infos
+            for info in self._part_infos
             if info.filename != _CONTENT_TYPES_NAME
             and ("/" + info.filename).casefold() not in overrides
             and _member_extension(info.filename) not in defaults
@@ -783,6 +805,22 @@ def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
             "[Content_Types].xml contains an unsupported declaration"
         )
     return defaults, overrides
+
+
+def _is_directory_entry(info: ZipInfo) -> bool:
+    """True for a ZIP directory record, which is never an OPC part.
+
+    A directory record carries no content and no part name can denote one, so a reader
+    ignores it rather than treating the package as invalid. Producers that emit them by
+    default include the ``zip`` CLI, ``shutil.make_archive`` and Java's
+    ``ZipOutputStream`` -- every "unzip, edit, rezip" pipeline passes through one.
+
+    The trailing slash is the whole test. A record carrying only the MS-DOS directory
+    attribute, with no slash, is deliberately NOT treated as a directory: such a name
+    denotes a file, and a package holding both a file ``ppt`` and members under ``ppt/``
+    contradicts itself. PowerPoint refuses that file, so admitting it would help nobody.
+    """
+    return info.is_dir()
 
 
 def _validate_member_name(name: str) -> None:

--- a/src/pptx/_zipguard.py
+++ b/src/pptx/_zipguard.py
@@ -819,8 +819,15 @@ def _is_directory_entry(info: ZipInfo) -> bool:
     attribute, with no slash, is deliberately NOT treated as a directory: such a name
     denotes a file, and a package holding both a file ``ppt`` and members under ``ppt/``
     contradicts itself. PowerPoint refuses that file, so admitting it would help nobody.
+
+    The empty-name guard keeps this callable before ``_validate_metadata`` runs: on Python
+    3.9 and 3.10 ``ZipInfo.is_dir`` reads ``filename[-1]`` and raises ``IndexError`` on an
+    empty name, which would escape as an untyped crash before the empty-name refusal fires.
+    An empty name is never a directory record, so returning False here defers it to
+    ``_validate_member_name``, which reports it as the ``PackageLimitError`` it is. On 3.11+
+    ``is_dir`` already returns False for an empty name, so this only aligns 3.9/3.10.
     """
-    return info.is_dir()
+    return bool(info.filename) and info.is_dir()
 
 
 def _validate_member_name(name: str) -> None:

--- a/tests/paper/test_package_round_trip.py
+++ b/tests/paper/test_package_round_trip.py
@@ -210,6 +210,79 @@ def test_package_past_the_compressed_and_binary_member_ceilings_opens(tmp_path):
     assert len(_guarded_open(target)) == 1
 
 
+# ------------------------------------------------------------------------ directory entries
+
+
+def _rezip_with_directory_entries(source, destination) -> int:
+    """Rewrite `source` the way an unzip-edit-rezip loop does; return the folder count.
+
+    The folder records are emitted *interleaved* with the members, ahead of the first member
+    in each directory, which is what `zip -r` and `shutil.make_archive` produce. Writing them
+    all at the front instead would leave every member's data region contiguous, and a reader
+    that mishandled them could still pass.
+    """
+    written = 0
+    with zipfile.ZipFile(source) as incoming, zipfile.ZipFile(
+        destination, "w", zipfile.ZIP_DEFLATED
+    ) as outgoing:
+        seen: set[str] = set()
+        for info in incoming.infolist():
+            folder = ""
+            for segment in info.filename.split("/")[:-1]:
+                folder += segment + "/"
+                if folder in seen:
+                    continue
+                seen.add(folder)
+                record = zipfile.ZipInfo(folder)
+                record.external_attr = (0o40755 << 16) | 0x10
+                outgoing.writestr(record, b"")
+                written += 1
+            outgoing.writestr(info.filename, incoming.read(info.filename))
+    return written
+
+
+def test_deck_rezipped_with_directory_entries_opens_and_round_trips(tmp_path):
+    """A ZIP directory record is not an OPC part, so it is ignored rather than refused.
+
+    PowerPoint opens such a package, so refusing it would reject decks the application
+    accepts. Every unzip-edit-rezip pipeline emits these records, which is the common way
+    a `.pptx` gets patched by hand.
+    """
+    original = tmp_path / "original.pptx"
+    _deck(2).save(str(original))
+    rezipped = tmp_path / "rezipped.pptx"
+    folder_count = _rezip_with_directory_entries(original, rezipped)
+    assert folder_count > 0, "fixture built no directory records"
+
+    reopened = Presentation(str(rezipped))
+
+    assert len(reopened.slides) == 2
+    saved = tmp_path / "saved.pptx"
+    reopened.save(str(saved))
+    with zipfile.ZipFile(saved) as archive:
+        names = archive.namelist()
+    # -- dropped on the way out, exactly as upstream and PowerPoint drop them
+    assert [name for name in names if name.endswith("/")] == []
+    assert len(Presentation(str(saved)).slides) == 2
+
+
+def test_directory_entries_do_not_trip_the_content_type_refusal(tmp_path):
+    """A folder record resolves to no content type, and must not be asked to.
+
+    It has no extension for a `Default` to match and no `Override` naming it. Checking
+    physical records rather than part records would refuse the package here instead.
+    """
+    original = tmp_path / "original.pptx"
+    _deck(1).save(str(original))
+    rezipped = tmp_path / "rezipped.pptx"
+    _rezip_with_directory_entries(original, rezipped)
+
+    partnames = _guarded_open(rezipped)
+
+    assert not [name for name in partnames if str(name).endswith("/")]
+    assert len(Presentation(str(rezipped)).slides) == 1
+
+
 # --------------------------------------------------------------------- guard against regrowth
 
 

--- a/tests/paper/test_zipguard_structural.py
+++ b/tests/paper/test_zipguard_structural.py
@@ -287,14 +287,16 @@ def test_normal_open_refuses_structurally_ambiguous_archive(tmp_path, build, fra
 
 
 def test_zipguard_structural_refusal_population_is_pinned():
-    """`_zipguard.py` has 84 `raise PackageLimitError` sites, every one structural.
+    """`_zipguard.py` has 83 `raise PackageLimitError` sites, every one structural.
 
     The twelve policy sites that enforced the six numeric resource ceilings are gone. Two
     sites were added, each for a shape PowerPoint refuses: a package carrying bytes in
     front of its first member, and a package whose members do not all resolve to a
-    declared content type. Any movement from 84 means a structural or ambiguity refusal
-    was added or dropped, so a mismatch here is a prompt to check which.
+    declared content type. One was removed: the directory-entry refusal, since a ZIP
+    directory record is not an OPC part and PowerPoint opens packages containing them.
+    Any movement from 83 means a structural or ambiguity refusal was added or dropped, so
+    a mismatch here is a prompt to check which.
     """
     source = Path(_zipguard.__file__).read_text(encoding="utf-8")
 
-    assert source.count("raise PackageLimitError") == 84
+    assert source.count("raise PackageLimitError") == 83

--- a/tests/paper/test_zipguard_structural.py
+++ b/tests/paper/test_zipguard_structural.py
@@ -185,6 +185,14 @@ _CASES = [
         id="metadata-nul-suffix-name",
     ),
     pytest.param(
+        # -- an empty member name. `_is_directory_entry` runs before `_validate_metadata`,
+        # -- and on Python 3.9/3.10 `ZipInfo.is_dir` reads `filename[-1]`, so an unguarded
+        # -- call raised IndexError there instead of this typed refusal.
+        lambda: _zip_bytes(_member("")),
+        "empty member name",
+        id="metadata-empty-member-name",
+    ),
+    pytest.param(
         lambda: _zip_bytes(_member("a.xml", flags=_FLAG_UTF8 | 0x0001)),
         "is encrypted",
         id="metadata-encrypted-member",


### PR DESCRIPTION
Stacked on #24.

## The bug

A ZIP directory record — a zero-byte member whose name ends in `/` — is not an OPC part; no part name can denote one. paper-pptx refused packages containing them, so **every deck produced by an unzip-edit-rezip loop was rejected**. `zip -r` and `shutil.make_archive` emit these records by default, which makes this the ordinary way a `.pptx` gets patched by hand.

PowerPoint opens such packages (the `directory_entries` shape, verified in the oracle ledger), and so does upstream python-pptx. Refusing them rejected decks the application accepts.

```
before   B_zip_cli.pptx        PackageLimitError: ZIP member name 'docProps/' is noncanonical
         C_make_archive.pptx   PackageLimitError: ZIP member name '_rels/' is noncanonical
after    both open, edit, save, and reopen
```

## Why the obvious fix doesn't work

Filtering the records out of `infolist()` relocates the failure rather than removing it. `_read_all_members` derives each member's boundary from the next record's offset, so a skipped record turns the bytes its local header occupies into an unexplained gap, and `"undeclared trailing data"` refuses the file instead. That filtering only appears to work against a fixture that writes every folder record ahead of the members — real producers interleave them.

## The change

Two roles were sharing one list, so they're separated:

- `_infos` — every central-directory record. Basis for the physical-layout checks, which need the complete picture.
- `_part_infos` — the subset that can be an OPC part. Drives name validation, member reading, `order`, and the content-type refusal.

Directory records still get their local header validated, so the region they occupy cannot conceal undeclared bytes (verified: splicing a payload into a `ppt/` record is still refused).

**#24 interaction:** the content-type refusal added there iterated `self._infos`, so a folder record — no extension for a `Default`, no `Override` naming it — would have been refused there instead. It now iterates `_part_infos`. `test_directory_entries_do_not_trip_the_content_type_refusal` pins this.

## Deliberately still refused

A member carrying only the MS-DOS directory attribute with no trailing slash is **not** treated as a directory. Such a name denotes a file, and a package holding both a file `ppt` and members under `ppt/` contradicts itself. PowerPoint refuses that shape; so do we.

## Verification

| check | result |
|---|---|
| PowerPoint, decks written from directory-entry inputs (`save` + `patch_save`) | open clean |
| `zip -r`, `shutil.make_archive`, hand-added records | open, edit, save, reopen |
| path traversal `../evil.xml`, `/evil.xml`, `ppt\evil.xml`, control chars, duplicate names | still refused |
| payload concealed in a directory record's region | still refused |
| `tests/paper` | 929 passed, 1 skipped |
| `ruff check` | clean |

Both new tests fail without the `src/` change.

Pinned refusal count 84 → 83: one refusal removed, with the reason recorded in the test's docstring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package intake in `_zipguard` (security-sensitive path); behavior is narrowed but boundary validation for directory records must stay correct to avoid accepting concealed data.
> 
> **Overview**
> **ZIP folder records** (names ending in `/`, as from `zip -r` or `shutil.make_archive`) are no longer rejected as invalid OPC parts. PowerPoint and upstream python-pptx accept them; refusing them broke common unzip–edit–rezip `.pptx` workflows.
> 
> `GuardedZipReader` now keeps **`_infos`** (all central-directory records, for boundary/layout checks) separate from **`_part_infos`** (records treated as OPC parts). Part-name validation, inflation, `order`, and undeclared content-type checks use `_part_infos` only. Directory entries still run through duplicate/offset/encryption checks and get **local headers validated** so hidden bytes in their regions remain refused.
> 
> Adds **`_is_directory_entry`** (trailing-slash `ZipInfo.is_dir()`, with an empty-name guard for Python 3.9/3.10). MS-DOS directory attribute without a trailing slash is still not treated as a directory.
> 
> New round-trip tests simulate interleaved folder records; structural test pins empty member names and updates the `PackageLimitError` count **84 → 83**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1d21c6eec1fc555d8686b361d5308101b2ed0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts ZIP directory entries and treats them as non-parts so unzip–rezip `.pptx` packages open and round‑trip. Previously we refused folder records (names ending with `/`); now we skip them for part rules while still validating their local headers to prevent hidden data.

- Split roles in `GuardedZipReader`: `_infos` = all central-directory records; `_part_infos` = records that can be OPC parts. Drive `order` (now omits directory entries), part-name validation, member reads, and content-type checks from `_part_infos`.
- Validate directory entries’ local headers; keep refusal for entries with only the MS‑DOS directory attribute and no trailing slash (contradictory file vs folder).
- Move undeclared content-type check to iterate `_part_infos` so directory entries don’t trigger false refusals; add tests for interleaved directory records and round‑trip behavior. Pinned structural refusal count 84 → 83.
- Guard empty member names in `_is_directory_entry` to avoid a crash on Python 3.9/3.10; they now raise the intended typed refusal.

<sup>Written for commit ff1d21c6eec1fc555d8686b361d5308101b2ed0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

