### PR TITLE
chore: bump paper-pptx to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Confirm the install:
 
 ```bash
 paper-pptx-doctor
-# paper-pptx-doctor: OK (paper-pptx 0.1.3)
+# paper-pptx-doctor: OK (paper-pptx 0.2.0)
 ```
 
 The doctor verifies that `paper-pptx` metadata is present, `python-pptx` is
@@ -417,7 +417,7 @@ corruption prevention:
   `import pptx` fails loudly when both `python-pptx` and `paper-pptx` metadata
   are installed, because a mixed site-packages can silently run a blend of the
   two libraries. `pptx.__version__` stays `"1.0.2"` (the upstream API surface),
-  and `pptx.__paper_version__` (`"0.1.3"`) identifies the fork release — so
+  and `pptx.__paper_version__` (`"0.2.0"`) identifies the fork release — so
   callers can distinguish "which upstream surface" from "which paper release".
 
 ## The safety contract
@@ -587,7 +587,7 @@ If you reference paper-pptx in research or writing:
   title   = {paper-pptx: an agent-first structure editor for PowerPoint files},
   author  = {{Paper Instruments, Inc.}},
   year    = {2026},
-  version = {0.1.3},
+  version = {0.2.0},
   url     = {https://github.com/paper-instruments/paper-pptx}
 }
 ```

--- a/src/pptx/_version.py
+++ b/src/pptx/_version.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, distribution
 
-__paper_version__ = "0.1.3"
+__paper_version__ = "0.2.0"
 
 
 def assert_distribution_identity() -> None:


### PR DESCRIPTION
## Summary
- Bump the fork sentinel and distribution version from `0.1.3` to `0.2.0` so a post-merge `v0.2.0` tag will publish the current mainline (batch API, ZIP-guard/oracle changes, scrub removal, bullet inspect/diff, docstring coverage) without also shipping a never-tagged `0.1.3`.
- Update the three README version strings that would otherwise go stale in the wheel: doctor sample output, the `__paper_version__` identity paragraph, and the BibTeX citation.
- Does **not** create or push a tag. `release.yaml` only publishes on `v*` tags that are already ancestors of `origin/main`; tag `v0.2.0` on `main` after this stack merges.

## Test plan
- `uv build` produced `paper_pptx-0.2.0-py3-none-any.whl` and `paper_pptx-0.2.0.tar.gz`
- `uvx --from twine==6.1.0 twine check --strict dist/*` PASSED for both artifacts
- Isolated wheel install: `pptx.__paper_version__` and `importlib.metadata.version("paper-pptx")` both report `0.2.0`
- Isolated wheel `paper-pptx-doctor: OK (paper-pptx 0.2.0)`; sdist smoke reports `0.2.0`
- `uv run python -m pytest -q tests/paper/test_distribution_doctor.py` — 8 passed
- Confirmed `git tag --list v0.2.0` is empty

## Checklist
- [x] Distribution doctor tests pass (`uv run python -m pytest -q tests/paper/test_distribution_doctor.py`)
- [x] Wheel identity matches `0.2.0` (`uv build` + isolated install + `paper-pptx-doctor`)
- [x] Lint clean on the version module (`uv run ruff check src/pptx/_version.py`)
- [x] No tag created or pushed

Stacked on #31. After #31 and this PR merge to `main`, tag the merge commit `v0.2.0` and push the tag to publish.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `paper-pptx` fork/distribution version from 0.1.3 to 0.2.0 to prepare a clean 0.2.0 release. Updates README examples and identity text so wheel metadata and docs match; old surfaces showed 0.1.3, new surfaces show 0.2.0.

- `pptx.__paper_version__` now returns "0.2.0"; README doctor output and citation reflect 0.2.0.
- Prevents publishing a never-tagged 0.1.3 when tagging 0.2.0.

**Rollout**
- No tag is created by this PR. After this stack merges to main, tag the merge commit `v0.2.0` to publish.

<sup>Written for commit 9f53212559ba0cb350558015ac95a5409c33f501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

