### PR TITLE
docs: correct and complete the docstrings for the fork delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,9 @@ mutated.
 **Layout rebind with a mandatory shift report.** `Slide.rebind_layout()` moves
 a slide to another layout under explicit placeholder and orphan policies, runs
 the effective-value resolver before and after, and reports every run whose
-resolved appearance changed — a rebind never shifts appearance silently.
+resolved font changed, so a typography shift never passes silently. Placeholder
+geometry and text direction are inherited from the layout too and sit outside
+that comparison.
 
 **Real fields, not static text.** `Presentation.apply_footers()` reproduces
 PowerPoint's Insert → Header & Footer behavior: genuine `a:fld` slide-number
@@ -402,9 +404,11 @@ corruption prevention:
   on its next save, and so does `save()`.
 - **Atomic save.** `save()` keeps its signature, but saving to a path now
   writes a sibling temporary file and atomically replaces the destination only
-  after serialization succeeds, preserving the existing file's permission bits;
-  stream saves snapshot and restore the destination on failure. Upstream wrote
-  directly to the destination, so a mid-save failure destroyed the only copy.
+  after serialization succeeds, preserving the existing file's permission bits.
+  Stream saves stage the whole package first, so a serialization failure emits
+  nothing, and restore the destination on failure when it can be read and
+  rewound; a write-only sink keeps whatever landed. Upstream wrote directly to
+  the destination, so a mid-save failure destroyed the only copy.
 - **`SlideLayouts.remove()` hardening.** Same signature, stricter semantics:
   stale or foreign proxies and unsafe states now refuse atomically instead of
   partially mutating.
@@ -419,8 +423,11 @@ corruption prevention:
 ## The safety contract
 
 Every added operation either does exactly what it claims or refuses
-atomically. Mutating operations validate fully before they change anything —
-never mutate-then-validate. When an operation cannot proceed safely, it raises
+atomically. Mutating operations run inside a package transaction: whatever the
+operation touched is restored if it refuses, and the deck-wide check runs
+before anything commits. Some operations, including `apply_footers()`,
+`append_deck()`, `import_slide()` and slide clone, additionally validate in
+full before touching anything. When an operation cannot proceed safely, it raises
 a typed refusal from the hierarchy rooted at `pptx.errors.PaperRefusal`
 (`PackageLimitError`, `TargetNotFoundError`, `StaleAnchorError`,
 `AmbiguousTargetError`, `UnsupportedStructureError`, `RelationshipPolicyError`,

--- a/src/pptx/_transaction.py
+++ b/src/pptx/_transaction.py
@@ -41,6 +41,12 @@ class TransactionRollbackError(RuntimeError):
         original_exception: BaseException,
         failures: Iterable[tuple[str, BaseException]],
     ):
+        """Build the composite error, exposing `original_exception` and `failures` as attributes.
+
+        `original_exception` is the failure that triggered the rollback and the only route back to
+        it, since this error propagates in its place. `failures` holds one `(label, exception)` pair
+        per restore step that failed.
+        """
         self.original_exception = original_exception
         self.failures = tuple(failures)
         details = "; ".join(
@@ -69,6 +75,9 @@ class _ElementTreeState:
     """Original element objects and scalar state for one XML part."""
 
     def __init__(self, root):
+        """Snapshot one element tree, namespace prefixes included, so a rollback restores it byte
+        for byte.
+        """
         from lxml import etree
 
         self._root = root
@@ -166,6 +175,11 @@ class _ObjectGraphState:
     """Mutable state reachable through existing package and caller proxy caches."""
 
     def __init__(self, roots: Iterable[object]):
+        """Snapshot the live proxy objects reachable from `roots`.
+
+        A rollback has to restore Python state as well as XML, or a caller keeps holding proxies
+        that point into a tree that no longer exists.
+        """
         from lxml import etree
 
         from pptx.opc.package import OpcPackage, Part
@@ -266,6 +280,8 @@ class _ValidationReadState:
         *,
         snapshot_all_xml: bool = True,
     ):
+        """Snapshot what validation needs to read, so a failed check can still restore the package.
+        """
         from pptx.opc.package import XmlPart
 
         self._transaction = transaction
@@ -332,6 +348,12 @@ class PackageTransaction:
     """Restore a package's original live graph if the guarded operation raises."""
 
     def __init__(self, package: "OpcPackage", *roots: object):
+        """Prepare a rollback boundary over `package`, tracking the proxies passed as `roots`.
+
+        Validates the relationship graph immediately, so a malformed relationship or a signature
+        part refuses here rather than on entry. Nothing is snapshotted until `__enter__`, so the
+        instance can be built well before the mutation site.
+        """
         self._package = package
         self._roots = tuple(roots)
         self._package_dict = {}
@@ -345,6 +367,15 @@ class PackageTransaction:
         self._validated_reachable_part_dicts(dict(package.__dict__))
 
     def __enter__(self) -> "PackageTransaction":
+        """Capture this block's own rollback snapshot and open the boundary.
+
+        Every entry snapshots independently, nested ones included: an inner block that raises
+        restores state as of its own entry, not the state before the outer block. Only the outermost
+        block on a given package validates the candidate on clean exit.
+
+        Raises RuntimeError if this object is already inside its own `with`, and
+        TransactionRollbackError if capturing the snapshot perturbs live state unrecoverably.
+        """
         if self._context_token is not None:
             raise RuntimeError("PackageTransaction cannot be entered more than once")
         self._capture_entry_snapshot()
@@ -393,6 +424,15 @@ class PackageTransaction:
         self._object_graph_state = state._object_graph_state
 
     def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        """Close the boundary; never suppress an exception.
+
+        On an exception, restore this block's entry snapshot and let the original error propagate,
+        unless a restore step also fails, in which case TransactionRollbackError propagates in its
+        place and the package must be treated as unsafe. On clean exit from the outermost block,
+        save and reopen the candidate, rolling back and re-raising if that fails.
+
+        Raises RuntimeError if the transaction was never entered, or if contexts exit out of order.
+        """
         token = self._context_token
         if token is None:
             raise RuntimeError("PackageTransaction exited without being entered")

--- a/src/pptx/_zipguard.py
+++ b/src/pptx/_zipguard.py
@@ -145,6 +145,13 @@ def preflight_zip(source: object) -> None:
 
 
 def _preflight_zip_stream(stream: BinaryIO) -> None:
+    """Validate the archive footer and central directory before `zipfile` parses them.
+
+    Runs first, so an ambiguous archive refuses before any part is read. Requires one unambiguous
+    central-directory region: a single end record accounting for the end of the file, no multi-disk
+    structure, counts and offsets that agree, and a first byte that starts a member record. Bytes
+    appended after the end record and bytes prepended before the archive both refuse.
+    """
     try:
         original_position = stream.tell()
         stream.seek(0, os.SEEK_END)
@@ -229,6 +236,11 @@ def _preflight_zip_stream(stream: BinaryIO) -> None:
 
 
 def _find_end_record(stream: BinaryIO, archive_size: int) -> Tuple[int, Tuple[int, ...]]:
+    """Locate the end-of-central-directory record that accounts for the end of the file.
+
+    Refuses when no record does, or when more than one does. Either way the member list has more
+    than one reading, and PowerPoint refuses the package in that state too.
+    """
     tail_size = min(archive_size, _END_RECORD.size + _MAX_END_COMMENT_BYTES)
     stream.seek(archive_size - tail_size, os.SEEK_SET)
     tail = stream.read(tail_size)
@@ -270,6 +282,12 @@ def _read_zip64_end_record(
     end_offset: int,
     legacy_fields: Tuple[int, ...],
 ) -> Tuple[int, int, int, int, int]:
+    """Read the ZIP64 locator and end record, returning counts, central size and offset, and the
+    record's own offset.
+
+    Refuses a missing, truncated, or misshaped locator or record, ZIP64 multi-disk structure, and
+    any ZIP64 field that disagrees with a non-sentinel legacy value.
+    """
     locator_offset = end_offset - _ZIP64_LOCATOR.size
     if locator_offset < 0:
         raise PackageLimitError("ZIP64 package is missing its locator")
@@ -333,6 +351,7 @@ def _validate_zip64_legacy_value(
     sentinel: int,
     label: str,
 ) -> None:
+    """Refuse when a ZIP64 field and its legacy counterpart disagree about the same quantity."""
     if legacy != sentinel and legacy != actual:
         raise PackageLimitError(f"ZIP64 {label} disagrees with the legacy end record")
 
@@ -343,6 +362,11 @@ def _scan_central_directory(
     central_size: int,
     expected_count: int,
 ) -> None:
+    """Walk every central-directory record, refusing a directory the region cannot hold one way.
+
+    Refuses a truncated or unsigned record, a record naming a nonzero disk, records that overrun the
+    declared region, and a member count that disagrees with the end record.
+    """
     cursor = central_offset
     central_end = central_offset + central_size
     actual_count = 0
@@ -374,12 +398,15 @@ def _scan_central_directory(
 class GuardedZipReader:
     """Validate and stream every member of an already-open ``ZipFile``.
 
-    Construction fully validates the archive and caches every member's bytes.
-    This makes ordinary ``Document()`` opens and package-kernel reads share the
-    same validation, including for members not reachable from OPC relationships.
+    Construction fully validates the archive and caches every member's bytes. This makes an ordinary
+    ``Presentation()`` open share the same validation, including for members not reachable from OPC
+    relationships.
     """
 
     def __init__(self, zip_file: ZipFile):
+        """Wrap `zip_file`, splitting its records into all members and the subset that can be OPC
+        parts.
+        """
         self._zip_file = zip_file
         # -- every central-directory record, directory entries included: the physical-layout
         # -- checks derive each member's boundary from the next record's offset, so they need
@@ -405,6 +432,14 @@ class GuardedZipReader:
         return dict(self._parts), list(self.order)
 
     def _validate_metadata(self) -> None:
+        """Refuse member records the archive cannot read one way, or cannot support.
+
+        Covers noncanonical part names (through `_validate_member_name`), duplicate and case-
+        colliding names, names whose stored bytes differ from the canonical form, invalid or shared
+        local-header offsets, encryption, patched-data encoding, compression outside the two the OPC
+        ZIP mapping allows, non-regular filesystem entry types, negative sizes, and stored members
+        whose two sizes disagree.
+        """
         seen_names: set[str] = set()
         seen_equivalent_names: set[str] = set()
         seen_offsets: set[int] = set()
@@ -463,6 +498,13 @@ class GuardedZipReader:
                 )
 
     def _read_all_members(self) -> Dict[str, bytes]:
+        """Read every part, validating physical layout as it goes.
+
+        Each member's boundary comes from the next record's offset, so a gap or an overlap refuses
+        instead of returning whatever bytes sit there. `[Content_Types].xml` is read first so the
+        member list can be checked against it; an archive carrying no such member skips that check
+        and fails in the OPC layer instead.
+        """
         if not self._infos:
             return {}
         stream = self._zip_file.fp
@@ -525,6 +567,12 @@ class GuardedZipReader:
         return parts
 
     def _validate_content_types(self, content_types: bytes) -> None:
+        """Refuse members that `[Content_Types].xml` gives no type, by Override or by Default
+        extension.
+
+        PowerPoint refuses such a package whatever the part is for, so accepting it here would hand
+        back a deck that will not open.
+        """
         defaults, overrides = _parse_content_types(content_types)
 
         # -- OPC gives every part a content type, by an Override naming the part or a
@@ -552,6 +600,7 @@ class GuardedZipReader:
             )
 
     def _validate_local_header(self, info: ZipInfo, boundary: int) -> int:
+        """Check one member's local header against its central-directory record and its boundary."""
         stream = self._zip_file.fp
         if stream is None:
             raise PackageLimitError("ZIP package stream is closed")
@@ -621,6 +670,9 @@ class GuardedZipReader:
         return data_start
 
     def _validate_data_descriptor(self, info: ZipInfo, data_end: int, boundary: int) -> None:
+        """Check a member's trailing data descriptor, refusing bytes between members that nothing
+        declares.
+        """
         stream = self._zip_file.fp
         if stream is None:
             raise PackageLimitError("ZIP package stream is closed")
@@ -659,6 +711,11 @@ class GuardedZipReader:
             )
 
     def _inflate_member(self, info: ZipInfo, data_start: int) -> bytes:
+        """Inflate one member from its raw bytes, checking CRC and declared size.
+
+        Reads the compressed bytes directly rather than through `ZipFile.read`, so a size header
+        that lies cannot pass unnoticed.
+        """
         stream = self._zip_file.fp
         if stream is None:
             raise PackageLimitError("ZIP package stream is closed")
@@ -744,6 +801,11 @@ def _member_extension(name: str) -> str:
 
 
 def _parse_content_types(data: bytes) -> Tuple[Dict[str, str], Dict[str, str]]:
+    """Parse `[Content_Types].xml` into its Default and Override maps.
+
+    Refuses a malformed document, a DTD, an unexpected root element, an invalid or ambiguous Default
+    or Override declaration, and any other child element.
+    """
     try:
         root = etree.fromstring(data, _CONTENT_TYPES_PARSER)
     except etree.XMLSyntaxError as exc:
@@ -831,6 +893,12 @@ def _is_directory_entry(info: ZipInfo) -> bool:
 
 
 def _validate_member_name(name: str) -> None:
+    """Refuse a member name that cannot denote one unambiguous OPC part.
+
+    Covers empty names, names that are not NFC-normalized, leading or trailing slashes, backslashes,
+    URI query or fragment characters, control characters, `.` and `..` path segments, drive-
+    qualified paths, and percent escapes that are malformed or unsafe.
+    """
     if not name:
         raise PackageLimitError("ZIP contains an empty member name")
     if name != unicodedata.normalize("NFC", name):

--- a/src/pptx/compose.py
+++ b/src/pptx/compose.py
@@ -61,6 +61,7 @@ class _ComposeTransaction(PackageTransaction):
     """Package transaction rooted at the destination presentation."""
 
     def __init__(self, dest_prs):
+        """Open a transaction over the destination package so a failed import rolls back."""
         super().__init__(dest_prs.part.package, dest_prs)
 
 
@@ -130,6 +131,7 @@ class ImportReport:
     run_shifts: tuple
 
     def to_dict(self) -> dict:
+        """Return the import report as a JSON-ready dict stamped with its schema and version."""
         return {
             "schema": SCHEMA_NAME,
             "version": SCHEMA_VERSION,
@@ -222,6 +224,10 @@ def append_deck(
 def _validate_arguments(
     dest_prs, source_prs, slide, mode, position, notes, section, target_layout
 ) -> "Slide":
+    """Check the import arguments and return the resolved source slide.
+
+    Runs before any part is copied, so a bad call cannot leave the destination half-imported.
+    """
     from pptx.presentation import Presentation as _Presentation
     from pptx.slide import Slide as _Slide
     from pptx.slide import SlideLayout as _SlideLayout
@@ -508,12 +514,20 @@ def _resolved_run_values(shape) -> list:
 
 @dataclass
 class _LayoutBinding:
+    """The destination layout an imported slide binds to, and how that layout was chosen."""
     layout: "Optional[SlideLayout]"  # -- None only for keep_appearance (pre-transplant)
     # -- name-match | type-match | explicit | blank-fallback | first-fallback | transplant
     method: str
 
 
 def _resolve_layout_binding(dest_prs, source_slide, mode, target_layout) -> _LayoutBinding:
+    """Choose the destination layout for an imported slide, or refuse.
+
+    `keep_appearance` short-circuits to a source-chain transplant. Otherwise: explicit
+    `target_layout`, then a layout-name match, then a layout-type match. With no match, `bake` falls
+    back to a blank layout and then the first layout, while `adopt_theme` raises
+    UnsupportedStructureError telling the caller to pass `target_layout`.
+    """
     if mode == "keep_appearance":
         return _LayoutBinding(None, "transplant")
     if target_layout is not None:
@@ -545,6 +559,7 @@ def _resolve_layout_binding(dest_prs, source_slide, mode, target_layout) -> _Lay
 def _perform_import(
     dest_prs, source_slide, plan, mode, binding, prep, position, notes, section
 ) -> ImportReport:
+    """Copy the source slide into the destination and report what changed."""
     from pptx.parts.slide import SlidePart
     from pptx.rebind import _resolution_state, _shifts_between
 
@@ -715,11 +730,20 @@ class _ImportSession(_CopySession):
     """
 
     def __init__(self, dest_package, source_package):
+        """Plan a fresh identity for every `a16:creationId` in the whole source package.
+
+        Any part may end up copied, so the plan spans the entire source deck. Refuses with
+        RelationshipPolicyError when the source contains duplicate creation ids, even in parts this
+        import will not touch. `created_parts` logs what the import adds.
+        """
         super().__init__(dest_package, tuple(source_package.iter_parts()))
         self.created_parts = []
 
 
 def _dedupe_cache(package) -> dict:
+    """Per-package fingerprint cache, so a repeated import reuses a transplanted master rather than
+    copying it again.
+    """
     cache = getattr(package, "_paper_compose_fingerprints", None)
     if cache is None:
         cache = {}
@@ -826,6 +850,7 @@ def _import_support_part(dest_package, part, allocated, reused):
 
 
 def _is_xml_payload(part) -> bool:
+    """True when `part` holds XML, judged by content type or by an `.xml` part name."""
     content_type = part.content_type.lower()
     return (
         content_type.endswith("+xml")
@@ -884,6 +909,10 @@ def _import_diagram_part(dest_package, dgm_part, allocated, reused):
 
 
 def _import_leaf_into(dest_package, part, allocated):
+    """Copy one part's payload into the destination under a fresh part name, identities remapped.
+
+    Relationships are not copied: the caller rebuilds them and rewrites `r:` references.
+    """
     partname = _allocate_partname(dest_package, _partname_template(str(part.partname)), allocated)
     if isinstance(part, XmlPart):
         copied = type(part)(partname, part.content_type, dest_package, copy.deepcopy(part._element))
@@ -933,6 +962,12 @@ def _transplant_layout_chain(dest_prs, source_layout, allocated, reused):
 
 
 def _transplant_master(dest_prs, source_master, allocated, reused):
+    """Copy a source master, its theme and media but NOT its layouts, into the destination.
+
+    Layouts enroll on demand through `_transplant_layout_chain`, which is what lets several slides
+    from one source deck share a single transplanted master. Returns an identical master already in
+    the destination instead of copying it twice.
+    """
     dest_package = dest_prs.part.package
     cache = _dedupe_cache(dest_package)
     master_part = source_master.part
@@ -996,6 +1031,7 @@ def _next_layout_or_master_id(dest_prs) -> int:
 
 
 def _find_section(presentation_elm, name: str):
+    """The `p14:section` named `name`, or None when the deck has no section by that name."""
     for section in presentation_elm.findall(".//{%s}sectionLst/{%s}section" % (_P14_NS, _P14_NS)):
         if section.get("name") == name:
             return section

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -62,6 +62,7 @@ class BulletShift:
     after: dict
 
     def to_dict(self) -> dict:
+        """Return this bullet change as a JSON-ready dict, before and after values included."""
         return {
             "part": self.part,
             "shape_id": self.shape_id,
@@ -74,21 +75,25 @@ class BulletShift:
 
 @dataclass(frozen=True)
 class SlideRef:
+    """Identifies a slide by id, position, and title."""
     slide_id: int
     position: int
     title: Optional[str]
 
     def to_dict(self) -> dict:
+        """Return this slide reference as a JSON-ready dict."""
         return {"slide_id": self.slide_id, "position": self.position, "title": self.title}
 
 
 @dataclass(frozen=True)
 class MovedSlide:
+    """A slide that kept its identity and changed position."""
     slide_id: int
     from_position: int
     to_position: int
 
     def to_dict(self) -> dict:
+        """Return this move as a JSON-ready dict."""
         return {
             "slide_id": self.slide_id,
             "from_position": self.from_position,
@@ -114,6 +119,7 @@ class SlideChange:
 
     @property
     def is_empty(self) -> bool:
+        """True when nothing on this slide changed. Check it before adding the slide to a report."""
         return not (
             self.shapes_added
             or self.shapes_removed
@@ -127,6 +133,8 @@ class SlideChange:
         )
 
     def to_dict(self) -> dict:
+        """Return this slide's changes as a JSON-ready dict, omitting the categories that are empty.
+        """
         payload: dict = {"slide_id": self.slide_id}
         if self.shapes_added:
             payload["shapes_added"] = list(self.shapes_added)
@@ -162,6 +170,7 @@ class DeckDiff:
 
     @property
     def is_empty(self) -> bool:
+        """True when the two decks match. Check it to skip reporting a no-op edit."""
         return not (
             self.slides_added
             or self.slides_removed
@@ -171,6 +180,7 @@ class DeckDiff:
         )
 
     def to_dict(self) -> dict:
+        """Return the whole diff as a JSON-ready dict stamped with its schema and version."""
         return {
             "schema": SCHEMA_NAME,
             "version": SCHEMA_VERSION,
@@ -431,6 +441,7 @@ def _longest_common_subsequence(sequence_a: "List[int]", sequence_b: "List[int]"
 
 
 def _title_of(slide) -> "Optional[str]":
+    """Title text of `slide`, or None when it has no title placeholder or the title is blank."""
     title = slide.shapes.title
     if title is None or not title.has_text_frame:
         return None
@@ -462,10 +473,22 @@ def _shape_keys(slide) -> dict:
 
 
 def _shape_key_text(key) -> str:
+    """Render a shape key for a report.
+
+    The shape name, or `kind#ordinal` when the name is missing or shared with another shape on the
+    same slide.
+    """
     return key[1] if key[0] == "name" else "%s#%d" % (key[1], key[2])
 
 
 def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
+    """Compare one id-matched slide pair, gated by `detail`.
+
+    Always: top-level shape add and remove, geometry, image replacement. `"text"` adds chart data,
+    text blocks and notes. `"full"` adds per-run effective-value shifts and bullet shifts. Shapes
+    match at the top level only, so a shape moved into a group reads as one removal plus one
+    addition.
+    """
     shapes_a = _shape_keys(slide_a)
     shapes_b = _shape_keys(slide_b)
     shapes_added = tuple(_shape_key_text(key) for key in sorted(set(shapes_b) - set(shapes_a)))
@@ -528,6 +551,12 @@ def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
 
 
 def _image_hash(shape) -> "Optional[str]":
+    """Short content hash of a picture's image bytes.
+
+    None when `shape` is not a picture, so non-pictures never enter the image comparison. An image
+    reference that will not load hashes as the sentinel "unreadable" rather than raising mid-diff:
+    two unreadable sides compare equal, but unreadable against readable reports as a replacement.
+    """
     from pptx.shapes.picture import Picture
 
     if not isinstance(shape, Picture):
@@ -614,6 +643,12 @@ def _diff_chart(key, chart_a, chart_b) -> "List[dict]":
 
 
 def _chart_data(chart):
+    """Return `(categories, series)` for `chart`, comparable by value across decks.
+
+    `categories` comes from `plots[0]`; `series` spans every plot as `(plot_index, series_index,
+    name, values)`. Raises IndexError on a chart with no plots, which is the signal `_diff_chart`
+    uses to compare chart XML opaquely instead.
+    """
     categories = [str(category) for category in chart.plots[0].categories]
     series = []
     for plot_index, plot in enumerate(chart.plots):
@@ -640,6 +675,11 @@ def _text_blocks_by_stable_key(slide) -> dict:
 
 
 def _diff_text(slide_a, slide_b) -> "List[dict]":
+    """Text and field-marker changes between two slides, matched on stable block keys.
+
+    A block reports when its literal text changed or its field markers did, so an entry whose before
+    and after strings are equal means only the fields moved or changed type.
+    """
     blocks_a = _text_blocks_by_stable_key(slide_a)
     blocks_b = _text_blocks_by_stable_key(slide_b)
     changes = []
@@ -700,12 +740,14 @@ def _iter_text_shapes(shapes):
 def _bullet_state(slide) -> dict:
     """(comparable bullet values, payload) per paragraph, keyed (shape_id, paragraph text).
 
-    Content-keyed for the same reason `pptx.rebind._resolution_state(align_by_content=True)`
-    is: a paragraph inserted above shifts every later index, and index keys would then pair
-    unrelated paragraphs and report bullet changes that never happened. Paragraphs whose text
-    repeats within their shape carry no unique identity and are skipped rather than guessed at.
+    Content-keyed for the same reason `pptx.rebind._resolution_state(align_by_content=True)` is: a
+    paragraph inserted above shifts every later index, and index keys would then pair unrelated
+    paragraphs and report bullet changes that never happened. Paragraphs that are empty, or whose
+    text repeats within their shape, carry no unique identity and are skipped rather than guessed
+    at.
 
-    Paragraphs the resolver refuses -- table cells, which are not `p:sp` -- are skipped too. A
+    Only `p:sp` text frames are walked, so table and chart text never reaches the resolver. A
+    paragraph the resolver does refuse (an out-of-schema `lvl`, a non-slide part) is skipped too: a
     refusal here is a scope boundary, not a diff failure.
     """
     from pptx.errors import UnsupportedStructureError
@@ -742,6 +784,10 @@ def _bullet_state(slide) -> dict:
 
 
 def _bullet_shifts_between(before_state, after_state) -> "Tuple[BulletShift, ...]":
+    """Bullet changes for paragraphs keyed in both states, skipping those whose values match.
+
+    `paragraph_index` on each shift is the before-side index.
+    """
     shifts = []
     for key in sorted(set(before_state) & set(after_state), key=lambda k: (k[0], k[1])):
         before_values, text, partname, before_payload, index = before_state[key]
@@ -761,6 +807,7 @@ def _bullet_shifts_between(before_state, after_state) -> "Tuple[BulletShift, ...
 
 
 def _notes_text(slide) -> "Optional[str]":
+    """Notes text of `slide`, or None when it carries no notes slide."""
     if not slide.has_notes_slide:
         return None
     return slide.read_notes_text()

--- a/src/pptx/edit.py
+++ b/src/pptx/edit.py
@@ -51,6 +51,7 @@ class ReplaceResult:
     blocks: Tuple[BlockAnchor, ...] = field(default_factory=tuple)
 
     def to_dict(self) -> dict:
+        """Return the replace result as a JSON-ready dict stamped with its schema and version."""
         return {
             "schema": RESULT_SCHEMA_NAME,
             "version": RESULT_SCHEMA_VERSION,
@@ -323,6 +324,11 @@ def _run_segments(p) -> "List[List[object]]":
 
 
 def _replace_in_segment(runs, find: str, replace: str) -> int:
+    """Replace every occurrence of `find` across `runs`.
+
+    Characters the edit does not touch keep their own run, so formatting survives a replacement that
+    straddles a run boundary.
+    """
     texts = [_run_text_of(r) for r in runs]
     full = "".join(texts)
     matches = _find_occurrences(full, find)
@@ -392,5 +398,6 @@ def _find_occurrences(text: str, find: str) -> "List[Tuple[int, int]]":
 
 
 def _run_text_of(r) -> str:
+    """Text of a run's `a:t` child, or an empty string when absent."""
     t = r.find(qn("a:t"))
     return (t.text or "") if t is not None else ""

--- a/src/pptx/errors.py
+++ b/src/pptx/errors.py
@@ -6,8 +6,10 @@ requested change unsafe or unsupported and said so instead of guessing. Callers 
 catch `PaperRefusal` distinctly from bugs; programmer errors (bad argument types or values)
 remain `TypeError`/`ValueError` as usual.
 
-Every paper mutating API is structured validate-fully-then-mutate, so a refusal can never
-leave a partial edit behind.
+Paper mutating APIs run inside a package transaction: whatever the operation touched is
+restored if it refuses, and the deck-wide check runs before anything commits. Some APIs
+(`apply_footers`, `append_deck`, `import_slide`, clone) additionally validate in full before
+touching anything. Either way a refusal never leaves a partial edit behind.
 """
 
 from __future__ import annotations
@@ -29,7 +31,12 @@ class PaperRefusal(Exception):
 
 
 class PackageLimitError(PaperRefusal):
-    """The package archive is ambiguous or unsafe to expand."""
+    """The package archive has no single unambiguous reading, or is unsafe to expand.
+
+    Raised reading a package (ambiguous ZIP end records, duplicate or overlapping members,
+    encryption, malformed `[Content_Types].xml`) and writing one (parts that would collide on a
+    single ZIP member name).
+    """
 
 
 class AmbiguousTargetError(PaperRefusal):
@@ -37,7 +44,12 @@ class AmbiguousTargetError(PaperRefusal):
 
 
 class TargetNotFoundError(PaperRefusal):
-    """The addressing given matches nothing in this document."""
+    """The target could not be resolved in this document.
+
+    Either the addressing given (name, index, id, section) matches nothing, or a proxy handed in has
+    gone stale because the shape, part, or content it wrapped is no longer reachable. See
+    |StaleAnchorError| for the content-hash case.
+    """
 
 
 class StaleAnchorError(TargetNotFoundError):
@@ -50,15 +62,29 @@ class StaleAnchorError(TargetNotFoundError):
 
 
 class UnsupportedStructureError(PaperRefusal):
-    """The document contains structure this API cannot operate on safely."""
+    """This API cannot operate safely on the document as it stands.
+
+    Covers input it will not touch (unsupported structure, an unreadable package, a signed deck a
+    rewrite would invalidate) and, at commit or `batch()` exit, edits whose result would not reopen
+    as a presentation. In that second case the edits roll back.
+    """
 
 
 class BoundaryViolationError(PaperRefusal):
-    """The operation would cross a boundary it promised to stay inside."""
+    """An operation ran outside the scope where it is safe.
+
+    Today that means one thing: saving while a `batch()` block is open on the package. Those edits
+    are not validated yet and may still roll back, so save after the block closes.
+    """
 
 
 class RelationshipPolicyError(PaperRefusal):
-    """The relationship graph cannot be honored under the requested policy."""
+    """The relationship graph cannot be carried across as asked.
+
+    Either the source carries relationship types this operation's ledger does not support, or the
+    graph itself is unusable: a malformed relationship collection, an invalid target mode, or an
+    internal relationship pointing outside its own package.
+    """
 
 
 def materialize_slides(prs, operation: str):

--- a/src/pptx/hf.py
+++ b/src/pptx/hf.py
@@ -129,6 +129,7 @@ def apply_slide_footers(
 
 
 def _validate_arguments(footer, slide_number, date_format, fixed_date, now) -> None:
+    """Check the header and footer arguments before any slide is touched."""
     if footer is not None:
         _validate_text("footer", footer)
     if not isinstance(slide_number, bool):
@@ -150,6 +151,10 @@ def _validate_arguments(footer, slide_number, date_format, fixed_date, now) -> N
 
 
 def _validate_text(name: str, value) -> None:
+    """Refuse text that is not a non-empty str, holds a lone surrogate, or holds a C0 control.
+
+    Tab is the one control allowed through, so a footer cannot span lines: a newline is refused.
+    """
     if not isinstance(value, str) or not value:
         raise ValueError("%s must be a non-empty str, or None to remove" % name)
     try:
@@ -194,6 +199,7 @@ def _validate_slide_furniture(slide, footer, slide_number, date_format, fixed_da
 
 
 def _wanted_kinds(footer, slide_number, date_format, fixed_date) -> "List[str]":
+    """Which of date, footer, and slide number the caller asked to be present."""
     wanted = []
     if date_format is not None or fixed_date is not None:
         wanted.append("dt")
@@ -208,6 +214,7 @@ def _wanted_kinds(footer, slide_number, date_format, fixed_date) -> "List[str]":
 
 
 def _first_slide_number(prs: "Presentation") -> int:
+    """The number this deck starts counting slides from."""
     return int(prs._element.get("firstSlideNum", "1"))
 
 
@@ -235,6 +242,11 @@ def _slide_phs(slide, kind):
 
 
 def _apply_to_slide(slide, number, footer, slide_number, date_format, fixed_date, now):
+    """Write the wanted date, footer, and slide-number placeholders onto one slide.
+
+    Clones the placeholder from the layout when the slide has none, and deletes the shapes for
+    unwanted kinds along with any duplicates past the first.
+    """
     wanted = _wanted_kinds(footer, slide_number, date_format, fixed_date)
     furniture = _layout_furniture(slide.slide_layout) if wanted else {}
 
@@ -312,6 +324,7 @@ def _fresh_paragraph(txBody):
 
 
 def _write_field(txBody, field_type: str, cached_text: str, field_id: str) -> None:
+    """Replace a placeholder's text with a field, so PowerPoint re-renders the value on open."""
     p, rPr, endParaRPr = _fresh_paragraph(txBody)
     fld = p.add_fld(field_id, field_type, cached_text)
     if rPr is not None:
@@ -321,6 +334,7 @@ def _write_field(txBody, field_type: str, cached_text: str, field_id: str) -> No
 
 
 def _write_literal(txBody, text: str) -> None:
+    """Replace a placeholder's text with a literal run."""
     p, rPr, endParaRPr = _fresh_paragraph(txBody)
     r = p.add_r()
     r.text = text

--- a/src/pptx/inspect.py
+++ b/src/pptx/inspect.py
@@ -94,6 +94,7 @@ class ProvenanceStep:
     supplied: bool  #: True on the step that supplied the resolved value
 
     def to_dict(self) -> dict:
+        """Return this rung as a JSON-ready dict, for reports that show where a value came from."""
         return {
             "level": self.level,
             "part": self.part,
@@ -113,6 +114,7 @@ class EffectiveValue:
     bake_color_xml: Optional[bytes] = field(default=None, repr=False, compare=False)
 
     def to_dict(self) -> dict:
+        """Return this resolved value as a JSON-ready dict, provenance trail included."""
         return {
             "value": (
                 int(self.value)
@@ -137,6 +139,10 @@ class EffectiveFont:
     underline: EffectiveValue = None  # pyright: ignore[reportAssignmentType]
 
     def to_dict(self) -> dict:
+        """Return the resolved font as a JSON-ready dict under the `paper-effective-font` schema.
+
+        Use it to report or diff typography without walking the inheritance chain again.
+        """
         return {
             "schema": "paper-effective-font",
             "version": 2,  # -- bold/italic/underline added
@@ -161,6 +167,9 @@ class EffectiveBullet:
     provenance: Tuple[ProvenanceStep, ...]
 
     def to_dict(self) -> dict:
+        """Return the resolved bullet as a JSON-ready dict, recording whether the answer came from
+        this paragraph or an inherited level.
+        """
         return {
             "type": self.type,
             "char": self.char,
@@ -189,6 +198,9 @@ class BlockAnchor:
     content_hash: str
 
     def to_dict(self) -> dict:
+        """Return this anchor as a JSON-ready dict. Store it to re-target the same text block on a
+        later open.
+        """
         return {
             "part": self.part,
             "block_index": self.block_index,
@@ -198,11 +210,13 @@ class BlockAnchor:
 
 @dataclass(frozen=True)
 class InspectedRun:
+    """One run of text paired with the font that renders it."""
     text: str
     font: EffectiveFont
     field_type: Optional[str] = None
 
     def to_dict(self) -> dict:
+        """Return this run as a JSON-ready dict, omitting `field_type` for ordinary text."""
         payload = {"text": self.text, "font": self.font.to_dict()}
         if self.field_type is not None:
             payload["field_type"] = self.field_type
@@ -234,6 +248,7 @@ class TextBlock:
     fields: Tuple[str, ...] = ()
 
     def to_dict(self) -> dict:
+        """Return this block as a JSON-ready dict, anchor included, for reports and diffs."""
         return {
             "anchor": self.anchor.to_dict(),
             "shape_id": self.shape_id,
@@ -262,6 +277,11 @@ class TextInspection:
         return sum(1 for block in self.blocks if block.blind)
 
     def to_dict(self) -> dict:
+        """Return the whole inspection as a JSON-ready dict stamped with its schema name and
+        version.
+
+        Hand this to anything outside Python that needs the text of a part.
+        """
         return {
             "schema": SCHEMA_NAME,
             "version": SCHEMA_VERSION,
@@ -304,6 +324,9 @@ class EffectiveParagraphFormat:
     bullet_size: EffectiveValue  #: fraction of text size, |Length| for points, or follows text
 
     def to_dict(self) -> dict:
+        """Return the resolved paragraph format as a JSON-ready dict under the `paper-effective-
+        paragraph-format` schema.
+        """
         return {
             "schema": "paper-effective-paragraph-format",
             "version": 3,  # -- was 2: bullet_font/bullet_size added
@@ -387,6 +410,7 @@ class ShapeManifest:
     children: Tuple["ShapeManifest", ...] = ()
 
     def to_dict(self) -> dict:
+        """Return this shape's manifest entry as a JSON-ready dict."""
         return {
             "shape_id": self.shape_id,
             "name": self.name,
@@ -419,6 +443,7 @@ class SlideManifest:
     alternate_content_count: int = 0  #: mc:AlternateContent subtrees (not surveyable)
 
     def to_dict(self) -> dict:
+        """Return this slide's manifest entry as a JSON-ready dict, shapes included."""
         return {
             "part": self.part,
             "slide_id": self.slide_id,
@@ -440,9 +465,14 @@ class DeckManifest:
 
     @property
     def slide_count(self) -> int:
+        """Number of slides the manifest describes."""
         return len(self.slides)
 
     def to_dict(self) -> dict:
+        """Return the deck manifest as a JSON-ready dict stamped with its schema and version.
+
+        This is the payload to hand a caller that cannot hold Python objects.
+        """
         return {
             "schema": DECK_MANIFEST_SCHEMA,
             "version": DECK_MANIFEST_VERSION,
@@ -498,6 +528,7 @@ def inspect_deck(prs) -> DeckManifest:
 
 
 def _shape_manifest(shape, z_index: int) -> ShapeManifest:
+    """Build one shape's manifest entry: kind, placeholder type, geometry, and z-order."""
     from pptx.shapes.group import GroupShape
     from pptx.shapes.picture import Picture
     from pptx.shapes.shapetree import _shape_kind
@@ -598,6 +629,7 @@ class EffectiveShapeFormat:
     line_rgb: EffectiveValue
 
     def to_dict(self) -> dict:
+        """Return the resolved fill and line colors as a JSON-ready dict."""
         return {
             "schema": "paper-effective-shape-format",
             "version": 1,
@@ -680,6 +712,14 @@ _MC_ALTERNATE_CONTENT = (
 
 
 def _iter_container(container_elm, group_path):
+    """Walk a shape tree, yielding one tuple per text body, plus one blind marker per region whose
+    text this version cannot survey.
+
+    Groups recurse and table frames yield one tuple per cell. `mc:AlternateContent`, charts, and
+    other graphic frames yield a `txBody=None` marker instead of content: for AlternateContent,
+    which branch renders depends on the consumer and picking one would be a guess. One marker still
+    equals one block index.
+    """
     for child in container_elm:
         if child.tag == _MC_ALTERNATE_CONTENT:
             # -- markup-compatibility content renders one of several branches depending on
@@ -784,6 +824,11 @@ def _walk_container(spTree, group_path, partname, resolver, blocks) -> None:
 def _append_block(
     blocks, partname, shape_elm, p, runs, placeholder_type, container, container_detail, blind
 ) -> None:
+    """Append one paragraph to `blocks` as a `TextBlock`.
+
+    The anchor hash covers only non-field text: a field's display text is volatile, so hashing it
+    would rot the anchor on the next PowerPoint render.
+    """
     text = "".join(inspected.text for inspected in runs if inspected.field_type is None)
     pPr = p.find(qn("a:pPr"))
     level = int(pPr.get("lvl", "0")) if pPr is not None else 0
@@ -809,11 +854,13 @@ def _append_block(
 
 
 def _cNvPr_name(shape_elm) -> str:
+    """Shape name from `p:cNvPr`, or an empty string when the element is absent."""
     cNvPr = shape_elm.find(".//%s" % qn("p:cNvPr"))
     return (cNvPr.get("name") or "") if cNvPr is not None else ""
 
 
 def _run_text(r) -> str:
+    """Text of a run's `a:t` child, or an empty string when absent."""
     t = r.find(qn("a:t"))
     return t.text or "" if t is not None else ""
 
@@ -851,6 +898,7 @@ class _FontResolver(object):
     """Executes the pinned inheritance walk for runs on one slide part. Strictly read-only."""
 
     def __init__(self, slide_part):
+        """Bind the resolver to one slide, caching its layout, master, and theme."""
         self._slide_part = slide_part
         self._layout = slide_part.slide_layout
         self._master = self._layout.slide_master
@@ -859,6 +907,11 @@ class _FontResolver(object):
     # ------------------------------------------------------------------------- public
 
     def effective_font(self, r, sp) -> EffectiveFont:
+        """Resolve the font that renders run `r`, walking run, paragraph, placeholder, master, then
+        theme.
+
+        Refuses when the paragraph declares an indent level outside the 0..8 the schema allows.
+        """
         p = r.getparent()
         pPr = p.find(qn("a:pPr"))
         level = int(pPr.get("lvl", "0")) if pPr is not None else 0
@@ -913,6 +966,12 @@ class _FontResolver(object):
             )
 
     def _placeholder_chain(self, sp, level):
+        """Yield the three placeholder rungs for `sp` at `level`, in inheritance order.
+
+        Layout placeholder `lstStyle`, then master placeholder `lstStyle`, then the master's
+        `p:txStyles` family style. Raises UnsupportedStructureError when the layout or master
+        placeholder match is missing or ambiguous.
+        """
         idx, ph_type = sp.ph_idx, sp.ph_type
         layout_ph = self._layout_placeholder(idx, ph_type)
         yield (
@@ -1272,6 +1331,7 @@ class _FontResolver(object):
         return None, []
 
     def _resolve_solid_fill(self, solidFill, label, partname, steps) -> EffectiveValue:
+        """Read a color out of an `a:solidFill`, appending the rung it came from to `steps`."""
         srgbClr = solidFill.find(qn("a:srgbClr"))
         if srgbClr is not None:
             detail = 'srgbClr val="%s"%s' % (
@@ -1315,12 +1375,16 @@ class _FontResolver(object):
 
     @staticmethod
     def _pPr_from_lstStyle(lstStyle, level):
+        """Paragraph properties for one indent level of an `a:lstStyle`, or None when there are
+        none.
+        """
         if lstStyle is None:
             return None
         return lstStyle.pPr_for_lvl(level)
 
     @staticmethod
     def _ph_lstStyle_pPr(placeholder_proxy, level):
+        """Paragraph properties from a placeholder's own `a:lstStyle` at `level`, or None."""
         if placeholder_proxy is None:
             return None
         txBody = placeholder_proxy._element.find(qn("p:txBody"))
@@ -1329,6 +1393,7 @@ class _FontResolver(object):
         return _FontResolver._pPr_from_lstStyle(txBody.find(qn("a:lstStyle")), level)
 
     def _master_family_style(self, ph_type):
+        """Master text style for the family `ph_type` belongs to: title, body, or other."""
         txStyles = self._master.element.txStyles
         if ph_type in _TITLE_FAMILY:
             return "titleStyle", txStyles.titleStyle if txStyles is not None else None
@@ -1376,6 +1441,10 @@ class _FontResolver(object):
         )
 
     def _master_placeholder(self, ph_type):
+        """Master placeholder matching `ph_type`.
+
+        Refuses when the master declares more than one: neither would be an unambiguous source.
+        """
         matches = [
             placeholder
             for placeholder in self._master.placeholders
@@ -1391,6 +1460,7 @@ class _FontResolver(object):
 
     @staticmethod
     def _master_placeholder_type(ph_type):
+        """Master placeholder type that a slide placeholder of `ph_type` inherits from."""
         if ph_type in _TITLE_FAMILY:
             return PP_PLACEHOLDER.TITLE
         if ph_type in (
@@ -1404,6 +1474,7 @@ class _FontResolver(object):
 
     @staticmethod
     def _ph_lstStyle_defRPr(placeholder_proxy, level):
+        """Default run properties from a placeholder's own `a:lstStyle` at `level`, or None."""
         if placeholder_proxy is None:
             return None
         txBody = placeholder_proxy._element.find(qn("p:txBody"))
@@ -1413,6 +1484,7 @@ class _FontResolver(object):
 
     @staticmethod
     def _defRPr_from_lstStyle(lstStyle, level):
+        """Default run properties for one indent level of an `a:lstStyle`, or None."""
         if lstStyle is None:
             return None
         lvl_pPr = lstStyle.pPr_for_lvl(level)
@@ -1423,6 +1495,11 @@ class _FontResolver(object):
     # ------------------------------------------------------------------------ resolvers
 
     def _resolve_size(self, chain) -> EffectiveValue:
+        """First explicit `sz` found walking `chain`, as an EMU Length with points in `value_pt`.
+
+        There is no default font size to fall back on, so an exhausted chain reports
+        `resolved=False` with the full consulted trail.
+        """
         steps = []
         for label, partname, rPr in chain:
             sz = rPr.get("sz") if rPr is not None else None
@@ -1468,6 +1545,11 @@ class _FontResolver(object):
         return EffectiveValue("none", None, True, tuple(steps))
 
     def _resolve_name(self, chain, text="") -> EffectiveValue:
+        """First explicit `a:latin` typeface found walking `chain`.
+
+        Returns unresolved for runs carrying non-Latin letters: this walk reads the Latin slot only,
+        so East Asian and complex-script selection stays unanswered rather than guessed.
+        """
         if self._has_non_latin_letters(text):
             return EffectiveValue(
                 None,
@@ -1506,6 +1588,7 @@ class _FontResolver(object):
         return EffectiveValue(None, None, False, tuple(steps))
 
     def _resolve_theme_font(self, token, steps) -> EffectiveValue:
+        """Resolve a `+mj-lt` or `+mn-lt` theme font reference against the theme's font scheme."""
         scheme_element = {"mj": "a:majorFont", "mn": "a:minorFont"}.get(token[1:3])
         if self._theme_root is None or scheme_element is None or not token.endswith("-lt"):
             steps.append(
@@ -1543,6 +1626,11 @@ class _FontResolver(object):
         return EffectiveValue(typeface, None, True, tuple(steps))
 
     def _resolve_color(self, chain, sp) -> EffectiveValue:
+        """First explicit color found walking `chain`, as an RRGGBB string.
+
+        Non-solid fills stop the walk unresolved. A color carrying transforms also reports
+        unresolved, with the unapplied transforms in `bake_color_xml`.
+        """
         steps = []
         for label, partname, rPr in chain:
             solidFill = rPr.find(qn("a:solidFill")) if rPr is not None else None
@@ -1606,6 +1694,9 @@ class _FontResolver(object):
         return EffectiveValue(None, None, False, tuple(steps))
 
     def _resolve_scheme_color(self, token, steps, source_partname) -> EffectiveValue:
+        """Resolve a scheme color token through the slide's color map, then the theme's color
+        scheme.
+        """
         slot, map_step = self._map_scheme_token(token, source_partname)
         steps.append(map_step)
         if slot is None:
@@ -1716,6 +1807,12 @@ class _FontResolver(object):
 
     @staticmethod
     def _transformed_color_value(color_element, base_rgb, steps) -> EffectiveValue:
+        """Return an unresolved value carrying `base_rgb` plus the element's unapplied transforms.
+
+        Transforms such as `lumMod` and `tint` are not computed here. The localized `a:srgbClr` goes
+        out as `bake_color_xml` for callers that can write it back verbatim, so the reported value
+        stays `resolved=False` rather than becoming a guess.
+        """
         localized = OxmlElement("a:srgbClr")
         localized.set("val", str(base_rgb).upper())
         for transform in color_element:
@@ -1732,6 +1829,7 @@ class _FontResolver(object):
 
     @staticmethod
     def _has_non_latin_letters(text: str) -> bool:
+        """True when `text` carries a letter outside the Latin scripts."""
         for char in text:
             if not unicodedata.category(char).startswith("L"):
                 continue
@@ -1757,6 +1855,7 @@ class _FontResolver(object):
 
     @staticmethod
     def _non_solid_fill_kind(rPr):
+        """Tag of the non-solid fill on `rPr`, or None when the fill is solid or absent."""
         if rPr is None:
             return None
         for tag in ("a:gradFill", "a:blipFill", "a:pattFill", "a:noFill", "a:grpFill"):
@@ -1766,13 +1865,21 @@ class _FontResolver(object):
 
     @staticmethod
     def _absence(rPr, what) -> str:
+        """Provenance detail for a rung that supplied nothing."""
         return "level not present" if rPr is None else what + " here"
 
     @property
     def _presentation_part(self):
+        """Presentation part this slide belongs to."""
         return self._slide_part.package.presentation_part
 
     def _load_theme(self):
+        """Parse the master's theme part, returning `(root, partname)`.
+
+        Returns `(None, None)` when the master has no theme relationship, so callers report an
+        unresolved theme. Raises UnsupportedStructureError when a theme part exists but will not
+        parse.
+        """
         try:
             theme_part = self._master.part.part_related_by(RT.THEME)
         except KeyError:

--- a/src/pptx/opc/package.py
+++ b/src/pptx/opc/package.py
@@ -82,6 +82,7 @@ class _StreamSnapshot:
     """
 
     def __init__(self, stream: IO[bytes], position: int | None, content: bytes | None):
+        """Hold a stream's position and prior bytes, so a failed publish can put them back."""
         self._stream = stream
         self._position = position
         self._content = content
@@ -119,6 +120,7 @@ class _StreamSnapshot:
 
     @property
     def can_roll_back(self) -> bool:
+        """True when the snapshot captured content and can restore it."""
         return self._content is not None
 
     def discard_tail(self) -> None:
@@ -253,30 +255,35 @@ class OpcPackage(_RelatableMixin):
     def save(self, pkg_file: str | IO[bytes]) -> None:
         """Save this package to `pkg_file`.
 
-        `file` can be either a path to a file (a string) or a file-like object.
+        `pkg_file` can be a filesystem path (`str` or `os.PathLike`) or a file-like object open
+        for writing bytes.
 
-        A path destination is written atomically: the package is serialized into a
-        temporary file in the destination's directory and moved into place with
-        `os.replace()`, so a failure part-way through leaves any existing file untouched.
-        Symlinks are resolved, so the file a link names is the file that is written.
+        A path destination is written atomically: the package is serialized into a temporary
+        file in the destination's directory and moved into place with `os.replace()`, so a
+        failure part-way through leaves any existing file untouched. Symlinks are resolved, so
+        the file a link names is the file that is written.
 
         A stream destination is serialized into a private staging buffer and then written
-        straight through, so no bytes reach the stream unless the whole package serialized.
-        A failure *during* that copy leaves a partial package with no rollback; a caller
-        writing to a pipe cannot expect otherwise. Only `write` is required of the stream.
-        The package is written at the stream's current position. A stream positioned at
-        the start is truncated to the package, so no tail of a previous document survives;
-        past that, bytes beyond the package are the caller's and are left alone.
+        straight through, so no bytes reach the stream unless the whole package serialized. Only
+        `write` is required of the stream. The package is written at the stream's current
+        position; past that, bytes beyond the package are the caller's and are left alone.
 
-        Atomic path writes are a deliberate departure from the v0 rule that `save()`
-        behavior is unchanged from upstream (`CONVENTIONS.md` "Explicitly NOT changed in
-        v0"; `PLAN-paper-pptx.md` Prohibitions), accepted because upstream serialized
-        directly into the destination, so a mid-write failure on the ordinary
-        `prs.save(same_path)` pattern destroyed the deck being edited, irrecoverably.
+        What a failure *during* that copy costs depends on what the destination supports. One
+        that can be read, rewound and truncated has its prior contents and cursor restored, and
+        if that restore itself fails the original error is replaced by a `RuntimeError` carrying
+        it as `__cause__`. A write-only or unseekable sink keeps whatever partial package landed;
+        a caller writing to a pipe cannot expect otherwise. The same capability decides
+        truncation: a readable stream positioned at the start is truncated to the package, so no
+        tail of a previous document survives, while a write-only stream keeps that tail.
 
-        The costs of replacing rather than overwriting: owner, group, ACLs, extended
-        attributes and hard links do not survive (mode bits are carried over), and the
-        destination's *directory* must be writable, not just the file.
+        Atomic path writes are a deliberate departure from the v0 rule that `save()` behavior is
+        unchanged from upstream, accepted because upstream serialized directly into the
+        destination, so a mid-write failure on the ordinary `prs.save(same_path)` pattern
+        destroyed the deck being edited, irrecoverably.
+
+        The costs of replacing rather than overwriting: owner, group, ACLs, extended attributes
+        and hard links do not survive (mode bits are carried over), and the destination's
+        *directory* must be writable, not just the file.
         """
         parts = tuple(self.iter_parts())
         if isinstance(pkg_file, (str, os.PathLike)):
@@ -431,8 +438,12 @@ class _PackageLoader:
     def _xml_rels(self) -> dict[PackURI, CT_Relationships]:
         """dict {partname: xml_rels} for package and all package parts.
 
-        This is used as the basis for other loading operations such as loading parts and
-        populating their relationships.
+        This is used as the basis for other loading operations such as loading parts and populating
+        their relationships.
+
+        Raises UnsupportedStructureError for a .rels part that declares one id twice, or that
+        targets a part the package does not contain. Neither has a single correct reading, and
+        PowerPoint refuses both.
         """
         xml_rels: dict[PackURI, CT_Relationships] = {}
         visited_partnames: Set[PackURI] = set()

--- a/src/pptx/opc/serialized.py
+++ b/src/pptx/opc/serialized.py
@@ -159,7 +159,12 @@ class _PhysPkgReader(Container[PackURI]):
 
     @classmethod
     def factory(cls, pkg_file: str | IO[bytes]) -> _PhysPkgReader:
-        """Return |_PhysPkgReader| subtype instance appropriage for `pkg_file`."""
+        """Return |_PhysPkgReader| subtype instance appropriage for `pkg_file`.
+
+        Accepts a `str` or `os.PathLike` path to a zip package, a path to a directory holding an
+        expanded package, or an open binary stream. Raises PackageNotFoundError when a path names
+        neither a directory nor a zip file.
+        """
         # --- for pkg_file other than str, assume it's a stream and pass it to Zip
         # --- reader to sort out
         if not isinstance(pkg_file, (str, os.PathLike)):
@@ -227,7 +232,13 @@ class _ZipPkgReader(_PhysPkgReader):
 
     @lazyproperty
     def _blobs(self) -> dict[PackURI, bytes]:
-        """dict mapping partname to package part binaries."""
+        """Every physical package member, as {partname: validated bytes}.
+
+        Read on first part access through `preflight_zip` and |GuardedZipReader|, so an archive with
+        more than one reading raises PackageLimitError here instead of loading one interpretation of
+        itself and editing that. Includes members no relationship reaches; ZIP directory records are
+        excluded.
+        """
         preflight_zip(self._pkg_file)
         with zipfile.ZipFile(self._pkg_file, "r") as z:
             guarded = GuardedZipReader(z)

--- a/src/pptx/oxml/simpletypes.py
+++ b/src/pptx/oxml/simpletypes.py
@@ -687,16 +687,21 @@ class ST_TextBulletSizePercent(BaseFloatType):
 
     @classmethod
     def convert_from_xml(cls, str_value):
+        """Read a bullet size as a fraction, accepting the percent-string and thousandths-of-a-
+        percent forms.
+        """
         if str_value.endswith("%"):
             return float(str_value[:-1]) / 100.0
         return int(str_value) / 100000.0
 
     @classmethod
     def convert_to_xml(cls, value):
+        """Write a bullet size fraction as a percent string."""
         return "%d%%" % int(round(value * 100.0))
 
     @classmethod
     def validate(cls, value):
+        """Refuse a bullet size outside 0.25..4.0, or one finer than a whole percent."""
         BaseFloatType.validate(value)
         if value < 0.25 or value > 4.0:
             raise ValueError("bullet size fraction must be in range 0.25..4.0, got %s" % value)
@@ -713,6 +718,7 @@ class ST_TextBulletStartAtNum(BaseIntType):
 
     @classmethod
     def validate(cls, value):
+        """Refuse a list start number outside the 1..32767 the schema allows."""
         cls.validate_int_in_range(value, 1, 32767)
 
 
@@ -754,16 +760,21 @@ class ST_TextLineSpaceReductionPercentOrPercentString(BaseFloatType):
 
     @classmethod
     def convert_from_xml(cls, str_value):
+        """Read a line-space reduction as a percent, accepting the percent-string and thousandths
+        forms.
+        """
         if str_value.endswith("%"):
             return float(str_value[:-1])
         return int(str_value) / 1000.0
 
     @classmethod
     def convert_to_xml(cls, value):
+        """Write a line-space reduction percent in thousandths."""
         return str(int(value * 1000.0))
 
     @classmethod
     def validate(cls, value):
+        """Refuse a line-space reduction outside 0.0..100.0 percent."""
         BaseFloatType.validate(value)
         if value < 0.0 or value > 100.0:
             raise ValueError("value must be in range 0.0..100.0 (percent), got %s" % value)
@@ -774,6 +785,9 @@ class ST_TextIndent(ST_Coordinate32Unqualified):
 
     @classmethod
     def validate(cls, value):
+        """Refuse an indent outside -51206400..51206400 EMU (plus or minus 56 inches), or a non-
+        integer.
+        """
         cls.validate_int_in_range(value, -51206400, 51206400)
 
 
@@ -788,6 +802,10 @@ class ST_TextMargin(ST_Coordinate32Unqualified):
 
     @classmethod
     def validate(cls, value):
+        """Refuse a margin outside 0..51206400 EMU (0 to 56 inches), or a non-integer.
+
+        Negatives are refused here, unlike `indent`.
+        """
         cls.validate_int_in_range(value, 0, 51206400)
 
 

--- a/src/pptx/package.py
+++ b/src/pptx/package.py
@@ -265,6 +265,10 @@ def xml_equivalent(a: Union[bytes, str], b: Union[bytes, str]) -> bool:
 
 
 def _c14n_bytes(data: Union[bytes, str]) -> bytes:
+    """Canonical XML form of `data`, so two parts compare on meaning rather than serialization.
+
+    This is what lets `patch_save` call a reformatted but semantically identical part unchanged.
+    """
     from xml.etree import ElementTree as _ElementTree
 
     out = _io.StringIO()
@@ -307,6 +311,7 @@ def _drop_structural_whitespace(data: Union[bytes, str]) -> str:
 
 
 def _is_xml_member(name: str) -> bool:
+    """True for member names compared as XML rather than as raw bytes."""
     return name.endswith(".xml") or name.endswith(".rels")
 
 
@@ -354,6 +359,7 @@ class PartDelta:
     detail: str  #: human-readable note on the difference
 
     def to_dict(self) -> dict:
+        """Return this part's change as a JSON-ready dict."""
         return {
             "partname": self.partname,
             "kind": self.kind,
@@ -374,9 +380,11 @@ class PackageDiff:
 
     @property
     def is_empty(self) -> bool:
+        """True when no part changed. Check it to recognize a no-op save."""
         return not self.deltas
 
     def to_dict(self) -> dict:
+        """Return the package diff as a JSON-ready dict under the `paper-package-diff` schema."""
         return {
             "schema": "paper-package-diff",
             "version": 1,
@@ -384,6 +392,7 @@ class PackageDiff:
         }
 
     def __repr__(self) -> str:
+        """Delta count, for logs and interactive use."""
         return "PackageDiff(%d deltas)" % len(self.deltas)
 
 
@@ -446,34 +455,39 @@ def _save_cannot_emit(name: str) -> bool:
 def patch_save(original_path: str, document, out_path: str) -> PackageDiff:
     """Save `document` to `out_path`, restoring original bytes for unchanged XML parts.
 
-    Compare-based narrow save: `document` (a |Presentation|) is serialized
-    normally, then every XML member that is semantically identical to its counterpart in
-    `original_path` is written with the ORIGINAL bytes, so unrelated parts never churn.
-    Returns the residual |PackageDiff| between `original_path` and `out_path`.
+    Compare-based narrow save: `document` (a |Presentation|) is serialized normally, then every XML
+    member that is semantically identical to its counterpart in `original_path` is written with the
+    ORIGINAL bytes, so unrelated parts never churn. Returns the residual |PackageDiff| between
+    `original_path` and `out_path`.
 
     Writes are deterministic — entry order is `[Content_Types].xml`, `_rels/.rels`, then all
-    remaining members sorted; every entry timestamp is fixed to 1980-01-01 — and atomic: the
-    package is built in a temp file in `out_path`'s directory and moved into place with
-    `os.replace`, so a mid-write failure leaves any existing `out_path` untouched. When
-    nothing changed at all, `out_path` is written as an exact byte copy of `original_path`
-    (the no-op round trip is byte-identical).
+    remaining members sorted; every entry timestamp is fixed to 1980-01-01 — and atomic: the package
+    is built in a temp file in `out_path`'s directory and moved into place with `os.replace`, so a
+    mid-write failure leaves any existing `out_path` untouched. When nothing changed at all,
+    `out_path` is written as an exact byte copy of `original_path`.
 
-    "Nothing changed" is decided over the members that can be parts: none added, none
-    removed, each semantically identical to its counterpart. A ZIP folder record such as
-    `ppt/` is not a part, so `save()` structurally cannot emit one and its absence from the
-    serialized candidate never evidences a change. Such a record therefore survives a no-op
-    round trip — the byte copy reproduces it — and is dropped by an actual edit, which
-    rebuilds the package from the members `save()` emitted.
+    That byte copy requires the original's `.rels` parts to already list relationships in the order
+    `save()` emits them, which holds for a package paper-pptx wrote and not for a PowerPoint-
+    authored deck: PowerPoint orders them differently, `.rels` compare order-sensitively, and the
+    re-serialized order counts as a change. On such a deck a no-op round trip is narrow but not
+    byte-identical.
 
-    Not interchangeable with :meth:`.Presentation.save`, which is also atomic on a path:
-    atomicity is how the bytes land, narrowness is which bytes get written. `save()`
-    re-serializes every part, so even an unchanged part gets new bytes; `patch_save`
-    restores the original bytes for every part that is semantically identical.
+    "Nothing changed" is decided over the members that can be parts: none added, none removed, each
+    semantically identical to its counterpart. A ZIP folder record such as `ppt/` is not a part, so
+    `save()` structurally cannot emit one and its absence from the serialized candidate never
+    evidences a change. Such a record therefore survives a no-op round trip — the byte copy
+    reproduces it — and is dropped by an actual edit, which rebuilds the package from the members
+    `save()` emitted.
+
+    Not interchangeable with :meth:`.Presentation.save`, which is also atomic on a path: atomicity
+    is how the bytes land, narrowness is which bytes get written. `save()` re-serializes every part,
+    so even an unchanged part gets new bytes; `patch_save` restores the original bytes for every
+    part that is semantically identical.
 
     Symlinked destinations are resolved, so the file a link names is the file replaced.
 
-    Raises |UnsupportedStructureError| when `original_path` is not a readable zip package
-    (before anything is written) and |ValueError| when `document` cannot save itself.
+    Raises |UnsupportedStructureError| when `original_path` is not a readable zip package (before
+    anything is written) and |ValueError| when `document` cannot save itself.
     """
     if not hasattr(document, "save"):
         raise ValueError(
@@ -516,11 +530,17 @@ def patch_save(original_path: str, document, out_path: str) -> PackageDiff:
 
 
 def _member_write_order(names: "Sequence[str]") -> "Sequence[str]":
+    """Order members for writing: content types first, then `_rels/.rels`, then the rest sorted.
+
+    Fixed order and fixed timestamps together are what make a no-op round trip byte-identical.
+    """
     head = [n for n in (_CONTENT_TYPES, "_rels/.rels") if n in names]
     return head + sorted(n for n in names if n not in head)
 
 
 def _atomic_write_zip(member_map: dict, out_path: str) -> None:
+    """Write `member_map` as a ZIP to `out_path`, with fixed entry order and fixed timestamps."""
+
     def write(handle):
         with _zipfile.ZipFile(handle, "w") as zipf:
             for name in _member_write_order(list(member_map)):
@@ -532,6 +552,7 @@ def _atomic_write_zip(member_map: dict, out_path: str) -> None:
 
 
 def _atomic_write_bytes(data: bytes, out_path: str) -> None:
+    """Write `data` to `out_path` through a temp file and an atomic replace."""
     _atomic_write(lambda handle: handle.write(data), out_path)
 
 
@@ -564,11 +585,13 @@ def _atomic_write(write, out_path: str) -> None:
 
 
 def _read_file_bytes(path: str) -> bytes:
+    """Read `path` as bytes."""
     with open(str(path), "rb") as handle:
         return handle.read()
 
 
 def _read_zip_map(path: str) -> dict:
+    """Read the package at `path` into a name-to-bytes map, refusing a file that will not open."""
     try:
         data = _read_file_bytes(path)
     except OSError as e:
@@ -577,6 +600,10 @@ def _read_zip_map(path: str) -> dict:
 
 
 def _read_zip_map_from_bytes(data: bytes, label: str) -> dict:
+    """Read package bytes into a name-to-bytes map, refusing duplicate member names.
+
+    `label` names the source in refusal messages.
+    """
     try:
         with _zipfile.ZipFile(_io.BytesIO(data)) as zipf:
             names = zipf.namelist()

--- a/src/pptx/presentation.py
+++ b/src/pptx/presentation.py
@@ -210,19 +210,18 @@ class Presentation(PartElementProxy):
 
         `file` can be either a file-path or a file-like object open for writing bytes.
 
-        A file-path destination is written atomically, resolving symlinks, so a failure
-        part-way through leaves any existing file untouched. A file-like destination is
-        written straight through once the whole package has serialized successfully. See
+        A file-path destination is written atomically, resolving symlinks, so a failure part-way
+        through leaves any existing file untouched. A file-like destination is written straight
+        through once the whole package has serialized successfully. See
         :meth:`pptx.opc.package.OpcPackage.save` for what atomic replacement costs.
 
-        :func:`pptx.package.patch_save` is the narrow-save alternative: it is atomic too,
-        and additionally restores the original bytes of every part that did not change, so
-        a no-op round trip is byte-identical.
+        :func:`pptx.package.patch_save` is the narrow-save alternative: atomic too, and it restores
+        the original bytes of every part that did not change. Its no-op round trip is byte-identical
+        only for a package paper-pptx wrote; see that function for why.
 
-        Refuses with |BoundaryViolationError| while a :meth:`batch` block is open on this
-        package: those edits have not been validated yet and may still roll back, so
-        writing them out would publish a package the block is not prepared to stand
-        behind. Save once the block has closed.
+        Refuses with |BoundaryViolationError| while a :meth:`batch` block is open on this package:
+        those edits have not been validated yet and may still roll back, so writing them out would
+        publish a package the block is not prepared to stand behind. Save once the block has closed.
         """
         from pptx._transaction import package_has_open_transaction
         from pptx.errors import BoundaryViolationError

--- a/src/pptx/rebind.py
+++ b/src/pptx/rebind.py
@@ -76,6 +76,7 @@ class RunShift:
     after: dict
 
     def to_dict(self) -> dict:
+        """Return this run change as a JSON-ready dict."""
         return {
             "part": self.part,
             "shape_id": self.shape_id,
@@ -114,6 +115,7 @@ class RebindReport:
     run_shifts: Tuple[RunShift, ...]
 
     def to_dict(self) -> dict:
+        """Return the rebind report as a JSON-ready dict stamped with its schema and version."""
         return {
             "schema": SCHEMA_NAME,
             "version": SCHEMA_VERSION,
@@ -282,6 +284,7 @@ def _rebind_layout_impl(slide, target_layout, *, placeholder_map, orphan_policy)
 
 
 def _layout_placeholder_slots(target_layout) -> "List[Tuple[PP_PLACEHOLDER, int]]":
+    """Placeholder type and index pairs the target layout offers, ordered by index."""
     slots = []
     for placeholder in target_layout.placeholders:
         slots.append((placeholder.element.ph_type, placeholder.element.ph_idx))
@@ -422,6 +425,7 @@ def _resolution_state(slide, *, align_by_content: bool = False):
 
 
 def _shifts_between(before_state, after_state) -> "Tuple[RunShift, ...]":
+    """Run changes for blocks present in both states, skipping runs whose values match."""
     shifts = []
     for key in sorted(set(before_state) & set(after_state)):
         before_values, text, part, before_payload, run_index = before_state[key]

--- a/src/pptx/shapes/shapetree.py
+++ b/src/pptx/shapes/shapetree.py
@@ -577,6 +577,10 @@ def _subtree_rIds(element) -> "set[str]":
 
 
 def _part_references_rId(part_element, rId: str) -> bool:
+    """True when any `r:` attribute in the part still points at `rId`.
+
+    Check this before dropping a relationship, so a part a sibling shape still draws survives.
+    """
     for descendant in part_element.iter():
         for attr_name, attr_value in descendant.attrib.items():
             if attr_value == rId and attr_name.startswith(_R_NS_PREFIX):
@@ -871,6 +875,12 @@ class SlideShapes(_BaseGroupShapes):
         return self._by_name_of_kind(name, "table", lambda s: s.has_table).table
 
     def _by_name_of_kind(self, name: str, kind: str, predicate):
+        """Return the one shape named `name` for which `predicate` is true, groups included.
+
+        `kind` is the noun used in refusal messages only. Raises TargetNotFoundError when no shape
+        has the name or none passes `predicate`, and AmbiguousTargetError when several pass, so a
+        caller never edits an arbitrary duplicate.
+        """
         from pptx.errors import AmbiguousTargetError, TargetNotFoundError
 
         named_shapes = [shape for shape in _iter_shapes_deep(self) if shape.name == name]

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -701,6 +701,7 @@ class HeaderFooters(object):
     """
 
     def __init__(self, owner):
+        """Bind to the layout or master that owns these flags."""
         super(HeaderFooters, self).__init__()
         self._owner = owner
         self._element = owner._element
@@ -736,6 +737,10 @@ class HeaderFooters(object):
         self._set_flag("dt", value)
 
     def _set_flag(self, attr_name: str, value: "bool | None") -> None:
+        """Set one `p:hf` visibility flag inside a transaction.
+
+        Refuses a detached element, and any value that is not True, False, or None.
+        """
         from pptx._ownership import require_element_attached
         from pptx._transaction import PackageTransaction
 
@@ -857,6 +862,10 @@ class SlideLayouts(ParentedElementProxy):
 
         Raises ValueError when `slide_layout` is in use; a slide layout which is the basis for one
         or more slides cannot be removed.
+
+        Refuses with TargetNotFoundError when the layout belongs to another presentation, and with
+        UnsupportedStructureError when its part carries inbound relationships beyond this
+        collection's own, where dropping it would strand whatever else points at it.
         """
         from pptx._transaction import PackageTransaction
 

--- a/src/pptx/slideops.py
+++ b/src/pptx/slideops.py
@@ -50,6 +50,12 @@ class _CopySession(set):
     """Partname reservations and document-wide identity remaps for one copy."""
 
     def __init__(self, package, source_parts):
+        """Reserve the destination package's identity values and plan a fresh GUID per source id.
+
+        `package` is the destination; `source_parts` are the parts about to be copied. Raises
+        RelationshipPolicyError when two source parts share an `a16:creationId`, since one id cannot
+        be remapped two ways.
+        """
         super().__init__()
         self._reserved = _document_identity_values(package)
         self._a16_mapping = {}
@@ -71,6 +77,11 @@ class _CopySession(set):
                 self._a16_mapping[key] = self._fresh_guid()
 
     def remap(self, source_part, copied_part) -> None:
+        """Rewrite identity attributes in `copied_part` so it shares no id with its source.
+
+        Only effective for parts whose source was passed to `__init__`; creation ids outside that
+        plan survive unchanged. `a:fld` ids are always re-minted. A no-op for non-XML parts.
+        """
         root = _xml_root(copied_part)
         if root is None:
             return
@@ -96,6 +107,7 @@ class _CopySession(set):
                 element.set("id", self._fresh_guid())
 
     def _fresh_guid(self) -> str:
+        """A GUID no part of the destination package already uses."""
         while True:
             value = "{%s}" % str(uuid.uuid4()).upper()
             if value.lower() not in self._reserved:
@@ -104,12 +116,19 @@ class _CopySession(set):
 
 
 def _replace_identity_attribute(element, name: str, mapping: dict) -> None:
+    """Rewrite one identity attribute through `mapping`, matching case-insensitively."""
     value = element.get(name)
     if value is not None and value.lower() in mapping:
         element.set(name, mapping[value.lower()])
 
 
 def _xml_root(part):
+    """Root element of `part`, or None for non-XML content or a blob that will not parse.
+
+    Returns the LIVE element for an XmlPart, so mutations apply directly. For any other part it
+    returns a detached reparse of `part.blob`, and mutations are lost unless the caller writes it
+    back.
+    """
     if isinstance(part, XmlPart):
         return part._element
     content_type = part.content_type.partition(";")[0].strip().lower()
@@ -124,6 +143,10 @@ def _xml_root(part):
 
 
 def _document_identity_values(package) -> set:
+    """Lowercased `a16:creationId` and `a:fld` ids in use across `package`, for GUID minting.
+
+    Deliberately narrow: only the two GUID-shaped attributes a copy has to avoid colliding with.
+    """
     values = set()
     for part in package.iter_parts():
         root = _xml_root(part)
@@ -294,6 +317,12 @@ def _validated_plan(source_part, policy) -> "List[Tuple[str, str, object]]":
 
 
 def _validate_chart_rels(chart_part) -> None:
+    """Refuse a chart clone unless every internal relationship is a leaf workbook or style child.
+
+    Only the embedded workbook, chartStyle, and chartColorStyle are allowed, and each must itself
+    have no internal relationships. Anything else, including an image, raises
+    RelationshipPolicyError. External relationships are always allowed.
+    """
     for rId in chart_part.rels:
         rel = chart_part.rels[rId]
         if rel.is_external:
@@ -312,6 +341,12 @@ def _validate_chart_rels(chart_part) -> None:
 
 
 def _validate_notes_rels(notes_part) -> None:
+    """Refuse a notes clone unless every internal relationship targets the notes master or its
+    slide.
+
+    So a notes slide holding a picture raises RelationshipPolicyError. External relationships are
+    always allowed.
+    """
     for rId in notes_part.rels:
         rel = notes_part.rels[rId]
         if not rel.is_external:
@@ -404,5 +439,6 @@ def _rewrite_r_references(root, rId_mapping: "Dict[str, str]") -> None:
 
 
 def _rId_sort_key(rId: str):
+    """Sort key ordering `rId7` before `rId10`, with non-numeric ids last."""
     match = re.fullmatch(r"rId([0-9]+)", rId)
     return (0, int(match.group(1))) if match else (1, rId)

--- a/src/pptx/table.py
+++ b/src/pptx/table.py
@@ -409,6 +409,7 @@ class _MergeRegion(object):
     """
 
     def __init__(self, top: int, left: int, rowSpan: int, gridSpan: int):
+        """A merged region, given its origin `(top, left)` and its row and column spans."""
         self.top = top
         self.left = left
         self.rowSpan = rowSpan
@@ -425,11 +426,13 @@ class _MergeRegion(object):
         return self.left + self.gridSpan - 1
 
     def __repr__(self) -> str:
+        """Origin and span bounds, for debugging."""
         return "<_MergeRegion origin=(%d, %d) rows %d..%d cols %d..%d>" % (
             self.top, self.left, self.top, self.bottom, self.left, self.right,
         )
 
     def __str__(self) -> str:
+        """Origin and span bounds in prose, as the surgery refusal messages quote them."""
         return "(%d, %d) spanning rows %d..%d, columns %d..%d" % (
             self.top, self.left, self.top, self.bottom, self.left, self.right,
         )

--- a/src/pptx/text/bullet.py
+++ b/src/pptx/text/bullet.py
@@ -61,6 +61,10 @@ class BulletFormat(object):
     """
 
     def __init__(self, p: CT_TextParagraph, part=None):
+        """Wrap a paragraph's bullet properties.
+
+        Passing `part` enables the attachment check and the rollback boundary that the setters use.
+        """
         super(BulletFormat, self).__init__()
         self._p = p
         self._part = part
@@ -184,6 +188,7 @@ class BulletFormat(object):
             pPr.get_or_change_to_buNone()
 
     def _require_attached(self) -> None:
+        """Refuse when the paragraph has been detached from its part."""
         if self._part is None:
             return
         from pptx._ownership import require_element_attached
@@ -191,6 +196,7 @@ class BulletFormat(object):
         require_element_attached(self._p, self._part, argument="paragraph")
 
     def _transaction(self):
+        """Rollback boundary for a bullet edit, or a no-op when the paragraph carries no part."""
         if self._part is None:
             from contextlib import nullcontext
 
@@ -240,6 +246,11 @@ class BulletFormat(object):
         left_margin: Length | None,
         hanging_indent: Length | None,
     ) -> None:
+        """Write the font, size, margin, and indent that every bullet kind shares.
+
+        `hanging_indent` is written as `-abs(value)`, because a hanging indent is negative in
+        ECMA-376.
+        """
         if font_name is not None:
             pPr.get_or_add_buFont().typeface = font_name
         if size_percent is not None:

--- a/src/pptx/text/text.py
+++ b/src/pptx/text/text.py
@@ -282,8 +282,9 @@ class TextFrame(Subshape):
     def _resolve_run_size(self, r):
         """Return `r`'s effective font size in centipoints via the inheritance walk, or None.
 
-        Used by `normalize_autofit(resolve=True)`. Import is deferred: `pptx.inspect` is a
-        leaf module and importing it at module scope would be a cycle.
+        Used by `normalize_autofit(resolve=True)`. None when `r`'s text body is not inside a `p:sp`
+        on a slide part, or when the walk cannot resolve a size; the caller turns that into a typed
+        refusal. `pptx.parts.slide` is imported lazily to break an import cycle.
         """
         from pptx.inspect import _FontResolver
         from pptx.parts.slide import SlidePart
@@ -679,6 +680,11 @@ class _Paragraph(Subshape):
         self._add_field("slidenum", "1")
 
     def _add_field(self, field_type: str, cached_text: str) -> None:
+        """Append an `a:fld` of `field_type` with `cached_text`, under a freshly minted GUID id.
+
+        PowerPoint re-renders the value when the deck opens. Transactional, and refuses a paragraph
+        detached from its part.
+        """
         import uuid
 
         from pptx._ownership import require_element_attached


### PR DESCRIPTION
## Summary

Rebased onto `main` (which now carries PR 30) and rebuilt from the spec at
`reference/paper-pptx-audit/planned/docstring-spec.md`.

Docstrings are the only documentation surface that reaches a sandbox: the wheel ships no `.rst`, and the docs-discovery audit found agents reading installed source in **69 traces and `.rst` in none**. So a fork-only function with no docstring is undocumented in practice, and one describing behavior the code does not have is worse, because it answers confidently.

Scope is the AST delta against python-pptx 1.0.2, the version `src/pptx/__init__.py` pins as the fork base. Untouched functions keep upstream's prose.

| | Before | After |
|---|---|---|
| Added symbols with a docstring | 279 / 432 | **429 / 432** |
| Changed functions still on upstream prose | 8 | **4 → 0 of the 4 that needed it** |
| Verified-false statements | 7 | 0 |

**+566 −82 across 21 files. No code changes.**

## Corrections

Each reproduced before and after, not read off the source.

| Symbol | Was | Verified |
|---|---|---|
| `OpcPackage.save` | "a failure during that copy leaves a partial package with no rollback" | A readable, seekable stream **is** restored (prior 20,000 bytes recovered) |
| `OpcPackage.save` | "a stream positioned at the start is truncated… no tail survives" | A write-only sink at position 0 kept **32,613 stale bytes** |
| `OpcPackage.save` | cites `CONVENTIONS.md`, `PLAN-paper-pptx.md` | **Neither exists.** Deleted in `2fd6956f`. Five lines of dead history were shipping in the wheel |
| `patch_save`, echoed in `Presentation.save` | "the no-op round trip is byte-identical" | True for a deck paper-pptx wrote; **false for PowerPoint-authored, including the bundled `default.pptx`**, because `.rels` compare order-sensitively |
| `errors.py` module | "Every paper mutating API is structured validate-fully-then-mutate" | The transaction snapshots, mutates, then reopens and restores. `batch()`'s own docstring says so |
| `GuardedZipReader` | "ordinary ``Document()`` opens and package-kernel reads share the same validation" | `Document()` is a python-docx leftover; `package.py` reads with bare `zipfile` |
| `_bullet_state` | refusals come from "table cells, which are not `p:sp`" | Table paragraphs never reach the resolver; `_iter_text_shapes` filters on `has_text_frame` |
| `_resolve_run_size` | `pptx.inspect` "is a leaf module and importing it at module scope would be a cycle" | Self-contradictory and false. The import that cycles is `pptx.parts.slide` |

The two `save()` defects fail in **opposite directions for opposite halves of the destination space**. The old text collapsed a capability-dependent contract into two unconditional sentences, and `_save_stream_atomically` one screen below already described it correctly. Rewritten by destination capability, 27 lines down to 20.

Five `errors.py` classes were wider or narrower than their raise sites. `BoundaryViolationError` has exactly one trigger and now names it.

## Additions

150 docstrings across 20 files, concentrated where agents introspect most: `inspect.py` (42), `diff.py` (18), `_zipguard.py` (15), `compose.py` (12), `package.py` (13).

The three symbols left bare are property setters whose getters carry the pair, matching upstream, which documents 13 of its 196.

Four changed functions still holding upstream prose now say what the fork added, three of them a refusal: `SlideLayouts.remove`, `_PackageLoader._xml_rels`, `_PhysPkgReader.factory`, `_ZipPkgReader._blobs`.

## README

Three factual fixes, no new sections:

- The safety contract repeated the `validate-fully-then-mutate` claim. Corrected to the transaction mechanism, naming the operations that genuinely do validate first.
- `rebind_layout` "never shifts appearance silently" narrowed to font resolution: `run_shifts` compares six font values, so geometry and text direction sit outside it.
- "stream saves snapshot and restore the destination on failure" made capability-dependent.

I tested the guarded-intake passage rather than assuming, including "a part that nothing references is *not* refused". It holds exactly as written, drop-on-save included.

## Style

One line where one line does; a second paragraph only where a caller gets burned without it. Exception names spelled plainly rather than as `|Name|` reST substitutions, which render as literal pipes to `help()` and `inspect.getsource` — the paths agents actually read.

## Verification

The first attempt at this work shipped 16 false docstrings, so verification is part of the spec now.

- **11 behavioral claims executed** against the final tree: the save matrix, the `patch_save` precondition on both a paper-written and a PowerPoint-authored deck, `HeaderFooters` rejecting a slide, the `indent`/`margin` ranges, the newline refusal, and shape deletion. All pass.
- **Mechanical claim check** with the docstring stripped from the haystack. The naive version searches a claim inside its own function source and reports everything satisfied; that produced a clean bill of health on a set holding 16 errors.
- `uv run pytest tests/paper -q` — **956 passed, 1 skipped**
- `uv run pytest tests/ --ignore=tests/paper -q -W ignore` — **2700 passed**
- `uv run ruff check src/pptx` — **31 findings, identical to the `main` baseline**
- `uv run ruff format --check` — **no file newly unformatted**

## Notes for review

- My first pass added 51 `E501` violations: drafts wrapped at 95 chars, but methods indent by 8. Fixed by reflowing all 165 touched docstrings to the limit programmatically rather than hand-patching lines, then re-checking against baseline.
- The previous commit on this branch (`6a92b6b1`, against the pre-rebase tip) was discarded rather than rebased. The audit confirmed 16 of its docstrings false; re-deriving under the spec was cleaner than correcting claim by claim.
- **13 code defects** surfaced while auditing and are deliberately not touched here. Recorded in §5 of the spec. Three I verified myself: the `batch()` boundary is escapable (`prs.part.save()` writes 28,104 unvalidated bytes while `prs.save()` refuses); the `.rels` ordering asymmetry defeats `patch_save`'s byte-identity; `discard_tail` gates on readability rather than truncatability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or test changes; risk is limited to documentation accuracy if any new docstring still misstates behavior.
> 
> **Overview**
> **Documentation-only** (+566/−82 across 21 files): adds or rewrites docstrings on fork-added and fork-changed symbols so installed-source introspection matches real behavior, and tightens README wording on transactions, rebind shifts, and stream `save()`.
> 
> **Corrected false or misleading claims** in existing docs: `OpcPackage.save` / `Presentation.save` now describe **capability-dependent** stream rollback and truncation (readable/seekable destinations can restore; write-only sinks may keep partial bytes or tails). `patch_save` / `Presentation.save` no longer promise a **byte-identical** no-op round trip for every deck—only when `.rels` order already matches serialization (typical for paper-written packages, not PowerPoint-authored). `errors.py` and the README safety contract now describe **package transactions** (snapshot → mutate → reopen validate) instead of “validate-fully-then-mutate” everywhere. `_zipguard.GuardedZipReader` refers to `Presentation()` opens, not `Document()`. `_bullet_state` and `_resolve_run_size` docstrings match actual traversal/import boundaries.
> 
> **New coverage** for previously undocumented fork surface: bulk additions in `inspect.py`, `diff.py`, `_zipguard.py`, `compose.py`, `package.py`, `_transaction.py`, `errors` exception classes, `slideops` clone validation, and JSON `to_dict()` helpers—generally stating **refusal conditions**, rollback boundaries, and report schemas where agents rely on them.
> 
> **README** narrows `rebind_layout` shift reporting to **resolved font** changes (geometry/text direction excluded) and aligns atomic-save / stream-save bullets with the updated `save()` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80358af8e06cd1d3ff15f01aefbe096b7731b1d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->