### PR TITLE
fix: retype the relationship refusals and name their remedy

### DIFF
--- a/src/pptx/opc/package.py
+++ b/src/pptx/opc/package.py
@@ -439,7 +439,7 @@ class _PackageLoader:
 
         def load_rels(source_partname: PackURI, rels: CT_Relationships):
             """Populate `xml_rels` dict by traversing relationships depth-first."""
-            from pptx.errors import PackageLimitError
+            from pptx.errors import UnsupportedStructureError
 
             xml_rels[source_partname] = rels
             visited_partnames.add(source_partname)
@@ -448,9 +448,23 @@ class _PackageLoader:
             rIds = [rel.rId for rel in rels.relationship_lst]
             duplicate_rIds = sorted({rId for rId in rIds if rIds.count(rId) > 1})
             if duplicate_rIds:
-                raise PackageLimitError(
-                    "relationship part for %s contains duplicate ids: %s"
-                    % (source_partname, ", ".join(duplicate_rIds))
+                # -- PowerPoint refuses a repeated relationship id whether or not the two
+                # -- declarations agree, so both cases are refused. Which one it is decides
+                # -- what the caller does about it, so the message says which.
+                targets = {
+                    rId: {rel.target_ref for rel in rels.relationship_lst if rel.rId == rId}
+                    for rId in duplicate_rIds
+                }
+                detail = (
+                    "they name different targets, so the id has no single meaning"
+                    if any(len(refs) > 1 for refs in targets.values())
+                    else "they name the same target, so one declaration is redundant"
+                )
+                raise UnsupportedStructureError(
+                    "relationship part for %s contains duplicate ids: %s; %s. Remove the"
+                    " extra declaration from that .rels part, or re-save the deck from"
+                    " PowerPoint"
+                    % (source_partname, ", ".join(duplicate_rIds), detail)
                 )
 
             # --- recursion stops when there are no unvisited partnames in rels ---
@@ -459,8 +473,10 @@ class _PackageLoader:
                     continue
                 target_partname = PackURI.from_rel_ref(base_uri, rel.target_ref)
                 if self._pkg_file is not None and target_partname not in self._package_reader:
-                    raise PackageLimitError(
-                        "relationship %s from %s targets missing part %s"
+                    raise UnsupportedStructureError(
+                        "relationship %s from %s targets missing part %s; the package is"
+                        " incomplete. Recover the missing part, or re-save the deck from"
+                        " PowerPoint"
                         % (rel.rId, source_partname, target_partname)
                     )
                 if target_partname in visited_partnames:

--- a/src/pptx/opc/package.py
+++ b/src/pptx/opc/package.py
@@ -455,16 +455,25 @@ class _PackageLoader:
                     rId: {rel.target_ref for rel in rels.relationship_lst if rel.rId == rId}
                     for rId in duplicate_rIds
                 }
-                detail = (
-                    "they name different targets, so the id has no single meaning"
-                    if any(len(refs) > 1 for refs in targets.values())
-                    else "they name the same target, so one declaration is redundant"
-                )
+                # -- the remedy has to match the diagnosis. Redundant declarations name the
+                # -- same target, so removing either restores a single meaning. Conflicting
+                # -- declarations name different targets, so there is no disposable "extra":
+                # -- the caller has to decide which target was intended and remove the other.
+                if any(len(refs) > 1 for refs in targets.values()):
+                    detail = "they name different targets, so the id has no single meaning"
+                    remedy = (
+                        "Decide which target is correct and remove the other declaration from"
+                        " that .rels part, or re-save the deck from PowerPoint"
+                    )
+                else:
+                    detail = "they name the same target, so one declaration is redundant"
+                    remedy = (
+                        "Remove the extra declaration from that .rels part, or re-save the deck"
+                        " from PowerPoint"
+                    )
                 raise UnsupportedStructureError(
-                    "relationship part for %s contains duplicate ids: %s; %s. Remove the"
-                    " extra declaration from that .rels part, or re-save the deck from"
-                    " PowerPoint"
-                    % (source_partname, ", ".join(duplicate_rIds), detail)
+                    "relationship part for %s contains duplicate ids: %s; %s. %s"
+                    % (source_partname, ", ".join(duplicate_rIds), detail, remedy)
                 )
 
             # --- recursion stops when there are no unvisited partnames in rels ---

--- a/tests/paper/test_package_io_hardening.py
+++ b/tests/paper/test_package_io_hardening.py
@@ -166,13 +166,19 @@ def test_duplicate_relationship_id_message_distinguishes_redundant_from_conflict
     """
     redundant = tmp_path / "redundant.pptx"
     _rewrite_package(_minimal_path(), redundant, _duplicate_first_rel(retarget=False))
-    with pytest.raises(UnsupportedStructureError, match="one declaration is redundant"):
+    with pytest.raises(UnsupportedStructureError, match="one declaration is redundant") as excinfo:
         Presentation(redundant)
+    # -- the two declarations are identical, so removing either restores a single meaning
+    assert "Remove the extra declaration" in str(excinfo.value)
 
     conflicting = tmp_path / "conflicting.pptx"
     _rewrite_package(_minimal_path(), conflicting, _duplicate_first_rel(retarget=True))
-    with pytest.raises(UnsupportedStructureError, match="no single meaning"):
+    with pytest.raises(UnsupportedStructureError, match="no single meaning") as excinfo:
         Presentation(conflicting)
+    # -- with different targets there is no disposable "extra"; the caller must choose which
+    # -- target was intended, so the remedy must not tell them to drop "the extra" one
+    assert "remove the other declaration" in str(excinfo.value)
+    assert "Remove the extra declaration" not in str(excinfo.value)
 
 
 def test_relationship_refusals_name_a_remedy(tmp_path):

--- a/tests/paper/test_package_io_hardening.py
+++ b/tests/paper/test_package_io_hardening.py
@@ -12,7 +12,7 @@ import pytest
 from lxml import etree
 
 from pptx import Presentation
-from pptx.errors import PackageLimitError, PaperRefusal
+from pptx.errors import PackageLimitError, PaperRefusal, UnsupportedStructureError
 from pptx.exc import PackageNotFoundError
 from pptx.opc import serialized
 
@@ -98,7 +98,7 @@ def test_normal_open_refuses_a_missing_relationship_target(tmp_path):
 
     _rewrite_package(_minimal_path(), target, transform)
 
-    with pytest.raises(PackageLimitError, match="targets missing part"):
+    with pytest.raises(UnsupportedStructureError, match="targets missing part"):
         Presentation(target)
 
 
@@ -137,8 +137,65 @@ def test_normal_open_refuses_duplicate_relationship_ids(tmp_path):
 
     _rewrite_package(_minimal_path(), target, transform)
 
-    with pytest.raises(PackageLimitError, match="duplicate ids"):
+    with pytest.raises(UnsupportedStructureError, match="duplicate ids"):
         Presentation(target)
+
+
+def _duplicate_first_rel(retarget: bool):
+    """Return a transform duplicating the first relationship, optionally to a new target."""
+
+    def transform(name, blob):
+        if name != "_rels/.rels":
+            return blob
+        root = etree.fromstring(blob)
+        clone = etree.fromstring(etree.tostring(root[0]))
+        if retarget:
+            clone.set("Target", "docProps/core.xml")
+        root.append(clone)
+        return etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
+
+    return transform
+
+
+def test_duplicate_relationship_id_message_distinguishes_redundant_from_conflicting(tmp_path):
+    """Both are refused -- PowerPoint refuses either -- but the repair differs.
+
+    Two declarations naming the same target are redundant: delete one and the meaning is
+    unchanged. Two naming different targets leave the id with no single meaning, so the
+    caller has to decide which was intended. The message says which it found.
+    """
+    redundant = tmp_path / "redundant.pptx"
+    _rewrite_package(_minimal_path(), redundant, _duplicate_first_rel(retarget=False))
+    with pytest.raises(UnsupportedStructureError, match="one declaration is redundant"):
+        Presentation(redundant)
+
+    conflicting = tmp_path / "conflicting.pptx"
+    _rewrite_package(_minimal_path(), conflicting, _duplicate_first_rel(retarget=True))
+    with pytest.raises(UnsupportedStructureError, match="no single meaning"):
+        Presentation(conflicting)
+
+
+def test_relationship_refusals_name_a_remedy(tmp_path):
+    """A refusal exists so a caller can repair the package without reading library code.
+
+    Both refuse input PowerPoint also refuses, so the caller's next step is the whole
+    value of the message.
+    """
+    duplicate = tmp_path / "dup.pptx"
+    _rewrite_package(_minimal_path(), duplicate, _duplicate_first_rel(retarget=False))
+    with pytest.raises(UnsupportedStructureError, match="Remove the extra declaration"):
+        Presentation(duplicate)
+
+    missing = tmp_path / "missing.pptx"
+
+    def drop_target(name, blob):
+        if name == "_rels/.rels":
+            return blob.replace(b"ppt/presentation.xml", b"ppt/missing-part.xml")
+        return blob
+
+    _rewrite_package(_minimal_path(), missing, drop_target)
+    with pytest.raises(UnsupportedStructureError, match="Recover the missing part"):
+        Presentation(missing)
 
 
 def test_path_save_failure_preserves_existing_file_and_mode(tmp_path, monkeypatch):


### PR DESCRIPTION
Stacked on #25. Closes C-1 and C-2 from `atomic-save-io-regressions.md` — the last two items outstanding from that document and `PROPOSAL-over-strict-input-guards.md`.

## Measured first

C-1/C-2 were argued from the specs alone, so the three shapes went to PowerPoint before anything changed. **All three get the Repair prompt**, and a plain member-for-member rebuild of the same deck opens — so the `zipfile` rebuild the fixtures pass through is not what PowerPoint objects to.

| shape | upstream python-pptx | paper-pptx | **PowerPoint** |
|---|---|---|---|
| `rebuilt_only` (confound control) | opens | opens | **opens** |
| `dangling_relationship` | `KeyError` | refused | **REPAIR** |
| `duplicate_rel_ids` (same target) | **opens** | refused | **REPAIR** |
| `conflicting_rel_ids` (different targets) | **opens** | refused | **REPAIR** |

`duplicate_rel_ids` is the load-bearing row. Nothing about that package is ambiguous — both declarations name the same target — and upstream opens it showing correct content. Reasoning from upstream alone would have deleted a guard PowerPoint proves is protecting users. **So both refusals stay; only their class and wording change.**

## C-1 — exception class

`PackageLimitError` is documented as *"the package archive is ambiguous or unsafe to expand"*. A dangling relationship and a repeated rId are defects in relationship XML, not in the archive. Both now raise `UnsupportedStructureError` — *"structure this API cannot operate on safely"*.

Blast radius is low: both derive from `PaperRefusal`, which `errors.py` documents as the intended catch point, so callers following the documented pattern are unaffected. Two existing tests asserted the leaf class and move with it; they match on `"targets missing part"` and `"duplicate ids"`, substrings that survive.

## C-2 — remedy

Both messages named the problem and stopped. Now:

```
relationship rId8 from /ppt/presentation.xml targets missing part /ppt/slides/slide2.xml;
the package is incomplete. Recover the missing part, or re-save the deck from PowerPoint

relationship part for /ppt/presentation.xml contains duplicate ids: rId1; they name the
same target, so one declaration is redundant. Remove the extra declaration from that
.rels part, or re-save the deck from PowerPoint
```

## The duplicate-id cases are no longer reported identically

Both were refused with the same `"contains duplicate ids"` text. Both are still refused, but the repair differs and the message now says which case it found:

- **same target** — redundant; delete either declaration and the meaning is unchanged
- **different targets** — the id has no single meaning; the caller has to decide which was intended

## Verification

- 931 passed, 1 skipped; `ruff check` clean
- Both new tests pin the redundant/conflicting split and the presence of a remedy in each message
- Verified against the four PowerPoint fixtures directly: correct class, correct discrimination

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change at load time with the same refusal policy; callers that catch PackageLimitError specifically should catch UnsupportedStructureError or PaperRefusal instead.
> 
> **Overview**
> Relationship-load failures during package open now raise **`UnsupportedStructureError`** instead of **`PackageLimitError`**, matching relationship/XML defects rather than archive expansion limits. **Refusal behavior is unchanged** (still rejects what PowerPoint would repair).
> 
> **Duplicate relationship ids** still block open, but the error text now distinguishes **redundant** duplicates (same target → remove the extra declaration) from **conflicting** ones (different targets → pick the correct target and remove the other). **Dangling internal relationships** to missing parts get a clearer message that the package is incomplete, with guidance to recover the part or re-save from PowerPoint.
> 
> Tests were updated for the new exception type and add coverage for the redundant/conflicting split and remedy wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a65340f092b81f6f4008315fd0f23d4fbb5902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retypes relationship-load refusals to `UnsupportedStructureError` and adds concrete repair guidance. Duplicate rIds now distinguish redundant (same target) vs conflicting (different targets), and each message names the correct remedy; refusal behavior is unchanged and matches PowerPoint.

- Old vs new: previously raised `PackageLimitError` with problem-only text; now raises `UnsupportedStructureError` with a remedy and splits duplicate rIds into redundant vs conflicting.
- Migration: if code catches `PackageLimitError` for these cases, update to catch `UnsupportedStructureError` or `PaperRefusal`.
- Messages: missing part — “Recover the missing part, or re-save the deck from PowerPoint”; redundant duplicate — “Remove the extra declaration from that .rels part…”; conflicting duplicate — “Decide which target is correct and remove the other declaration from that .rels part…”.
- Scope/tests: `src/pptx/opc/package.py`; tests in `tests/paper/test_package_io_hardening.py` assert the new exception type, redundant/conflicting split, and remedy wording.

<sup>Written for commit a4a65340f092b81f6f4008315fd0f23d4fbb5902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

