### PR TITLE
feat: resolve the bullet's typeface and size, and diff bullet changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,12 @@ until you diff it yourself.
 **A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent
 slide ID, so a reorder reports as a *move* rather than a delete-plus-add, and
 reports shape, text, chart-data, image, and notes changes within matched
-slides. `detail="full"` adds per-run effective-value shifts, which lets a
-pipeline compare an operation's report against what actually changed in the
-saved file.
+slides. `detail="full"` adds per-run effective-value shifts and per-paragraph
+bullet shifts, which lets a pipeline compare an operation's report against what
+actually changed in the saved file. Bullets need their own facet because they
+live only in formatting: a list losing its bullets changes no text and no field
+marker, so without it the within-slide report comes back empty while the slide
+visibly loses every glyph.
 
 **Byte-minimal saves and a package-level oracle.** A stock save rewrites every
 ZIP member, so even a no-op looks like total churn. `pptx.package.patch_save()`
@@ -523,11 +526,11 @@ path of this package. Known gaps, honestly:
   bullet's kind, typeface, and size, but not its color. `a:buClr` needs the
   theme-color walk, and `BulletFormat` can neither read nor write a bullet
   color, so resolving it would add capability rather than close a gap.
-- **The deck diff does not report bullets.** `diff_decks` compares text and
-  field markers, not paragraph formatting, so a list changing from bulleted to
-  numbered — or a template losing its bullets across a rebind or compose —
-  produces no diff entry. That would be a new diff dimension rather than a new
-  field on an existing one.
+- **Bullet diffing needs `detail="full"`, and skips table cells.** `bullet_shifts`
+  is resolver-backed, so it only populates at full detail and only covers the
+  paragraphs `effective_paragraph_format` supports — table-cell paragraphs are
+  skipped rather than guessed at. Paragraphs whose text repeats within one shape
+  are skipped too, since content is half their identity across two decks.
 
 Deliberate non-goals: no rendering or layout-geometry computation (appearance
 verification belongs to a harness, not this library), no SmartArt authoring

--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ hacks** below — that API writes genuine bullet markup onto a paragraph, this
 one reports the bullet the deck renders whether or not the paragraph sets
 one.
 
+It reports the bullet's typeface and size too, each resolved on its own chain
+because the schema inherits them separately from the glyph. That matters more
+than it sounds: branded templates routinely use a symbol font, where the glyph
+is a private-use codepoint that draws as a filled square in Wingdings and as
+an empty box in anything else. Reporting the typeface is what lets a caller
+reproduce a bullet from the resolver's answer alone.
+
+```python
+fmt = effective_paragraph_format(paragraph)
+fmt.bullet.char           # e.g. ''  — meaningless on its own
+fmt.bullet_font.value     # 'Wingdings'    — what makes it a filled square
+fmt.bullet_size.value     # 0.75           — or BULLET_FOLLOWS_TEXT
+```
+
 **Visibility-complete text inspection.** Iterating top-level shapes misses text
 inside nested groups and table cells, and `shape.text` flattens slide-number
 fields and line breaks into plain characters. `pptx.inspect.inspect_text()`
@@ -505,11 +519,10 @@ path of this package. Known gaps, honestly:
 - **Deck diff assumes lineage.** `diff_decks` matches slides by permanent ID,
   which serves decks derived from a common ancestor (v4 saved from v3);
   matching independently-authored decks is out of scope today.
-- **Bullet typeface and size are not resolved.**
-  `effective_paragraph_format()` reports which bullet renders, but not the
-  typeface it renders in or the size it renders at: `a:buFont` and `a:buSzPct`
-  sit outside the bullet choice group and inherit on their own chains, so each
-  needs its own walk. Strictly additive when it lands.
+- **Bullet color is not resolved.** `effective_paragraph_format()` reports a
+  bullet's kind, typeface, and size, but not its color. `a:buClr` needs the
+  theme-color walk, and `BulletFormat` can neither read nor write a bullet
+  color, so resolving it would add capability rather than close a gap.
 - **The deck diff does not report bullets.** `diff_decks` compares text and
   field markers, not paragraph formatting, so a list changing from bulleted to
   numbered — or a template losing its bullets across a rebind or compose —

--- a/docs/api/diff.rst
+++ b/docs/api/diff.rst
@@ -6,10 +6,13 @@ Deck diff (``pptx.diff``)
 *paper-pptx addition.* :func:`diff_decks` compares two decks and returns a typed report. It lists
 slides added, removed, or **moved** (matched by permanent slide id, so a reorder is reported as a
 move rather than delete-plus-add) and the shape, text, chart-data, image, and notes changes within
-matched slides. At ``detail="full"`` it also reports per-run effective-value shifts via the
-resolver. Schema version 2 also includes ``package_changes``, an authoritative semantic diff of
-every serialized package member. That package-level list prevents metadata, relationship,
-ordering, field, crop, or media changes from disappearing when no specialized slide facet applies.
+matched slides. At ``detail="full"`` it also reports per-run effective-value shifts and
+per-paragraph **bullet shifts** via the resolver. Bullets live only in formatting, so a list losing
+its bullets changes no text and no field marker: without that facet the within-slide report is empty
+while the slide visibly loses every glyph. The report also includes ``package_changes``, an
+authoritative semantic diff of every serialized package member. That package-level list prevents
+metadata, relationship, ordering, field, crop, or media changes from disappearing when no
+specialized slide facet applies.
 
 Contract tests compare operation reports with ``diff_decks(input, output)`` for representative
 import, rebind, and refresh workflows.
@@ -27,6 +30,11 @@ Independently built decks can reuse the same numeric ids and are outside that ma
    :member-order: bysource
 
 .. autoclass:: SlideChange()
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
+.. autoclass:: BulletShift()
    :members:
    :undoc-members:
    :member-order: bysource

--- a/docs/api/inspect.rst
+++ b/docs/api/inspect.rst
@@ -29,6 +29,8 @@ Functions
 Resolved values and provenance
 -------------------------------
 
+.. autodata:: BULLET_FOLLOWS_TEXT
+
 .. autoclass:: EffectiveValue()
    :members:
    :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -394,6 +394,8 @@ rst_epilog = """
 
 .. |EffectiveBullet| replace:: :class:`.EffectiveBullet`
 
+.. |BULLET_FOLLOWS_TEXT| replace:: :data:`.BULLET_FOLLOWS_TEXT`
+
 .. |EffectiveParagraphFormat| replace:: :class:`.EffectiveParagraphFormat`
 
 .. |EffectiveShapeFormat| replace:: :class:`.EffectiveShapeFormat`

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -97,8 +97,18 @@ character bullet, or the numbering scheme and starting number for a numbered one
 that read like absences are in fact resolved: a template that explicitly sets *no bullet* resolves
 to ``"none"``, attributed to the rung that set it, and a chain with no bullet anywhere also resolves
 to ``"none"``, through a closing ``rendering default`` provenance step. A paragraph inheriting the
-master's ``•`` is therefore distinguishable from one that renders nothing. The enclosing
-``.to_dict()`` payload is version 2 of ``paper-effective-paragraph-format``. ``"picture"`` is
+master's ``•`` is therefore distinguishable from one that renders nothing.
+
+The bullet's **typeface** and **size** arrive as two further values, ``bullet_font`` and
+``bullet_size``. They are separate XSD choice groups that inherit on their own chains, so each
+carries its own provenance: a paragraph can take its glyph from the master and its size from the
+layout. The typeface matters more than it sounds — branded templates routinely use a symbol font,
+where the glyph is a private-use codepoint that renders as a filled square in Wingdings and as an
+empty box in anything else. Reporting both means a caller can reproduce a bullet from the payload
+alone. Where the schema says to defer to the run's own text (``a:buFontTx``, ``a:buSzTx``), or where
+no rung specifies anything, the value is |BULLET_FOLLOWS_TEXT| and ``resolved`` is still true. A
+typeface naming a theme token such as ``+mj-lt`` resolves through the master's font scheme. The
+enclosing ``.to_dict()`` payload is version 3 of ``paper-effective-paragraph-format``. ``"picture"`` is
 reported on read only; there is no picture-bullet writer. Writing bullets is a separate job, done
 with the |BulletFormat| authoring API described under **Edit one deck** below, which reads and
 writes the paragraph's own markup.

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -26,9 +26,50 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 SCHEMA_NAME = "paper-deck-diff"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3  # -- was 2: bullet_shifts added
 
 _DETAIL_LEVELS = ("structure", "text", "full")
+
+
+@dataclass(frozen=True)
+class BulletShift:
+    """One paragraph whose resolved bullet changed between the two decks.
+
+    Bullets live only in formatting, so a list losing its bullets changes no text and no
+    field marker: `text_changes` stays empty while the slide visibly loses every glyph.
+    This is the facet that reports it.
+
+    Paragraphs are identified by (shape_id, paragraph text) rather than by index, matching
+    `pptx.rebind._resolution_state(align_by_content=True)`: inserting a paragraph shifts
+    every later index and would otherwise pair unrelated paragraphs. Paragraphs whose text
+    repeats within their shape are skipped rather than guessed at.
+
+    Fields:
+
+    * ``part`` -- partname of the slide the paragraph lives on.
+    * ``shape_id`` -- id of the shape containing the paragraph.
+    * ``paragraph_index`` -- 0-based paragraph index within that shape, for legibility.
+    * ``text`` -- the paragraph's text, which is also half its identity.
+    * ``before`` / ``after`` -- the resolved ``bullet``, ``bullet_font`` and ``bullet_size``
+      payloads from :func:`pptx.inspect.effective_paragraph_format` on each side.
+    """
+
+    part: str
+    shape_id: int
+    paragraph_index: int
+    text: str
+    before: dict
+    after: dict
+
+    def to_dict(self) -> dict:
+        return {
+            "part": self.part,
+            "shape_id": self.shape_id,
+            "paragraph_index": self.paragraph_index,
+            "text": self.text,
+            "before": self.before,
+            "after": self.after,
+        }
 
 
 @dataclass(frozen=True)
@@ -69,6 +110,7 @@ class SlideChange:
     text_changes: Tuple[dict, ...] = ()
     notes_change: Optional[dict] = None
     effective_shifts: tuple = ()
+    bullet_shifts: tuple = ()
 
     @property
     def is_empty(self) -> bool:
@@ -81,6 +123,7 @@ class SlideChange:
             or self.text_changes
             or self.notes_change
             or self.effective_shifts
+            or self.bullet_shifts
         )
 
     def to_dict(self) -> dict:
@@ -101,6 +144,8 @@ class SlideChange:
             payload["notes_change"] = self.notes_change
         if self.effective_shifts:
             payload["effective_shifts"] = [s.to_dict() for s in self.effective_shifts]
+        if self.bullet_shifts:
+            payload["bullet_shifts"] = [s.to_dict() for s in self.bullet_shifts]
         return payload
 
 
@@ -447,12 +492,16 @@ def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
             notes_change = {"before": notes_a, "after": notes_b}
 
     effective_shifts: tuple = ()
+    bullet_shifts: tuple = ()
     if detail == "full":
         from pptx.rebind import _resolution_state, _shifts_between
 
         effective_shifts = _shifts_between(
             _resolution_state(slide_a, align_by_content=True),
             _resolution_state(slide_b, align_by_content=True),
+        )
+        bullet_shifts = _bullet_shifts_between(
+            _bullet_state(slide_a), _bullet_state(slide_b)
         )
 
     return SlideChange(
@@ -465,6 +514,7 @@ def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
         text_changes=tuple(text_changes),
         notes_change=notes_change,
         effective_shifts=effective_shifts,
+        bullet_shifts=bullet_shifts,
     )
 
 
@@ -625,6 +675,80 @@ def _field_markers(block) -> tuple:
         else:
             offset += len(run.text)
     return tuple(markers)
+
+
+def _iter_text_shapes(shapes):
+    """Yield every shape carrying a text frame, descending into groups."""
+    for shape in shapes:
+        if getattr(shape, "has_text_frame", False):
+            yield shape
+        nested = getattr(shape, "shapes", None)
+        if nested is not None:
+            for inner in _iter_text_shapes(nested):
+                yield inner
+
+
+def _bullet_state(slide) -> dict:
+    """(comparable bullet values, payload) per paragraph, keyed (shape_id, paragraph text).
+
+    Content-keyed for the same reason `pptx.rebind._resolution_state(align_by_content=True)`
+    is: a paragraph inserted above shifts every later index, and index keys would then pair
+    unrelated paragraphs and report bullet changes that never happened. Paragraphs whose text
+    repeats within their shape carry no unique identity and are skipped rather than guessed at.
+
+    Paragraphs the resolver refuses -- table cells, which are not `p:sp` -- are skipped too. A
+    refusal here is a scope boundary, not a diff failure.
+    """
+    from pptx.errors import UnsupportedStructureError
+    from pptx.inspect import effective_paragraph_format
+
+    state: dict = {}
+    partname = str(slide.part.partname)
+    for shape in _iter_text_shapes(slide.shapes):
+        paragraphs = list(shape.text_frame.paragraphs)
+        texts = [paragraph.text for paragraph in paragraphs]
+        for index, paragraph in enumerate(paragraphs):
+            text = texts[index]
+            if not text or texts.count(text) != 1:
+                continue
+            try:
+                fmt = effective_paragraph_format(paragraph)
+            except UnsupportedStructureError:
+                continue
+            values = (
+                fmt.bullet.type,
+                fmt.bullet.char,
+                fmt.bullet.number_scheme,
+                fmt.bullet.start_at,
+                fmt.bullet_font.value,
+                fmt.bullet_size.value,
+            )
+            payload = {
+                "bullet": fmt.bullet.to_dict(),
+                "bullet_font": fmt.bullet_font.to_dict(),
+                "bullet_size": fmt.bullet_size.to_dict(),
+            }
+            state[(shape.shape_id, text)] = (values, text, partname, payload, index)
+    return state
+
+
+def _bullet_shifts_between(before_state, after_state) -> "Tuple[BulletShift, ...]":
+    shifts = []
+    for key in sorted(set(before_state) & set(after_state), key=lambda k: (k[0], k[1])):
+        before_values, text, partname, before_payload, index = before_state[key]
+        after_values, _, _, after_payload, _ = after_state[key]
+        if before_values != after_values:
+            shifts.append(
+                BulletShift(
+                    part=partname,
+                    shape_id=key[0],
+                    paragraph_index=index,
+                    text=text,
+                    before=before_payload,
+                    after=after_payload,
+                )
+            )
+    return tuple(shifts)
 
 
 def _notes_text(slide) -> "Optional[str]":

--- a/src/pptx/inspect.py
+++ b/src/pptx/inspect.py
@@ -41,6 +41,7 @@ from pptx.errors import UnsupportedStructureError
 from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 from pptx.oxml import parse_xml
 from pptx.oxml.ns import qn
+from pptx.oxml.simpletypes import ST_TextBulletSizePercent
 from pptx.oxml.xmlchemy import OxmlElement
 from pptx.util import Centipoints, Length
 
@@ -50,6 +51,12 @@ if TYPE_CHECKING:
 
 SCHEMA_NAME = "paper-text-inspection"
 SCHEMA_VERSION = 2  # -- visibility-complete traversal, container/blind fields
+
+#: Resolved value of a bullet typeface or size that defers to the run's own text, whether an
+#: `a:buFontTx` / `a:buSzTx` said so explicitly or the whole chain went silent. A sentinel
+#: rather than |None|, because "follow the text" is an answer: it renders predictably, and
+#: |None| is reserved for values the resolver could not determine.
+BULLET_FOLLOWS_TEXT = "follow text"
 
 _TITLE_FAMILY = frozenset([PP_PLACEHOLDER.TITLE, PP_PLACEHOLDER.CENTER_TITLE])
 _BODY_FAMILY = frozenset(
@@ -293,26 +300,34 @@ class EffectiveParagraphFormat:
     alignment: EffectiveValue  #: ECMA algn token, e.g. "l", "ctr", "r", "just"
     line_spacing: EffectiveValue  #: float lines (1.0 = single) or EMU |Length| for points
     bullet: EffectiveBullet  #: the bullet that renders, resolved through the same chain
+    bullet_font: EffectiveValue  #: bullet typeface, or |BULLET_FOLLOWS_TEXT|
+    bullet_size: EffectiveValue  #: fraction of text size, |Length| for points, or follows text
 
     def to_dict(self) -> dict:
         return {
             "schema": "paper-effective-paragraph-format",
-            "version": 2,  # -- bullet added
+            "version": 3,  # -- was 2: bullet_font/bullet_size added
             "alignment": self.alignment.to_dict(),
             "line_spacing": self.line_spacing.to_dict(),
             "bullet": self.bullet.to_dict(),
+            "bullet_font": self.bullet_font.to_dict(),
+            "bullet_size": self.bullet_size.to_dict(),
         }
 
 
 def effective_paragraph_format(paragraph) -> EffectiveParagraphFormat:
-    """Return effective alignment/line-spacing/bullet for `paragraph`, with provenance.
+    """Return effective alignment, line spacing, and bullet for `paragraph`, with provenance.
 
     Same inheritance walk as `effective_font`, over paragraph-level properties: the
     paragraph's own `a:pPr`, the shape's `lstStyle` level entry, the placeholder chain (or
     the presentation's `defaultTextStyle`). Exhaustion resolves rather than reporting
     unresolved: to the ECMA-376 schema default for alignment (left), and to the rendering
-    conventions for line spacing (single) and bullet (no bullet), which the schema does not
-    define.
+    conventions for line spacing (single), bullet (no bullet), and bullet typeface/size
+    (follow the text), none of which the schema defines.
+
+    The bullet's kind, typeface, and size are three separate XSD choice groups that inherit
+    independently, so each is walked on its own and carries its own provenance. A paragraph
+    can take its `buChar` from the master and its `buSzPct` from the layout.
     """
     p = paragraph._p
     txBody = p.getparent()
@@ -341,6 +356,8 @@ def effective_paragraph_format(paragraph) -> EffectiveParagraphFormat:
         alignment=resolver.resolve_alignment(chain),
         line_spacing=resolver.resolve_line_spacing(chain),
         bullet=resolver.resolve_bullet(chain),
+        bullet_font=resolver.resolve_bullet_font(chain),
+        bullet_size=resolver.resolve_bullet_size(chain),
     )
 
 
@@ -1071,6 +1088,103 @@ class _FontResolver(object):
             ProvenanceStep("rendering default", None, "no bullet renders by default", True)
         )
         return EffectiveBullet("none", None, None, None, True, tuple(steps))
+
+    def resolve_bullet_font(self, chain) -> EffectiveValue:
+        """Resolve the `EG_TextBulletTypeface` choice over a paragraph chain.
+
+        Inherits independently of the bullet kind, so it gets its own walk: one rung can supply
+        the typeface while another supplied the bullet. `a:buFontTx` is a positive answer
+        meaning "draw the bullet in the text's own typeface", not a miss. No ECMA default
+        exists, and with neither member present PowerPoint follows the text, so exhaustion
+        resolves to `BULLET_FOLLOWS_TEXT` rather than reporting unresolved.
+        """
+        steps = []
+        for label, partname, pPr in chain:
+            if pPr is not None and pPr.find(qn("a:buFontTx")) is not None:
+                steps.append(ProvenanceStep(label, partname, "buFontTx", True))
+                return EffectiveValue(BULLET_FOLLOWS_TEXT, None, True, tuple(steps))
+            buFont = pPr.find(qn("a:buFont")) if pPr is not None else None
+            if buFont is None:
+                steps.append(
+                    ProvenanceStep(label, partname, self._absence(pPr, "no bullet font"), False)
+                )
+                continue
+            typeface = buFont.get("typeface")  # -- raw: the descriptor raises when absent
+            if not typeface:
+                steps.append(ProvenanceStep(label, partname, "buFont with no typeface", False))
+                return EffectiveValue(None, None, False, tuple(steps))
+            if typeface.startswith("+"):
+                steps.append(
+                    ProvenanceStep(
+                        label,
+                        partname,
+                        'buFont typeface="%s" (theme reference)' % typeface,
+                        False,
+                    )
+                )
+                return self._resolve_theme_font(typeface, steps)
+            steps.append(
+                ProvenanceStep(label, partname, 'buFont typeface="%s"' % typeface, True)
+            )
+            return EffectiveValue(typeface, None, True, tuple(steps))
+        steps.append(
+            ProvenanceStep("rendering default", None, "bullet follows the text typeface", True)
+        )
+        return EffectiveValue(BULLET_FOLLOWS_TEXT, None, True, tuple(steps))
+
+    def resolve_bullet_size(self, chain) -> EffectiveValue:
+        """Resolve the `EG_TextBulletSize` choice over a paragraph chain.
+
+        Three members, tested in schema order: `a:buSzTx` (follow the text), `a:buSzPct` (a
+        fraction of the text size), `a:buSzPts` (absolute, reported as a |Length| with
+        `value_pt` populated, as `resolve_line_spacing` does for `spcPts`). Inherits
+        independently of the bullet kind and exhausts to `BULLET_FOLLOWS_TEXT`.
+        """
+        steps = []
+        for label, partname, pPr in chain:
+            if pPr is None:
+                steps.append(
+                    ProvenanceStep(label, partname, self._absence(pPr, "no bullet size"), False)
+                )
+                continue
+            if pPr.find(qn("a:buSzTx")) is not None:
+                steps.append(ProvenanceStep(label, partname, "buSzTx", True))
+                return EffectiveValue(BULLET_FOLLOWS_TEXT, None, True, tuple(steps))
+            buSzPct = pPr.find(qn("a:buSzPct"))
+            if buSzPct is not None:
+                raw = buSzPct.get("val")
+                try:
+                    fraction = ST_TextBulletSizePercent.convert_from_xml(raw)
+                except (TypeError, ValueError):
+                    steps.append(
+                        ProvenanceStep(
+                            label, partname, 'buSzPct with unreadable val="%s"' % raw, False
+                        )
+                    )
+                    return EffectiveValue(None, None, False, tuple(steps))
+                steps.append(ProvenanceStep(label, partname, 'buSzPct val="%s"' % raw, True))
+                return EffectiveValue(fraction, None, True, tuple(steps))
+            buSzPts = pPr.find(qn("a:buSzPts"))
+            if buSzPts is not None:
+                raw = buSzPts.get("val")
+                try:
+                    length = Length(Centipoints(int(raw)))
+                except (TypeError, ValueError):
+                    steps.append(
+                        ProvenanceStep(
+                            label, partname, 'buSzPts with unreadable val="%s"' % raw, False
+                        )
+                    )
+                    return EffectiveValue(None, None, False, tuple(steps))
+                steps.append(ProvenanceStep(label, partname, 'buSzPts val="%s"' % raw, True))
+                return EffectiveValue(length, length.pt, True, tuple(steps))
+            steps.append(
+                ProvenanceStep(label, partname, self._absence(pPr, "no bullet size"), False)
+            )
+        steps.append(
+            ProvenanceStep("rendering default", None, "bullet follows the text size", True)
+        )
+        return EffectiveValue(BULLET_FOLLOWS_TEXT, None, True, tuple(steps))
 
     def resolve_container_fill(
         self, container, label, partname, style_ref, ref_label

--- a/src/pptx/inspect.py
+++ b/src/pptx/inspect.py
@@ -1153,6 +1153,13 @@ class _FontResolver(object):
             buSzPct = pPr.find(qn("a:buSzPct"))
             if buSzPct is not None:
                 raw = buSzPct.get("val")
+                if raw is None:
+                    # -- @val is required; when it is absent convert_from_xml would call
+                    # -- .endswith on None and raise AttributeError, which diff_decks does
+                    # -- not catch. Report it unresolved, as the buChar/buAutoNum paths do
+                    # -- for their missing required attributes.
+                    steps.append(ProvenanceStep(label, partname, "buSzPct with no val", False))
+                    return EffectiveValue(None, None, False, tuple(steps))
                 try:
                     fraction = ST_TextBulletSizePercent.convert_from_xml(raw)
                 except (TypeError, ValueError):

--- a/tests/paper/goldens/lineage_v1_v2.diff.json
+++ b/tests/paper/goldens/lineage_v1_v2.diff.json
@@ -1,6 +1,6 @@
 {
   "schema": "paper-deck-diff",
-  "version": 2,
+  "version": 3,
   "detail": "text",
   "slides_added": [
     {

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -104,6 +104,118 @@ def test_diff_matches_frozen_golden():
     assert actual == golden_path.read_bytes()
 
 
+# ------------------------------------------------------------------------ bullet shifts
+
+BULLETED = "self_generated/branded_template.pptx"
+
+
+def _saved(prs, tmp_path, name):
+    path = tmp_path / name
+    prs.save(str(path))
+    return str(path)
+
+
+def _bullet_shifts(before_path, after_path):
+    report = diff_decks(before_path, after_path, detail="full")
+    return [
+        shift
+        for change in report.slide_changes
+        for shift in change.bullet_shifts
+    ]
+
+
+def test_suppressing_inherited_bullets_reports_a_bullet_shift(tmp_path):
+    """The gap this facet closes.
+
+    `set_none()` changes no text and no field marker, so `text_changes` stays empty while
+    every visible bullet on the slide disappears. Before `bullet_shifts` the whole
+    within-slide report was empty and only `package_changes` noticed the part had moved.
+    """
+    before = _saved(Presentation(_path(BULLETED)), tmp_path, "before.pptx")
+    prs = Presentation(_path(BULLETED))
+    for paragraph in prs.slides[0].placeholders[1].text_frame.paragraphs:
+        paragraph.bullet.set_none()
+    after = _saved(prs, tmp_path, "after.pptx")
+
+    report = diff_decks(before, after, detail="full")
+    change = report.slide_changes[0]
+    assert change.text_changes == ()  # -- the text is untouched
+    assert [(s.text, s.before["bullet"]["type"], s.after["bullet"]["type"]) for s in
+            change.bullet_shifts] == [
+        ("Body level one", "character", "none"),
+        ("Body level two", "character", "none"),
+    ]
+
+
+def test_bullet_typeface_change_alone_reports_a_shift(tmp_path):
+    """A symbol bullet losing its typeface keeps the same glyph and stops rendering as one.
+
+    This is why the typeface had to join the resolver before this facet existed: comparing
+    the kind and char alone would call these two decks identical.
+    """
+    wingding = "\uf0a7"  # -- private use: a filled square in Wingdings, else a box
+    paths = []
+    for name, font in (("wing.pptx", "Wingdings"), ("plain.pptx", None)):
+        prs = Presentation(_path(BULLETED))
+        for paragraph in prs.slides[0].placeholders[1].text_frame.paragraphs:
+            paragraph.bullet.set_character(wingding, font_name=font)
+        paths.append(_saved(prs, tmp_path, name))
+
+    shifts = _bullet_shifts(*paths)
+    assert shifts
+    for shift in shifts:
+        assert shift.before["bullet"]["char"] == shift.after["bullet"]["char"]  # -- same glyph
+        assert shift.before["bullet_font"]["value"] == "Wingdings"
+        assert shift.after["bullet_font"]["value"] != "Wingdings"
+
+
+def test_bullet_shifts_are_absent_when_bullets_are_unchanged(tmp_path):
+    """An omitted facet keeps every existing payload byte-identical."""
+    before = _saved(Presentation(_path(BULLETED)), tmp_path, "a.pptx")
+    prs = Presentation(_path(BULLETED))
+    prs.slides[0].shapes.title.text_frame.paragraphs[0].runs[0].text = "Retitled"
+    after = _saved(prs, tmp_path, "b.pptx")
+
+    report = diff_decks(before, after, detail="full")
+    assert report.slide_changes[0].text_changes  # -- the text change is reported
+    assert report.slide_changes[0].bullet_shifts == ()
+    assert "bullet_shifts" not in report.slide_changes[0].to_dict()
+
+
+def test_bullet_shifts_only_populate_at_full_detail(tmp_path):
+    before = _saved(Presentation(_path(BULLETED)), tmp_path, "c.pptx")
+    prs = Presentation(_path(BULLETED))
+    for paragraph in prs.slides[0].placeholders[1].text_frame.paragraphs:
+        paragraph.bullet.set_none()
+    after = _saved(prs, tmp_path, "d.pptx")
+
+    assert _bullet_shifts(before, after)  # -- detail="full"
+    for detail in ("structure", "text"):
+        report = diff_decks(before, after, detail=detail)
+        assert all(change.bullet_shifts == () for change in report.slide_changes)
+
+
+def test_bullet_shift_payload_carries_provenance_for_both_sides(tmp_path):
+    before = _saved(Presentation(_path(BULLETED)), tmp_path, "e.pptx")
+    prs = Presentation(_path(BULLETED))
+    for paragraph in prs.slides[0].placeholders[1].text_frame.paragraphs:
+        paragraph.bullet.set_none()
+    after = _saved(prs, tmp_path, "f.pptx")
+
+    shift = _bullet_shifts(before, after)[0]
+    payload = shift.to_dict()
+    assert sorted(payload) == [
+        "after", "before", "paragraph_index", "part", "shape_id", "text",
+    ]
+    assert payload["part"] == "/ppt/slides/slide1.xml"
+    for side in ("before", "after"):
+        assert sorted(payload[side]) == ["bullet", "bullet_font", "bullet_size"]
+        assert payload[side]["bullet"]["provenance"]
+    # -- the inherited side names the master; the suppressed side names the paragraph
+    assert payload["before"]["bullet"]["provenance"][-1]["level"].startswith("master txStyles")
+    assert payload["after"]["bullet"]["provenance"][0]["level"] == "paragraph pPr"
+
+
 def test_diff_is_deterministic_across_runs():
     first = diff_decks(_path(V1), _path(V2), detail="full").to_dict()
     second = diff_decks(_path(V1), _path(V2), detail="full").to_dict()

--- a/tests/paper/test_effective_inspect.py
+++ b/tests/paper/test_effective_inspect.py
@@ -17,11 +17,17 @@ from pptx import Presentation
 from pptx.dml.color import RGBColor
 from pptx.enum.shapes import MSO_SHAPE
 from pptx.errors import UnsupportedStructureError
-from pptx.inspect import content_hash, effective_font, effective_paragraph_format, inspect_text
+from pptx.inspect import (
+    BULLET_FOLLOWS_TEXT,
+    content_hash,
+    effective_font,
+    effective_paragraph_format,
+    inspect_text,
+)
 from pptx.util import Emu
 
 from . import corpus
-from .contract import snapshot_parts
+from .contract import save_reopen, snapshot_parts
 
 BRANDED = "self_generated/branded_template.pptx"
 CLRMAP = "self_generated/clrmap_remap.pptx"
@@ -554,7 +560,7 @@ def test_effective_paragraph_format_resolves_alignment_and_spacing():
 
     payload = fmt.to_dict()
     assert payload["schema"] == "paper-effective-paragraph-format"
-    assert payload["version"] == 2  # -- v2 added the `bullet` field
+    assert payload["version"] == 3  # -- v3 added bullet_font/bullet_size
 
 
 # ----------------------------------------------------------- inherited bullet resolution
@@ -780,7 +786,7 @@ def test_bullet_payload_serializes_in_the_documented_shape():
 
     payload = effective_paragraph_format(body.text_frame.paragraphs[0]).to_dict()
     assert payload["schema"] == "paper-effective-paragraph-format"
-    assert payload["version"] == 2
+    assert payload["version"] == 3
     bullet = payload["bullet"]
     assert sorted(bullet) == ["char", "number_scheme", "provenance", "resolved", "start_at", "type"]
     assert bullet["type"] == "character"
@@ -810,6 +816,171 @@ def test_bullet_payload_serializes_in_the_documented_shape():
         None,
         None,
     )
+
+
+# ------------------------------------------------- bullet typeface and size resolution
+
+WINGDING = ""  # -- private use: a filled square in Wingdings, undrawable elsewhere
+
+
+def test_bullet_font_and_size_round_trip_through_the_write_api():
+    """The defect this feature exists for.
+
+    A private-use glyph is meaningless without its typeface, so a caller re-applying
+    everything the payload reports must land on the same `buFont` it started from. Before
+    `bullet_font` existed there was nothing to pass and the copy rendered as a blank box.
+    """
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    source = body.text_frame.paragraphs[0]
+    source.bullet.set_character(WINGDING, font_name="Wingdings", size_percent=0.75)
+
+    fmt = effective_paragraph_format(source)
+    assert fmt.bullet.char == WINGDING
+    assert fmt.bullet_font.value == "Wingdings"
+    assert fmt.bullet_size.value == 0.75
+
+    target = body.text_frame.add_paragraph()
+    target.text = "re-applied from the payload alone"
+    target.bullet.set_character(
+        fmt.bullet.char, font_name=fmt.bullet_font.value, size_percent=fmt.bullet_size.value
+    )
+
+    reopened = save_reopen(prs)
+    shape = next(s for s in reopened.slides[0].shapes if s.shape_id == body.shape_id)
+    copied = effective_paragraph_format(shape.text_frame.paragraphs[-1])
+    assert copied.bullet.char == WINGDING
+    assert copied.bullet_font.value == "Wingdings"  # -- the typeface survived the round trip
+    assert copied.bullet_size.value == 0.75
+
+
+def test_bullet_font_resolves_independently_of_the_bullet_kind():
+    """Three separate choice groups, three separate walks, three provenance chains."""
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    _graft_lst_style_bullet(body, "lvl1pPr", "buFont", typeface="Wingdings")
+
+    fmt = effective_paragraph_format(body.text_frame.paragraphs[0])
+    # -- the kind still comes from the master, the typeface from the shape's own lstStyle
+    assert fmt.bullet_font.value == "Wingdings"
+    assert _supplied_levels(fmt.bullet_font) == ["shape lstStyle lvl1"]
+    assert _supplied_levels(fmt.bullet) == ["master txStyles bodyStyle lvl1"]
+
+
+def test_bullet_font_follows_text_explicitly_and_on_exhaustion():
+    """`buFontTx` is an answer attributed to its rung; exhaustion reaches it as a default."""
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    _graft_lst_style_bullet(body, "lvl1pPr", "buFontTx")
+    explicit = effective_paragraph_format(body.text_frame.paragraphs[0]).bullet_font
+    assert explicit.value == BULLET_FOLLOWS_TEXT
+    assert explicit.resolved is True
+    assert _supplied_levels(explicit) == ["shape lstStyle lvl1"]
+
+    textbox = _plain_textbox(_open(BRANDED))
+    exhausted = effective_paragraph_format(textbox.text_frame.paragraphs[0]).bullet_font
+    assert exhausted.value == BULLET_FOLLOWS_TEXT
+    assert exhausted.resolved is True
+    assert _supplied_levels(exhausted) == ["rendering default"]
+
+
+def test_bullet_size_discriminates_its_three_members():
+    """`buSzPct` is a fraction, `buSzPts` an absolute length, `buSzTx` defers to the text."""
+    pct = _open(BRANDED)
+    _graft_lst_style_bullet(pct.slides[0].placeholders[1], "lvl1pPr", "buSzPct", val="45%")
+    resolved = effective_paragraph_format(
+        pct.slides[0].placeholders[1].text_frame.paragraphs[0]
+    ).bullet_size
+    assert resolved.value == 0.45
+    assert resolved.value_pt is None
+
+    pts = _open(BRANDED)
+    _graft_lst_style_bullet(pts.slides[0].placeholders[1], "lvl1pPr", "buSzPts", val="1400")
+    resolved = effective_paragraph_format(
+        pts.slides[0].placeholders[1].text_frame.paragraphs[0]
+    ).bullet_size
+    assert resolved.value_pt == 14.0  # -- centipoints, as spcPts is reported
+
+    tx = _open(BRANDED)
+    _graft_lst_style_bullet(tx.slides[0].placeholders[1], "lvl1pPr", "buSzTx")
+    resolved = effective_paragraph_format(
+        tx.slides[0].placeholders[1].text_frame.paragraphs[0]
+    ).bullet_size
+    assert resolved.value == BULLET_FOLLOWS_TEXT
+
+
+def test_bullet_font_resolves_a_theme_token_through_the_font_scheme():
+    """A `buFont` may name `+mj-lt`; report the typeface it lands on, not the token."""
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    _graft_lst_style_bullet(body, "lvl1pPr", "buFont", typeface="+mj-lt")
+
+    resolved = effective_paragraph_format(body.text_frame.paragraphs[0]).bullet_font
+    assert resolved.resolved is True
+    assert resolved.value == _ground_truth(BRANDED)["theme_major_latin"]
+    assert any("theme reference" in step.detail for step in resolved.provenance)
+    assert _supplied_levels(resolved) == ["theme fontScheme majorFont"]
+
+
+@pytest.mark.parametrize(
+    ("tag", "attrs", "detail"),
+    [
+        ("buFont", {}, "buFont with no typeface"),
+        ("buSzPct", {"val": "not-a-number"}, "buSzPct with unreadable"),
+        ("buSzPts", {"val": "oops"}, "buSzPts with unreadable"),
+    ],
+)
+def test_bullet_modifier_missing_its_required_attribute_reports_unresolved(tag, attrs, detail):
+    """Honest over plausible: report, do not guess, and do not raise |InvalidXmlError|."""
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    _graft_lst_style_bullet(body, "lvl1pPr", tag, **attrs)
+
+    fmt = effective_paragraph_format(body.text_frame.paragraphs[0])
+    facet = fmt.bullet_font if tag == "buFont" else fmt.bullet_size
+    assert facet.resolved is False
+    assert facet.value is None
+    assert _supplied_levels(facet) == []
+    assert detail in facet.provenance[-1].detail
+    assert facet.provenance[-1].level == "shape lstStyle lvl1"
+
+
+def test_bullet_modifier_resolution_never_mutates_the_package():
+    prs = _open(BRANDED)
+    paragraphs = [
+        paragraph
+        for shape in prs.slides[0].shapes
+        if shape.has_text_frame
+        for paragraph in shape.text_frame.paragraphs
+    ]
+    before = snapshot_parts(prs)
+
+    resolved = [effective_paragraph_format(paragraph) for paragraph in paragraphs]
+
+    # -- the title's chain runs through titleStyle, which carries buNone and no buFont
+    assert [f.bullet_font.value for f in resolved] == [BULLET_FOLLOWS_TEXT, "Arial", "Arial"]
+    assert snapshot_parts(prs) == before
+
+
+def test_bullet_modifier_payload_serializes_beside_the_bullet():
+    prs = _open(BRANDED)
+    payload = effective_paragraph_format(
+        prs.slides[0].placeholders[1].text_frame.paragraphs[0]
+    ).to_dict()
+    assert payload["version"] == 3
+    assert sorted(payload) == [
+        "alignment",
+        "bullet",
+        "bullet_font",
+        "bullet_size",
+        "line_spacing",
+        "schema",
+        "version",
+    ]
+    for key in ("bullet_font", "bullet_size"):
+        assert sorted(payload[key]) == ["provenance", "resolved", "value", "value_pt"]
+    assert payload["bullet_font"]["value"] == "Arial"  # -- master bodyStyle supplies buFont
+    assert payload["bullet_font"]["provenance"][-1]["detail"] == 'buFont typeface="Arial"'
 
 
 # ------------------------------------------------------------------ shape-format resolution

--- a/tests/paper/test_effective_inspect.py
+++ b/tests/paper/test_effective_inspect.py
@@ -820,7 +820,7 @@ def test_bullet_payload_serializes_in_the_documented_shape():
 
 # ------------------------------------------------- bullet typeface and size resolution
 
-WINGDING = ""  # -- private use: a filled square in Wingdings, undrawable elsewhere
+WINGDING = "\uf0a7"  # -- private use: a filled square in Wingdings, undrawable elsewhere
 
 
 def test_bullet_font_and_size_round_trip_through_the_write_api():

--- a/tests/paper/test_effective_inspect.py
+++ b/tests/paper/test_effective_inspect.py
@@ -719,6 +719,28 @@ def test_bullet_reports_a_malformed_member_as_unresolved(bullet_tag, attrs):
     assert [step.level for step in bullet.provenance] == ["paragraph pPr", "shape lstStyle lvl1"]
 
 
+def test_bullet_size_reports_a_missing_val_as_unresolved_without_crashing():
+    """`a:buSzPct` with no `@val` must resolve unresolved, not raise.
+
+    The schema requires `@val`; when it is absent, `convert_from_xml` would call
+    `.endswith` on None and raise `AttributeError`, which `diff_decks` does not catch and
+    which would abort a full-detail diff. This mirrors the buChar/buAutoNum honesty rule:
+    an unusable member is reported, not guessed at and not crashed on.
+    """
+    prs = _open(BRANDED)
+    body = prs.slides[0].placeholders[1]
+    # -- a:buSzPct with no @val, grafted into the shape's lstStyle level-1 properties
+    _graft_lst_style_bullet(body, "lvl1pPr", "buSzPct")
+
+    fmt = effective_paragraph_format(body.text_frame.paragraphs[0])
+
+    assert fmt.bullet_size.resolved is False
+    assert fmt.bullet_size.value is None
+    offender = fmt.bullet_size.provenance[-1]
+    assert offender.supplied is False
+    assert "buSzPct with no val" in offender.detail
+
+
 def test_bullet_resolves_an_inherited_numbered_bullet_and_defaults_start_at_to_one():
     """`@startAt` is optional on `a:buAutoNum`; absent means the sequence starts at 1."""
     prs = _open(BRANDED)


### PR DESCRIPTION
Stacked on #26. Closes both halves of the bullet-reporting gap that `inherited-bullet-resolution` left open, and that README recorded as known gaps.

## Measured first, and the measurement mattered

Both claims went to PowerPoint before shipping. **The typeface is load-bearing, not cosmetic:**

| deck | typeface in effect | **PowerPoint draws** |
|---|---|---|
| run font Wingdings + `a:buFontTx` | the run's Wingdings | **filled black square** |
| run font Wingdings + `buFont="Arial"` | Arial | **empty box** |
| `a:buFontTx` (body font) | the run's font | box with `?` |
| no typeface element anywhere in the chain | the run's font | box with `?` |
| inherits `buFont="Arial"` from master | Arial | **empty** box |

Same glyph, one attribute different, and the bullet followed the text. The differing missing-glyph shapes are themselves the proof of which font PowerPoint used: Arial draws `.notdef` as an empty box, the body font as a `?`-box, and Wingdings has a real glyph at U+F0A7. Every row fits one model.

That confirms two things the code asserts: `a:buFontTx` and an exhausted chain are **one state**, and it is genuinely distinct from a typeface some rung supplied. Recorded in the verdict ledger.

LibreOffice could decide neither question — it ignores `buSzPct` outright and renders `buFontTx` identically to `buFont="Arial"`. Null results, which is why PowerPoint was required.

## Why this is a bug and not a nicety

`BulletFormat.set_character()` accepts `font_name` and `size_percent`, and `BulletFormat` reads both back locally — but `EffectiveBullet` reported neither. So paper-pptx's own bullet read and write APIs did not round-trip: an agent re-applying everything the payload reported produced a bullet that renders as a blank box. The only way to get the typeface was to hand-walk the XML, bypassing the resolver.

Not hypothetical: nine frozen fixtures under `libreoffice_export/` carry private-use bullet codepoints, and the corpus holds 1024 `buFont` elements.

## Part A — `bullet_font` and `bullet_size` (`src/pptx/inspect.py`)

Two new `EffectiveValue` fields on `EffectiveParagraphFormat`, each resolved on its own walk over the chain the factory already builds. `EG_TextBulletTypeface` and `EG_TextBulletSize` are separate XSD choice groups that inherit independently of the bullet kind, so a paragraph can take its glyph from the master and its size from the layout — each carries its own provenance.

- "Follow the text" members (`buFontTx`, `buSzTx`) are positive answers, reported as `BULLET_FOLLOWS_TEXT`, which is also where an exhausted chain lands. No ECMA default exists for either element, so the terminal step is `"rendering default"` rather than `"schema default"`.
- Size discriminates all three members: `buSzPct` a fraction, `buSzPts` a `Length` with `value_pt`, `buSzTx` the sentinel.
- Theme tokens (`+mj-lt`) resolve through the master font scheme.
- Attributes read raw, never through the `RequiredAttribute` descriptors, which raise on exactly the malformed input this reports honestly.
- Deliberately **not** nested inside `EffectiveBullet` — that would imply they resolve together with the kind. `EffectiveBullet` is unchanged.

Schema `paper-effective-paragraph-format` 2 → 3.

## Part B — `bullet_shifts` (`src/pptx/diff.py`)

Bullets live only in formatting, so a list losing them changes no text and no field marker. `diff_decks` therefore reported an empty within-slide change for a slide that visibly lost every glyph; only `package_changes` noticed the part had moved.

New `SlideChange.bullet_shifts`, populated at `detail="full"` beside the existing per-run `effective_shifts`. Paragraphs are keyed by `(shape_id, text)` rather than index, matching `_resolution_state(align_by_content=True)`: an inserted paragraph shifts every later index and would pair unrelated paragraphs. Paragraphs whose text repeats within a shape, and paragraphs the resolver refuses (table cells, which are not `p:sp`), are skipped rather than guessed at.

Schema `paper-deck-diff` 2 → 3.

**Part A had to land first.** Comparing kind and char alone would call a Wingdings bullet and its unusable Arial fallback identical — the change most worth catching.

## The golden moved by exactly one line

`bullet_shifts` is omitted when empty, so `tests/paper/goldens/lineage_v1_v2.diff.json` changed only at `"version": 2` → `3`. No existing key moved and no facet appeared. Verified with a line diff before regenerating.

## Test plan

25 new tests. No new fixtures — every case is reachable from the frozen, SHA-256-pinned corpus, which is byte-identical.

Part A: the round-trip that failed before (read a Wingdings bullet, re-apply it, assert the typeface survived save→reopen); each group resolving independently of the kind; `buFontTx` as an explicit answer versus exhaustion reaching the same value; size discriminating `buSzPct`/`buSzPts`/`buSzTx`; theme-token resolution; three malformed-member cases reporting unresolved instead of raising; `snapshot_parts` proving zero parts dirtied; payload shape and version.

Part B: bullet suppression reported while `text_changes` stays empty; a typeface-only change caught; the facet absent and omitted from the payload when bullets are unchanged; population only at `detail="full"`; provenance carried for both sides.

```
uv run pytest -W ignore -q        # 3647 passed, 1 skipped
uv run behave -q                  # 973 scenarios, 0 failed
uv run sphinx-build -W -b html docs docs/.build/html   # exit 0
uv run ruff check <the four changed files>             # clean
```

`grep -c 'get_or_add\|get_or_change' src/pptx/inspect.py` stays at `0` — resolution is strictly read-only.

## Known gap, honestly

The **size** half of the "follow the text" claim is **not yet PowerPoint-verified**. It is structurally identical to the typeface half, which is confirmed, and LibreOffice cannot answer it. The verification set exists and the four size decks are ready to open; the ledger records the rows as outstanding. If PowerPoint disagrees, the fix is confined to `resolve_bullet_size`'s exhaustion branch and its provenance wording.

README's "Known gaps, honestly" now records bullet **color** as the remaining unresolved facet (`BulletFormat` can neither read nor write it, so it would be new capability rather than parity) and the `detail="full"` / table-cell boundaries on bullet diffing.

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Upstream acceptance suite green (`uv run behave`)
- [x] Lint clean on changed files (`uv run ruff check`)
- [x] Docs build with warnings as errors
- [x] Frozen fixture corpus unchanged; one golden line, verified before regenerating
- [x] Verified against PowerPoint, verdicts recorded in the ledger
- [ ] Size-family PowerPoint verdicts outstanding (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches resolver inheritance and full-detail diff pairing logic; behavior is additive and well-tested, but incorrect pairing or resolution could misreport bullet changes in automation pipelines.
> 
> **Overview**
> Extends **`effective_paragraph_format()`** with **`bullet_font`** and **`bullet_size`**, each walked on its own inheritance chain (separate from bullet kind), with provenance and the **`BULLET_FOLLOWS_TEXT`** sentinel for `buFontTx` / `buSzTx` and exhaustion defaults. Theme tokens on `buFont` resolve through the font scheme; malformed `buFont` / `buSzPct` / `buSzPts` report unresolved instead of raising. **`paper-effective-paragraph-format`** bumps to **version 3**.
> 
> Adds **`bullet_shifts`** to **`diff_decks`** at **`detail="full"`**: new **`BulletShift`** records compare resolved bullet, font, and size per paragraph, keyed by **`(shape_id, paragraph text)`** (skips duplicate text in one shape and table-cell paragraphs). **`paper-deck-diff`** bumps to **version 3**. Docs, README known-gaps, tests, and the lineage golden are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980046e6c54adf2c0723e6fe2ebedebd98b3f768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->