### PR TITLE
fix: compare like with like in patch_save and diff_decks

### DIFF
--- a/docs/api/diff.rst
+++ b/docs/api/diff.rst
@@ -10,7 +10,7 @@ matched slides. At ``detail="full"`` it also reports per-run effective-value shi
 per-paragraph **bullet shifts** via the resolver. Bullets live only in formatting, so a list losing
 its bullets changes no text and no field marker: without that facet the within-slide report is empty
 while the slide visibly loses every glyph. The report also includes ``package_changes``, an
-authoritative semantic diff of every serialized package member. That package-level list prevents
+authoritative semantic diff of every package member. That package-level list prevents
 metadata, relationship, ordering, field, crop, or media changes from disappearing when no
 specialized slide facet applies.
 

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -192,6 +192,11 @@ def diff_decks(path_a, path_b, *, detail: str = "structure") -> DeckDiff:
     series/category, notes), "full" (+ per-run effective-value shifts via the resolver
     - expensive on large decks, deliberately opt-in).
 
+    When either side is an open |Presentation|, both sides are normalized by serializing
+    before the package-level comparison, because a live presentation has no on-disk package
+    to read; when both sides are a path or a file-like object, the packages are compared
+    exactly.
+
     Matching is by permanent slide id and is intended for lineage-derived decks.
     Independently built decks can reuse ids and are outside this contract. One declared
     hazard: slide ids allocate as max+1, so deleting the highest-id slide and then adding
@@ -318,20 +323,24 @@ def _restore_stream_positions(stream_positions) -> None:
 
 
 def _package_changes(source_a, prs_a, source_b, prs_b) -> tuple:
-    """Return semantic deltas from the exact supplied packages when recoverable."""
+    """Return semantic deltas, reading both sides of the pair the same way."""
     from pptx.package import _diff_maps
+    from pptx.presentation import Presentation as _PresentationProxy
 
-    map_a = _source_package_map(source_a, prs_a, "before")
-    map_b = _source_package_map(source_b, prs_b, "after")
+    # -- the choice belongs to the PAIR, not to one input: reading one side exactly and
+    # -- the other serialized compares two renderings of one document, and reports the
+    # -- difference between the renderings as a change to the document
+    normalized = any(isinstance(s, _PresentationProxy) for s in (source_a, source_b))
+    map_a = _source_package_map(source_a, prs_a, "before", normalized)
+    map_b = _source_package_map(source_b, prs_b, "after", normalized)
     return _diff_maps(map_a, map_b, "before", "after").deltas
 
 
-def _source_package_map(source, prs, label: str) -> dict:
-    """Read a path/stream package exactly; serialize only Presentation proxies."""
+def _source_package_map(source, prs, label: str, normalized: bool) -> dict:
+    """Serialize the side when the pair is normalized; else read the package exactly."""
     from pptx.package import _read_zip_map, _read_zip_map_from_bytes
-    from pptx.presentation import Presentation as _PresentationProxy
 
-    if isinstance(source, _PresentationProxy):
+    if normalized:
         buffer = io.BytesIO()
         # -- serialize through the package, not `Presentation.save`: this is a read for
         # -- comparison, not a publish, so an open `batch()` block must not refuse it

--- a/src/pptx/package.py
+++ b/src/pptx/package.py
@@ -426,6 +426,23 @@ def _diff_maps(map_a: dict, map_b: dict, label_a: str, label_b: str) -> PackageD
     return PackageDiff(tuple(deltas))
 
 
+def _save_cannot_emit(name: str) -> bool:
+    """True when `save()` structurally cannot emit the zip member called `name`.
+
+    `save()` rebuilds from the OPC part graph, so a ZIP folder record -- not a part, carrying
+    no bytes -- can never appear in its output. Its absence from a candidate is therefore
+    never evidence that the document changed; every other absent member is real content
+    leaving the package and still counts as one.
+
+    The trailing slash is the whole test, because the member maps are keyed by name and no
+    `ZipInfo` survives to consult. `_zipguard._is_directory_entry` asks `ZipInfo.is_dir()`,
+    which on Windows also matches a backslash-suffixed name; this one does not. That
+    divergence is safe in the only direction it goes: a name missed here defeats
+    `unchanged` and the package is rewritten as today, never the reverse.
+    """
+    return name.endswith("/")
+
+
 def patch_save(original_path: str, document, out_path: str) -> PackageDiff:
     """Save `document` to `out_path`, restoring original bytes for unchanged XML parts.
 
@@ -440,6 +457,13 @@ def patch_save(original_path: str, document, out_path: str) -> PackageDiff:
     `os.replace`, so a mid-write failure leaves any existing `out_path` untouched. When
     nothing changed at all, `out_path` is written as an exact byte copy of `original_path`
     (the no-op round trip is byte-identical).
+
+    "Nothing changed" is decided over the members that can be parts: none added, none
+    removed, each semantically identical to its counterpart. A ZIP folder record such as
+    `ppt/` is not a part, so `save()` structurally cannot emit one and its absence from the
+    serialized candidate never evidences a change. Such a record therefore survives a no-op
+    round trip — the byte copy reproduces it — and is dropped by an actual edit, which
+    rebuilds the package from the members `save()` emitted.
 
     Not interchangeable with :meth:`.Presentation.save`, which is also atomic on a path:
     atomicity is how the bytes land, narrowness is which bytes get written. `save()`
@@ -476,8 +500,12 @@ def patch_save(original_path: str, document, out_path: str) -> PackageDiff:
     # -- (in-place narrow save), in which case a post-write diff would always be empty
     residual = _diff_maps(original_map, out_map, str(original_path), str(out_path))
 
-    unchanged = set(out_map) == set(original_map) and all(
-        out_map[name] == original_map[name] for name in out_map
+    # -- forgiving the one absence `save()` could not have avoided is what lets a genuine
+    # -- no-op reach the byte-copy path below; anything else dropped is a real change
+    unchanged = (
+        set(out_map) <= set(original_map)
+        and all(_save_cannot_emit(name) for name in set(original_map) - set(out_map))
+        and all(out_map[name] == original_map[name] for name in out_map)
     )
     if unchanged:
         _atomic_write_bytes(_read_file_bytes(original_path), out_path)

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -273,6 +273,53 @@ def test_package_changes_use_original_package_members(tmp_path, source_kind):
     assert [delta.partname for delta in report.package_changes] == ["/[Content_Types].xml"]
 
 
+def _deck_with_directory_records(tmp_path):
+    """Copy a fixture, prefixing ZIP folder records that `save()` cannot reproduce.
+
+    Three records, one of them nested, so a predicate keying on a top-level prefix
+    cannot satisfy the assertions by accident.
+    """
+    target = tmp_path / "directory-records.pptx"
+    source = corpus.fixture_path("self_generated/minimal_clean.pptx")
+    with zipfile.ZipFile(source) as incoming, zipfile.ZipFile(target, "w") as outgoing:
+        for name in ("docProps/", "ppt/", "ppt/slides/"):
+            record = zipfile.ZipInfo(name)
+            record.external_attr = (0o040755 << 16) | 0x10
+            outgoing.writestr(record, b"")
+        for info in incoming.infolist():
+            outgoing.writestr(info, incoming.read(info.filename))
+    return str(target)
+
+
+def test_directory_record_deck_gets_one_verdict_however_it_is_named(tmp_path):
+    """A folder-record deck read exactly and read serialized must agree, and be empty.
+
+    Folder records exist on disk and can never appear in a serialization, so comparing
+    the disk side against the other side's rendering reported three removals that
+    described the mismatched comparison rather than any difference in the document.
+    """
+    deck = _deck_with_directory_records(tmp_path)
+
+    from_disk = diff_decks(deck, deck)
+    from_proxy = diff_decks(deck, Presentation(deck))
+
+    assert from_disk.is_empty == from_proxy.is_empty
+    assert from_disk.is_empty, from_disk.to_dict()
+    assert from_proxy.is_empty, from_proxy.to_dict()
+
+
+def test_control_deck_gets_one_verdict_however_it_is_named():
+    """The same agreement on a deck with no folder records, which held before the fix."""
+    deck = _path("self_generated/minimal_clean.pptx")
+
+    from_disk = diff_decks(deck, deck)
+    from_proxy = diff_decks(deck, Presentation(deck))
+
+    assert from_disk.is_empty == from_proxy.is_empty
+    assert from_disk.is_empty, from_disk.to_dict()
+    assert from_proxy.is_empty, from_proxy.to_dict()
+
+
 def test_seekable_stream_positions_survive_success_and_failure():
     data = corpus.fixture_path("self_generated/minimal_clean.pptx").read_bytes()
     before = io.BytesIO(data)

--- a/tests/paper/test_package_kernel.py
+++ b/tests/paper/test_package_kernel.py
@@ -34,6 +34,28 @@ def _slide1_xml(relpath):
     return zip_member_map(corpus.fixture_path(relpath).read_bytes())["ppt/slides/slide1.xml"]
 
 
+def _deck_with_extra_members(relpath, target, extras):
+    """Write corpus fixture `relpath` to `target` with `extras` (name -> bytes) appended.
+
+    Kept out of the corpus deliberately: no fixture carries these shapes today and adding
+    one would change what every other suite sees.
+    """
+    with zipfile.ZipFile(corpus.fixture_path(relpath)) as incoming:
+        with zipfile.ZipFile(str(target), "w") as outgoing:
+            for info in incoming.infolist():
+                outgoing.writestr(info, incoming.read(info.filename))
+            for name, data in extras.items():
+                outgoing.writestr(name, data)
+    return target
+
+
+def _folder_record_deck(target):
+    """MINIMAL plus three ZIP folder records, one of them nested under another."""
+    return _deck_with_extra_members(
+        MINIMAL, target, {"docProps/": b"", "ppt/": b"", "ppt/slides/": b""}
+    )
+
+
 # -------------------------------------------------------------------------- xml_equivalent
 
 
@@ -132,6 +154,70 @@ def test_noop_round_trip_is_byte_identical(relpath, tmp_path):
     diff = patch_save(_fixture(relpath), Presentation(_fixture(relpath)), str(out))
     assert diff.is_empty
     assert out.read_bytes() == corpus.fixture_path(relpath).read_bytes()
+
+
+def test_noop_round_trip_is_byte_identical_on_a_deck_carrying_folder_records(tmp_path):
+    """A ZIP folder record is not a part, so `save()` structurally cannot emit one.
+
+    Its absence from the candidate save is therefore never evidence that the document
+    changed, and the documented no-op guarantee has to hold for these decks too --
+    "unzip, edit, rezip" pipelines emit folder records by default.
+    """
+    source = _folder_record_deck(tmp_path / "folders.pptx")
+    out = tmp_path / "folders_noop.pptx"
+
+    diff = patch_save(str(source), Presentation(str(source)), str(out))
+
+    assert diff.is_empty
+    assert out.read_bytes() == source.read_bytes()
+    assert len(Presentation(str(out)).slides) == 1  # -- equal bytes AND a readable deck
+    assert "ppt/" in zip_member_map(out.read_bytes())
+
+
+def test_edited_patch_save_changes_one_part_and_still_reports_dropped_folder_records(
+    tmp_path,
+):
+    """An actual edit rewrites, which drops the folder records -- as `save()` and
+    PowerPoint's own Save As both do. The residual must keep saying so: exactly one part
+    CHANGED, and the three records honestly reported as removed rather than hidden."""
+    source = _folder_record_deck(tmp_path / "folders.pptx")
+    presentation = Presentation(str(source))
+    presentation.slides[0].shapes.title.text_frame.paragraphs[0].runs[0].text = "Edited title"
+    out = tmp_path / "folders_edit.pptx"
+
+    diff = patch_save(str(source), presentation, str(out))
+
+    assert [d.partname for d in diff.deltas if d.change == "changed"] == ["/ppt/slides/slide1.xml"]
+    assert [d.partname for d in diff.deltas if d.change == "removed"] == [
+        "/docProps/",
+        "/ppt/",
+        "/ppt/slides/",
+    ]
+    assert not [d for d in diff.deltas if d.change == "added"]
+    members = zip_member_map(out.read_bytes())
+    assert not [name for name in members if name.endswith("/")]
+    assert Presentation(str(out)).slides[0].shapes.title.text == "Edited title"
+
+
+def test_noop_patch_save_still_drops_and_reports_an_orphan_part(tmp_path):
+    """The boundary the folder-record forgiveness must never widen to cover.
+
+    An unreferenced part with a declared content type is real content: `save()` drops it
+    (as PowerPoint does), so a no-op `patch_save` must rewrite rather than byte-copy, and
+    must report the removal. `.jpeg` is a declared Default in MINIMAL, so the part has a
+    content type and the deck is not refused at open for lacking one.
+    """
+    source = _deck_with_extra_members(
+        MINIMAL, tmp_path / "orphan.pptx", {"ppt/media/orphan.jpeg": b"\xff\xd8\xffnot a part"}
+    )
+    out = tmp_path / "orphan_noop.pptx"
+
+    diff = patch_save(str(source), Presentation(str(source)), str(out))
+
+    assert [(d.partname, d.change) for d in diff.deltas] == [("/ppt/media/orphan.jpeg", "removed")]
+    assert out.read_bytes() != source.read_bytes()
+    assert "ppt/media/orphan.jpeg" not in zip_member_map(out.read_bytes())
+    assert len(Presentation(str(out)).slides) == 1
 
 
 def test_noop_on_a_libreoffice_file_restores_every_part_but_content_types(tmp_path):


### PR DESCRIPTION
Stacked on #27.

`patch_save` and `diff_decks` each compared a package **read from disk** against one **produced by `save()`**. Those differ even when the document does not: `save()` rebuilds from the OPC part graph, so a ZIP folder record such as `ppt/` — emitted by Java, `shutil.make_archive`, and every unzip-edit-rezip pipeline — cannot survive it.

## Measured first

Before writing any code, the question was whether these members are ours to drop at all. They are — PowerPoint drops them itself:

| input | members in | members out | extra member survived? |
|---|---|---|---|
| `directory_entries` (`ppt/`, `ppt/slides/`, `docProps/`) | 43 | **39** | **no** |
| `orphan_part` (declared content type) | 41 | **39** | **no** |

So dropping is the oracle's own behaviour, not a fork invention. **Reporting the drop is therefore correct and is deliberately left alone.** When PowerPoint performs the round trip, `diff_package` reports those same removals correctly among 27 true deltas.

An earlier proposal (`one-zip-reader`) would have filtered folder records out of the member map. That is superseded — it would have suppressed a correct report.

## The two real defects

**`patch_save` broke its documented promise.** The `unchanged` test compared member *sets*; the sets differed by the folder records alone, so the byte-copy fast path never fired.

```
no-op patch_save on a folder-record deck
  before:  3 deltas, byte-identical False, file rewritten
  after:   0 deltas, byte-identical True
```

**`diff_decks` gave two answers for one document**, depending only on which side got serialized:

```
                                   before          after
diff_decks(path, path)             is_empty True   True
diff_decks(path, Presentation)     is_empty False  True     <-- same deck
```

## What changed

- `unchanged` now decides over the members that can be parts, so a member `save()` structurally cannot emit no longer defeats it. A folder record survives a no-op and is still dropped by an actual edit.
- The exact-vs-normalized choice in `diff_decks` belongs to the **pair**, not to one input. On-disk pairs are still compared exactly — pinned by the pre-existing `test_package_changes_use_original_package_members`, which passes unmodified.

## The boundary

A dropped **orphan part** is real content and must still defeat the byte-copy path:

```
folder records missing  -> unchanged True   (byte-copy fires)
orphan part missing     -> unchanged False  (rewrite + report the removal)
```

Pinned by test, and confirmed by mutation testing: widening the predicate to `return True` fails the orphan test, narrowing it to `return False` fails the byte-identity test. Both directions caught.

## Verification

- `tests/paper`: **952 passed, 1 skipped** (+5 new tests)
- Every artifact the fixed code produces is **byte-identical** to one already opened in PowerPoint and confirmed to open — including the newly reachable shape, a package paper-pptx writes that carries folder records. Recorded as Round 6 in the verdict ledger.
- Pre-existing repo-wide `ruff` findings are unchanged (identical count at the base commit); all five changed files are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core package diff/save semantics used for verification and narrow saves; behavior changes are intentional and heavily tested, but callers relying on the old false positives or broken no-op path could see different reports.
> 
> **Overview**
> **`patch_save`** no longer treats missing ZIP folder entries (names ending in `/`) as document changes when deciding the byte-copy no-op path. It adds `_save_cannot_emit` for members `save()` cannot rebuild from the OPC graph; real dropped parts (e.g. orphan media) still force a rewrite and stay in the residual diff. Actual edits still drop folder records and report them as removed.
> 
> **`diff_decks`** picks exact vs serialized package reads **per input pair**: if either side is an open `Presentation`, both sides are serialized for `package_changes`; path/stream pairs are still read exactly from disk. That removes false `package_changes` when a deck on disk has folder records but the other side is loaded in memory.
> 
> Docs note the normalization rule; new tests cover folder-record decks, orphan-part boundaries, and consistent empty diffs for `(path, path)` vs `(path, Presentation)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43caabb91a1f156f731a53c6612324a7b18afaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent package comparisons that caused false removals and unnecessary rewrites. Before, `patch_save` and `diff_decks` compared a disk package to a `save()`-rendered package; now both compare like with like, restoring byte-identical no-op saves and consistent diffs.

- patch_save: decides “unchanged” over members that can be parts. ZIP folder records (names ending with “/”) no longer defeat the byte-copy path; actual edits still drop and report them. Orphan parts still force a rewrite and a “removed” delta.
- diff_decks: normalization is decided per pair. If either side is a `Presentation`, both sides are serialized; if both are paths/streams, both are read exactly. `(path, path)` and `(path, Presentation(path))` now agree.
- Internal/tests/docs: adds `_save_cannot_emit(name)` and a `normalized` flag threaded through `_source_package_map`; clarifies docs to “every package member”; adds tests for folder-record decks, edited saves that report dropped folder records, and the orphan-part boundary. No API changes or migrations.

<sup>Written for commit d43caabb91a1f156f731a53c6612324a7b18afaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

