### PR TITLE
docs: condense the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,35 @@
 <div align="center">
   <a href="https://github.com/paper-instruments/paper-pptx">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset=".github/assets/logo-dark.svg">
-      <img alt="paper-pptx logo" src=".github/assets/logo-light.svg" height="128">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/paper-instruments/paper-pptx/main/.github/assets/logo-dark.svg">
+      <img alt="paper-pptx logo" src="https://raw.githubusercontent.com/paper-instruments/paper-pptx/main/.github/assets/logo-light.svg" height="128">
     </picture>
   </a>
   <h1>paper-pptx</h1>
 
 [![PyPI](https://img.shields.io/pypi/v/paper-pptx.svg)](https://pypi.org/project/paper-pptx/)
 [![Python versions](https://img.shields.io/pypi/pyversions/paper-pptx.svg)](https://pypi.org/project/paper-pptx/)
-[![License](https://img.shields.io/pypi/l/paper-pptx.svg)](LICENSE)
-[![CI](https://github.com/paper-instruments/paper-pptx/actions/workflows/test.yml/badge.svg)](https://github.com/paper-instruments/paper-pptx/actions/workflows/test.yml)
-[![Downloads](https://img.shields.io/pypi/dm/paper-pptx.svg)](https://pypi.org/project/paper-pptx/)
+[![Test](https://github.com/paper-instruments/paper-pptx/actions/workflows/test.yml/badge.svg)](https://github.com/paper-instruments/paper-pptx/actions/workflows/test.yml)
 
 </div>
 
-An agent-first structure editor for PowerPoint files.
+**An import-compatible, agent-first structure editor for PowerPoint files, designed to prevent silent corruption when editing existing decks.**
 
-`paper-pptx` is a Python library for safely inspecting, editing, composing, and
-verifying existing PowerPoint (`.pptx`) presentations. It is a drop-in hard fork
-of [`python-pptx`](https://github.com/scanny/python-pptx) `v1.0.2`: the
-distribution is renamed, the import name stays `pptx`, and every existing call
-keeps working unchanged.
+`paper-pptx` is a drop-in hard fork of [python-pptx](https://github.com/scanny/python-pptx) `v1.0.2` for safely inspecting, editing, composing, and verifying existing PowerPoint (`.pptx`) presentations. It keeps python-pptx's package layer, XML mapping, and object model. It adds the rendered values a deck actually shows, edits that survive PowerPoint's run fragmentation, and refusals in place of guesses.
 
 ```python
-from pptx import Presentation          # the import name is unchanged
+from pptx import Presentation   # the import name is unchanged — see "Drop-in by design"
 ```
 
-The fork exists to prevent **silent corruption**: a deck that opens fine and is
-quietly wrong. Automated systems cannot eyeball a slide, so every added
-operation returns its outcome as typed, machine-readable data — and when an
-operation cannot proceed safely, it raises a typed refusal and leaves the
-presentation byte-for-byte unchanged rather than guessing.
+The fork exists to prevent **silent corruption**: a deck that opens fine and is quietly wrong. Automated systems cannot eyeball a slide, so every added operation returns its outcome as typed, machine-readable data, and an operation that cannot proceed safely raises a typed refusal and leaves the presentation byte-for-byte unchanged rather than guessing.
 
-## Table of contents
+---
 
-1. [Installation](#installation)
-1. [Quick start](#quick-start)
-1. [What we changed from python-pptx, and why](#what-we-changed-from-python-pptx-and-why)
-1. [The safety contract](#the-safety-contract)
-1. [API surface map](#api-surface-map)
-1. [Everything from python-pptx still works](#everything-from-python-pptx-still-works)
-1. [Documentation](#documentation)
-1. [Roadmap and known limitations](#roadmap-and-known-limitations)
-1. [How it's tested](#how-its-tested)
-1. [Contributing](#contributing)
-1. [Community and support](#community-and-support)
-1. [Citation](#citation)
-1. [License](#license)
-1. [Acknowledgments](#acknowledgments)
+## Why paper-pptx exists
 
-## Installation
+`python-pptx` is excellent at *creating* decks. Its lossless package layer, disciplined XML mapping, and a decade of absorbed edge cases are why this fork builds on it.
 
-Requires Python 3.9+.
-
-```bash
-python -m pip uninstall -y python-pptx paper-pptx
-python -m pip install paper-pptx
-```
-
-> [!WARNING]
-> The clean uninstall is required when migrating from `python-pptx`. Both
-> distributions own the same `pptx` import package (the same
-> distribution/import split as Pillow: `pip install pillow`, `import PIL`), and
-> pip cannot safely overlay or uninstall two distributions that own the same
-> files. If both are installed, `import pptx` refuses with an `ImportError`
-> rather than running an unverifiable mix of the two.
-
-Confirm the install:
-
-```bash
-paper-pptx-doctor
-# paper-pptx-doctor: OK (paper-pptx 0.2.0)
-```
-
-The doctor verifies that `paper-pptx` metadata is present, `python-pptx` is
-absent, and the installed `pptx` files match the distribution's RECORD hashes —
-so "I am actually running paper-pptx" is provable, not assumed.
+The harder problem is changing an existing deck without flattening formatting, stranding relationships, or losing content outside the slide body. Stock `run.font.size` returns `None` for any value inherited through the placeholder chain, the only stock write path flattens every run in a paragraph, and there is no public clone, delete, or reorder for slides. An agent cannot look at the result, so it needs the deck's structure and every edit outcome as typed data, and it needs the library to refuse rather than guess.
 
 ## Quick start
 
@@ -89,494 +42,134 @@ prs = Presentation("deck.pptx")
 
 run = prs.slides[0].shapes.title.text_frame.paragraphs[0].runs[0]
 font = run.effective_font()
-print(font.size.value_pt)              # resolved through layout/master/theme, e.g. 36.0
+print(font.size.value_pt)              # resolved through layout/master/theme
 
 replace_text(prs, "FY25", "FY26")      # preserves untouched run formatting
-prs.save("deck.v2.pptx")               # atomic: the old file survives any failure
+prs.save("deck.v2.pptx")               # atomic on a path: the old file survives any failure
 
 delta = diff_decks("deck.pptx", "deck.v2.pptx", detail="text")
 print(len(delta.slide_changes), "slides changed")
 ```
 
-A fuller composition workflow (import a slide from another deck, apply live
-footers, and verify) is in
-[A complete example](#compose-assemble-decks-across-files) below and in
-[`docs/user/paper-additions.rst`](docs/user/paper-additions.rst).
-
-## What we changed from python-pptx, and why
-
-`python-pptx` is excellent at *creating* presentations. Its lossless package
-layer, disciplined XML mapping, and a decade of absorbed real-world edge cases
-are why this fork builds on it rather than starting over.
-
-The harder problem is changing a live, branded, template-driven deck. Upstream's
-editing surface stalled short of that: you cannot copy, delete, or reorder a
-slide through the public API; you cannot make a real bullet in an arbitrary
-text box; you cannot learn what font size a shape actually renders at when the
-value is inherited through placeholder → layout → master → theme — the API
-returns `None`. Production automation therefore falls back to raw XML and
-ZIP-package surgery for exactly the operations template work needs most, and
-the dominant failure mode of that surgery is silent corruption: decks that open
-in python-pptx but not in PowerPoint, cloned slides that secretly share an
-editable chart with their original.
-
-paper-pptx extends the fork into a superset of upstream's public Python API —
-every inherited call keeps working, and upstream's own pytest and behave suites
-run green on every change — while adding the missing operations as safe,
-first-class APIs. The entire fork is one reviewed change on top of upstream
-`v1.0.2` (git tag `paper-base`): 180 files changed, 27,546 insertions. The
-additions group into four verbs: **perceive**, **edit**, **compose**,
-**verify**. A handful of existing behaviors are deliberately stricter; those
-are listed honestly in
-[What is deliberately not additive](#what-is-deliberately-not-additive).
-
-**One capability was cut before release.** An earlier plan made a `scrub()`
-verb — a single call bundling eight deletion passes behind toggles, returning a
-report — the "exit gate" for delivery. It was built, then removed. Its stated
-safety property (a part reachable from a live slide cannot be removed) is the
-serializer's, not the verb's: dropping a relationship un-writes a part for any
-caller. What remained was a loop over `drop_rel` with a receipt attached, and a
-four-line recipe does the same job with primitives that were already public.
-Deleting a deck's speaker notes, comments, and authorship is the caller's job,
-and the package it saves is the evidence.
+## What paper-pptx adds
 
 ### Perceive: read what the deck actually renders
 
-**Effective formatting, with provenance.** Stock `run.font.size`, `.name`, and
-`.color` return `None` for any value inherited through the placeholder →
-layout → master → theme chain — on a branded template, that is nearly
-everything, so callers are blind to what the deck looks like. paper-pptx adds
-`pptx.inspect.effective_font()`, `effective_paragraph_format()`, and
-`effective_shape_format()` (plus `run.effective_font()` as a convenience). Each
-value reports whether it resolved, resolves theme colors through the master
-color map, and carries the ordered provenance chain of sources consulted.
-Values the resolver does not support — gradients, East Asian typefaces, style
-modulations — report `resolved=False` instead of a guess.
-
-```python
-font = prs.slides[0].shapes.title.text_frame.paragraphs[0].runs[0].effective_font()
-font.size.value_pt        # e.g. 26.0, even though run.font.size is None
-for step in font.size.provenance:
-    if step.supplied:
-        print("supplied by", step.level)   # e.g. "master txStyles titleStyle lvl1"
-```
-
-`effective_paragraph_format()` resolves the paragraph's bullet the same way:
-which bullet actually renders, walked through the same chain, reported with
-the same provenance. On a branded template that is the common case — the
-master supplies the `•` and the paragraph's own markup says nothing. Two
-answers that look like absences are resolved answers: an explicit `a:buNone`
-at any rung is the positive statement "no bullet renders here", not a miss,
-and a chain carrying no bullet at any rung also resolves to no bullet rather
-than reporting unresolved. This is the read half of **Real bullets, not glyph
-hacks** below — that API writes genuine bullet markup onto a paragraph, this
-one reports the bullet the deck renders whether or not the paragraph sets
-one.
-
-It reports the bullet's typeface and size too, each resolved on its own chain
-because the schema inherits them separately from the glyph. That matters more
-than it sounds: branded templates routinely use a symbol font, where the glyph
-is a private-use codepoint that draws as a filled square in Wingdings and as
-an empty box in anything else. Reporting the typeface is what lets a caller
-reproduce a bullet from the resolver's answer alone.
-
-```python
-fmt = effective_paragraph_format(paragraph)
-fmt.bullet.char           # e.g. ''  — meaningless on its own
-fmt.bullet_font.value     # 'Wingdings'    — what makes it a filled square
-fmt.bullet_size.value     # 0.75           — or BULLET_FOLLOWS_TEXT
-```
-
-**Visibility-complete text inspection.** Iterating top-level shapes misses text
-inside nested groups and table cells, and `shape.text` flattens slide-number
-fields and line breaks into plain characters. `pptx.inspect.inspect_text()`
-traverses shapes, groups (recursively), and table cells; fields keep their
-field type; every block carries a content-hash `BlockAnchor` for stale-safe
-edits; and regions the library cannot read (chart text, SmartArt) are counted
-as blind regions instead of silently vanishing from "all the text".
-
-**A deterministic deck manifest.** `pptx.inspect.inspect_deck()` emits a
-versioned, JSON-friendly structural manifest — slides, shapes, z-order,
-geometry, placeholder bindings, layouts, masters — deterministic enough to
-golden-file, so an agent can fingerprint structure before and after an edit
-without crawling OOXML.
+- **`pptx.inspect` effective values, with provenance.** `effective_font()`, `effective_paragraph_format()`, and `effective_shape_format()` resolve size, typeface, color, alignment, line spacing, and bullets through the run, paragraph, placeholder, layout, master, and theme chain, and report which rung supplied each value. Bullet typeface and size resolve on their own chains, because the schema inherits them separately from the glyph. Unresolved is reported as unresolved rather than guessed.
+- **Visibility-complete text inspection.** `inspect_text()` reaches nested groups and table cells, which iterating top-level shapes misses, and returns content-hash anchors that survive an edit. Regions it cannot survey are reported as blind blocks rather than silently skipped.
+- **A deterministic deck manifest.** `inspect_deck()` emits a versioned, JSON-friendly structural manifest: slides, shapes, z-order, geometry, and placeholder identity.
 
 ### Edit: change one deck without flattening it
 
-**Anchored, formatting-preserving text replacement.** The only stock write path
-(`shape.text = ...`) flattens every run's formatting in the paragraph.
-`pptx.edit.replace_text()` replaces matches deck-wide — through groups and
-table cells, never across field or line-break boundaries — while untouched runs
-keep their exact XML. `replace_text_at()` applies an edit at a `BlockAnchor`
-and raises `StaleAnchorError` if the content changed since inspection, and
-`refind()` is the explicit recovery path.
-
-```python
-from pptx.edit import replace_text, replace_text_at
-
-result = replace_text(prs, "ACME", "NORTHSTAR", include_notes=True)
-anchor = result.blocks[0]
-replace_text_at(prs, anchor, "NORTHSTAR", "NS")   # StaleAnchorError if the deck moved on
-```
-
-**Relationship-safe slide lifecycle.** Upstream has no public clone, delete,
-move, or reorder for slides; the folk XML recipes leave sections and custom
-shows pointing at deleted slides and produce clones that secretly share an
-editable chart and workbook with their original. `Slides.clone()` deep-copies
-charts *with their embedded workbooks* and notes under an explicit
-`SlideClonePolicy`; `delete()` purges section and custom-show references and
-never strands orphaned parts; `reorder()` requires an exact permutation.
-Relationship types the library cannot clone safely (OLE objects, ActiveX)
-refuse before anything changes.
-
-```python
-prs.slides.clone(3)
-prs.slides.move(prs.slides[3], 0)
-prs.slides.delete(1)
-```
-
-**Real bullets, not glyph hacks.** Upstream has no bullet API, so automation
-fakes lists by typing `- ` or `•` into the text — which changes the text
-itself and is invisible to PowerPoint's list semantics. `paragraph.bullet`
-writes genuine `a:buChar` / `a:buAutoNum` / `a:buNone` markup with
-hanging-indent geometry.
-
-```python
-paragraph.bullet.set_numbered("arabicPeriod", start_at=1)
-paragraph.bullet.set_character("•")
-paragraph.bullet.set_none()
-```
-
-**Autofit made explicit.** PowerPoint stores shrink-to-fit as invisible
-`normAutofit` scale percentages; editing text or flipping the autofit flag
-silently changes how the deck renders at next open. `TextFrame.font_scale` and
-`line_space_reduction` expose the scaling, and `normalize_autofit()` bakes the
-currently-rendered sizes into explicit formatting before disabling autofit —
-refusing (rather than guessing) when a size cannot be resolved.
-
-**Notes without side effects.** Merely *reading* `slide.notes_slide` upstream
-creates a notes part — reconnaissance mutates the package.
-`Slide.read_notes_text()` never creates anything, and `replace_notes_text()`
-edits only an existing notes body, refusing on slides that have none.
-
-**Typed, group-aware shape lookup.** `shapes.shape_by_name()`,
-`picture_by_name()`, `table_by_name()`, and `chart_by_name()` recurse into
-groups, return the right object type, and raise `AmbiguousTargetError` on
-duplicate names instead of silently taking the first match — the canonical way
-an automated edit lands on the wrong object with no error at all.
-
-**Shape and table surgery that keeps the package consistent.**
-`SlideShapes.delete()` / `move()` / `add_copy()` manage relationships
-correctly (an image relationship is dropped only when nothing else uses it;
-copied charts get their own workbook). `Table.insert_row()` / `delete_row()` /
-`insert_column()` / `delete_column()` keep the grid and frame geometry
-consistent and guard merged regions cell-wise — only an operation that would
-actually split a merge refuses.
-
-```python
-table.insert_row(after=2, copy_format_from=2)
-table.insert_column(after=4)
-table.delete_row(0)     # refuses if a vertical merge spans past row 0
-```
-
-**Image and chart replacement without collateral damage.**
-`Picture.replace_image()` swaps image bytes while leaving position, size,
-rotation, and crop untouched — and when two pictures share one image part, only
-the targeted picture changes. `Chart.replace_data_safe()` validates the target
-chart and workbook structure fully before writing, refuses shared chart parts
-and unsupported chart families, and supports workbook-less charts; upstream's
-unguarded `replace_data()` remains available.
-
-```python
-pic = slide.shapes.picture_by_name("Shared Logo A")
-pic.replace_image("new_logo.png")
-
-chart = slide.shapes.chart_by_name("Quarterly Chart")
-chart.replace_data_safe(["North", "South"], [("FY27", [10, 20])])
-```
+- **Anchored, formatting-preserving replacement.** `pptx.edit.replace_text` and `replace_text_at` rewrite text while leaving untouched runs byte-identical. The stock `shape.text = ...` flattens every run's formatting in the paragraph.
+- **Relationship-safe slide lifecycle.** `slides.clone/delete/move/reorder` maintain sections, custom shows, and relationships. Upstream has no public equivalent, and the folk XML recipes strand both.
+- **Real bullets.** `paragraph.bullet` authors genuine `a:buChar` and `a:buAutoNum` state, including bullet typeface and size, instead of typing `-` or `•` into the text.
+- **Autofit made explicit.** `text_frame.normalize_autofit()` freezes PowerPoint's invisible `normAutofit` scale percentages so an edit does not silently resize text.
+- **Notes without side effects.** `slide.read_notes_text()` never creates a notes part; merely reading `slide.notes_slide` upstream does.
+- **Typed, group-aware lookup.** `shape_by_name()`, `picture_by_name()`, `table_by_name()`, and `chart_by_name()` recurse into groups and refuse a duplicate rather than returning the first match.
+- **Surgery that keeps the package consistent.** `SlideShapes.delete/move/add_copy`, table row and column insert and delete, `Picture.replace_image()`, and `Chart.replace_data_safe()` maintain relationships and owned parts.
+- **Batched validation.** `with prs.batch():` validates once at block exit instead of once per mutating call, and discards every edit in the block if that check fails.
 
 ### Compose: assemble decks across files
 
-Nobody builds a pitch book from scratch: overview pages come from the master
-deck, tombstones from the credentials library, sector pages from the sector
-team. The job *is* composition, and composition is relationship-and-inheritance
-surgery — the corruption-prone, package-level mechanics this fork exists to
-own. A slide's appearance half lives outside the slide, in its layout, master,
-and theme; copying slide XML alone produces the failure everyone has seen —
-fonts snap to defaults, brand colors revert, charts detach from their data.
-
-**Cross-deck import with explicit fidelity modes.**
-`Presentation.import_slide()` and `append_deck()` make the inheritance
-trade-off explicit — `mode` is required, with no default: `"adopt_theme"`
-rebinds to a destination layout, `"keep_appearance"` transplants the source
-layout/master/theme chain (fingerprint-deduplicated, so ten slides from one
-source share one master), and `"bake"` freezes resolved formatting into the
-slide. Every import returns an `ImportReport`, and the source deck is never
-mutated.
-
-**Layout rebind with a mandatory shift report.** `Slide.rebind_layout()` moves
-a slide to another layout under explicit placeholder and orphan policies, runs
-the effective-value resolver before and after, and reports every run whose
-resolved font changed, so a typography shift never passes silently. Placeholder
-geometry and text direction are inherited from the layout too and sit outside
-that comparison.
-
-**Real fields, not static text.** `Presentation.apply_footers()` reproduces
-PowerPoint's Insert → Header & Footer behavior: genuine `a:fld` slide-number
-and date fields that renumber on reorder, bound to the layout's footer
-placeholders, applied idempotently.
-
-**Send-safe delivery, no special API needed.** Speaker notes, comments, and
-metadata leaking in an externally sent deck is a compliance failure, not a
-cosmetic one — and removing them is `drop_rel` plus a cleared core property. A
-part leaves the package by becoming unreachable, and the serializer never writes
-an unreachable part, so anything a live slide still uses structurally cannot be
-removed. Unused layouts go through `SlideLayouts.remove()`, which refuses a
-layout still in use. The recipe is in
-[`docs/user/paper-additions.rst`](docs/user/paper-additions.rst).
-
-A complete example:
-
-```python
-from pptx import Presentation
-from pptx.diff import diff_decks
-
-prs = Presentation("house_deck.pptx")
-source = Presentation("sector_team_deck.pptx")
-
-report = prs.import_slide(source, 0, mode="adopt_theme")
-for shift in report.run_shifts:
-    print(shift.text, shift.before["name"]["value"], "->", shift.after["name"]["value"])
-
-prs.apply_footers(footer="Confidential", slide_number=True)
-prs.core_properties.author = ""
-prs.save("house_deck.v2.pptx")
-
-delta = diff_decks("house_deck.pptx", "house_deck.v2.pptx", detail="text")
-print("slides added:", [s.slide_id for s in delta.slides_added])
-```
+- **Cross-deck import with explicit fidelity modes.** `Presentation.import_slide()` and `append_deck()` make the inheritance trade-off a required argument: `adopt_theme`, `keep_appearance`, or `bake`. Each returns an `ImportReport` naming every part added, reused, and dropped.
+- **Layout rebind with a shift report.** `Slide.rebind_layout()` moves a slide under explicit placeholder and orphan policies and reports every run whose resolved font changed. Placeholder geometry and text direction are inherited from the layout too and sit outside that comparison.
+- **Real fields, not static text.** `apply_footers()` writes genuine `a:fld` slide-number and date fields, so PowerPoint refreshes them.
 
 ### Verify: prove what changed
 
-A deck is amnesiac: the format carries no revision markup, so "what changed
-between v3 and v4" has no programmable answer anywhere in the ecosystem —
-until you diff it yourself.
+- **A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent slide ID, so a reorder reports as a move rather than a delete plus an add. `detail="text"` adds chart data, text, and notes; `detail="full"` adds per-run and bullet shifts.
+- **Byte-minimal saves and a package oracle.** `pptx.package.patch_save()` writes semantically unchanged parts back with their original bytes, so a one-line edit diffs as a few parts rather than all of them, and `diff_package()` reports exactly which parts differ.
 
-**A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent
-slide ID, so a reorder reports as a *move* rather than a delete-plus-add, and
-reports shape, text, chart-data, image, and notes changes within matched
-slides. `detail="full"` adds per-run effective-value shifts and per-paragraph
-bullet shifts, which lets a pipeline compare an operation's report against what
-actually changed in the saved file. Bullets need their own facet because they
-live only in formatting: a list losing its bullets changes no text and no field
-marker, so without it the within-slide report comes back empty while the slide
-visibly loses every glyph.
+## What is deliberately not additive
 
-**Byte-minimal saves and a package-level oracle.** A stock save rewrites every
-ZIP member, so even a no-op looks like total churn. `pptx.package.patch_save()`
-writes semantically-unchanged parts back with their original bytes — a
-one-line edit to a sixty-slide deck diffs as one part, not sixty — and
-`diff_package()` reports exactly which parts differ. Meaningful whitespace,
-including a trailing space inside a run, is treated as content.
+The public API is a superset of upstream's, but a few narrow behaviors changed on purpose. Each trades edge-case permissiveness for corruption prevention.
 
-```python
-from pptx.package import patch_save
-
-residual = patch_save("deck.pptx", prs, "out.pptx")   # PackageDiff of real changes only
-```
-
-### What is deliberately not additive
-
-paper-pptx's public Python API is a superset of upstream's, but a few narrow
-existing behaviors changed on purpose. Each trades edge-case permissiveness for
-corruption prevention:
-
-- **Guarded package intake.** Opening a `.pptx` now rejects ambiguous or unsafe
-  ZIP archives — duplicate or case-colliding member names, path traversal,
-  encrypted or exotically-compressed members, lying size headers, an archive that
-  does not span its file exactly, and any member that resolves to no content type
-  — with a typed `PackageLimitError` *before* any editable object exists. A
-  permissive reader "successfully" opens an ambiguous archive and then faithfully
-  edits the wrong interpretation of it. Some odd-but-consumer-readable files that
-  upstream accepted are now refused; each such refusal was checked by opening the
-  file in PowerPoint first, and matches what PowerPoint does. A part that nothing
-  references is *not* refused — PowerPoint opens that package and drops the part
-  on its next save, and so does `save()`.
-- **Atomic save.** `save()` keeps its signature, but saving to a path now
-  writes a sibling temporary file and atomically replaces the destination only
-  after serialization succeeds, preserving the existing file's permission bits.
-  Stream saves stage the whole package first, so a serialization failure emits
-  nothing, and restore the destination on failure when it can be read and
-  rewound; a write-only sink keeps whatever landed. Upstream wrote directly to
-  the destination, so a mid-save failure destroyed the only copy.
-- **`SlideLayouts.remove()` hardening.** Same signature, stricter semantics:
-  stale or foreign proxies and unsafe states now refuse atomically instead of
-  partially mutating.
+- **Guarded package intake.** Opening a `.pptx` rejects ambiguous or unsafe ZIP archives: duplicate or case-colliding member names, path traversal, encrypted or exotically-compressed members, lying size headers, an archive that does not span its file exactly, and any member that resolves to no content type. A part that nothing references is *not* refused; PowerPoint opens that package and drops the part on its next save, and so does `save()`.
+- **Atomic save.** Saving to a path writes a sibling temporary file and replaces the destination only after serialization succeeds, preserving the existing file's permission bits and resolving symlinks. Stream saves stage the whole package first, so a serialization failure emits nothing, and restore the destination on failure when it can be read and rewound; a write-only sink keeps whatever landed.
+- **`SlideLayouts.remove()` hardening.** Same signature, stricter semantics: stale or foreign proxies and unsafe states refuse atomically instead of partially mutating.
 - **Python 3.9+ floor.** Upstream `v1.0.2` supported Python 3.8.
-- **Distribution identity.** The distribution is renamed `paper-pptx`, and
-  `import pptx` fails loudly when both `python-pptx` and `paper-pptx` metadata
-  are installed, because a mixed site-packages can silently run a blend of the
-  two libraries. `pptx.__version__` stays `"1.0.2"` (the upstream API surface),
-  and `pptx.__paper_version__` (`"0.2.0"`) identifies the fork release — so
-  callers can distinguish "which upstream surface" from "which paper release".
+- **Distribution identity.** The distribution is renamed `paper-pptx`, and `import pptx` refuses when both distributions are installed.
 
-## The safety contract
+## Safety contract
 
-Every added operation either does exactly what it claims or refuses
-atomically. Mutating operations run inside a package transaction: whatever the
-operation touched is restored if it refuses, and the deck-wide check runs
-before anything commits. Some operations, including `apply_footers()`,
-`append_deck()`, `import_slide()` and slide clone, additionally validate in
-full before touching anything. When an operation cannot proceed safely, it raises
-a typed refusal from the hierarchy rooted at `pptx.errors.PaperRefusal`
-(`PackageLimitError`, `TargetNotFoundError`, `StaleAnchorError`,
-`AmbiguousTargetError`, `UnsupportedStructureError`, `RelationshipPolicyError`,
-`BoundaryViolationError`) and leaves the presentation byte-for-byte unchanged
-in memory and on disk. Programmer mistakes — a bad type, an out-of-range
-index — remain plain `ValueError` or `TypeError`, so callers can catch
-`PaperRefusal` separately:
+Every added operation either does exactly what it claims or refuses atomically. Mutating operations run inside a package transaction: whatever the operation touched is restored if it refuses, and the deck-wide check runs before anything commits. Some operations, including `apply_footers()`, `append_deck()`, `import_slide()` and slide clone, additionally validate in full before touching anything.
 
-```python
-from pptx import Presentation
-from pptx.errors import PaperRefusal
+A refusal raises a typed error from the hierarchy rooted at `pptx.errors.PaperRefusal` and leaves the presentation byte-for-byte unchanged in memory and on disk. The subclasses say what went wrong: `PackageLimitError`, `TargetNotFoundError`, `StaleAnchorError`, `AmbiguousTargetError`, `UnsupportedStructureError`, `RelationshipPolicyError`, and `BoundaryViolationError`. Programmer mistakes remain plain `ValueError` or `TypeError`, so callers can catch `PaperRefusal` separately.
 
-prs = Presentation("deck.pptx")
-try:
-    prs.slides.clone(3)                 # slide contains an embedded OLE object
-except PaperRefusal:
-    ...                                 # document is untouched; handle or report
-```
-
-A refused edit is a success mode; a quietly wrong file is the worst outcome
-this library can produce. Held proxies survive a refusal too: after a refused
-multi-part operation, existing slide and shape objects still point at valid,
-unchanged content, and stale handles (a slide proxy held across that slide's
-deletion) raise `TargetNotFoundError` instead of silently editing a neighbor.
-
-Refusal atomicity is enforced operation by operation: each documented refusal
-condition has a test asserting both that the typed refusal is raised and that
-output bytes equal input bytes. It is a per-operation contract proven by the
-test harness, not a blanket guarantee over every code path.
+A refused edit is a success mode; a quietly wrong file is the worst outcome this library can produce. Held proxies survive a refusal, and a stale handle raises `TargetNotFoundError` instead of silently editing a neighbor. Each documented refusal condition has a test asserting both that the typed refusal is raised and that output bytes equal input bytes.
 
 ## API surface map
 
-New modules, plus methods added to existing classes. Nothing is re-exported
-from `pptx` itself; import from the module named below.
+| Module | What it does |
+|---|---|
+| `pptx.inspect` | Effective values with provenance, text inspection with content-hash anchors, deck manifest |
+| `pptx.edit` | Deck-wide and anchored text replacement that preserves run formatting |
+| `pptx.diff` | Semantic deck-to-deck diff (`diff_decks`) |
+| `pptx.compose` | Cross-deck slide import and deck append (via `Presentation.import_slide` / `append_deck`) |
+| `pptx.rebind` | Layout rebinding with shift reports (via `Slide.rebind_layout`) |
+| `pptx.hf` | Real slide-number, date, and footer fields (via `apply_footers`) |
+| `pptx.package` | Semantic package diff and byte-minimal `patch_save` |
+| `pptx.errors` | The `PaperRefusal` typed-refusal hierarchy |
 
-| Module | What it does | Reference |
-|---|---|---|
-| `pptx.inspect` | Effective (rendered) values with provenance; text inspection with content-hash anchors; deck manifest | [docs](docs/api/inspect.rst) |
-| `pptx.edit` | Deck-wide and anchored text replacement that preserves run formatting | [docs](docs/api/edit.rst) |
-| `pptx.diff` | Semantic deck-to-deck diff (`diff_decks`) | [docs](docs/api/diff.rst) |
-| `pptx.compose` | Cross-deck slide import and deck append (via `Presentation.import_slide` / `append_deck`) | [docs](docs/api/compose.rst) |
-| `pptx.rebind` | Layout rebinding with shift reports (via `Slide.rebind_layout`) | [docs](docs/api/rebind.rst) |
-| `pptx.hf` | Real slide-number/date/footer fields (via `apply_footers`) | [docs](docs/api/hf.rst) |
-| `pptx.package` | Semantic package diff and byte-minimal `patch_save` | [docs](docs/api/package.rst) |
-| `pptx.errors` | The `PaperRefusal` typed-refusal hierarchy | [docs](docs/api/errors.rst) |
+## Drop-in by design
 
-Methods added to inherited classes: `Presentation.batch`; `Slides.clone` /
-`delete` / `reorder` / `move`; `SlideShapes.delete` / `move` / `add_copy` and
-the `*_by_name` lookups; `Table.insert_row` / `delete_row` / `insert_column` /
-`delete_column`; `Picture.replace_image`; `Chart.replace_data_safe`;
-`TextFrame.normalize_autofit`, `font_scale`, `line_space_reduction`;
-`_Paragraph.bullet` and field helpers; `Slide.read_notes_text` /
-`replace_notes_text` / `apply_footers` / `rebind_layout`.
+Only the distribution and repository are renamed. The importable package stays `pptx`. This is the same distribution/import split as Pillow (`pip install pillow`, `import PIL`), and it preserves existing code, snippets, and model priors.
 
-## Everything from python-pptx still works
+- GitHub repository / PyPI distribution: **`paper-pptx`**
+- Python import: **`pptx`**
+- Fork sentinel: `pptx.__paper_version__`
 
-The import surface is unchanged: `from pptx import Presentation`, `pptx.util`,
-`pptx.chart.data`, placeholder access, shape trees — every documented upstream
-API behaves as upstream documents it, and upstream's own pytest and behave
-suites run on every change to keep it that way. Existing code, snippets, and
-model priors that say `import pptx` work as-is; `pptx.__version__` still
-reports the upstream base (`"1.0.2"`).
+Every documented upstream API behaves as upstream documents it: `from pptx import Presentation`, `pptx.util`, `pptx.chart.data`, placeholder access, shape trees. New upstream releases are merged, never rebased, so the fork retains its history and compatibility.
 
-New upstream releases are merged, never rebased, so the fork retains its
-history and compatibility.
+## Installation
+
+Requires Python 3.9+.
+
+```bash
+python -m pip uninstall -y python-pptx paper-pptx
+python -m pip install paper-pptx
+```
+
+The clean uninstall is required when migrating from `python-pptx`. Both distributions own the same `pptx` import package, and pip cannot safely overlay or uninstall two distributions that own the same files. If both are installed, `import pptx` refuses with an `ImportError` rather than running an unverifiable mix of the two.
+
+Confirm the install:
+
+```bash
+paper-pptx-doctor
+```
 
 ## Documentation
 
-There is no hosted documentation site yet. The Sphinx docs build in CI and
-extend the upstream python-pptx documentation:
+The Sphinx docs extend the upstream python-pptx documentation to cover the fork's additions: start with `docs/user/paper-additions.rst` and the `docs/api/*.rst` reference pages. Everything inherited from python-pptx works as documented at the [python-pptx documentation](https://python-pptx.readthedocs.io/).
 
-- [`docs/user/paper-additions.rst`](docs/user/paper-additions.rst) — the
-  narrative guide to everything the fork adds (perceive / edit / compose /
-  verify), with worked examples.
-- [`docs/api/`](docs/api/) — reference pages for each added module.
-- The remaining documentation is inherited from python-pptx and describes the
-  shared, unchanged foundation.
+## Current limitations
 
-Build locally with `uv sync --group docs` and `uv run make docs`.
+Converting a documented typed refusal into a correct operation is the sanctioned growth path of this package. The known gaps:
 
-## Roadmap and known limitations
+- **Notes parts are never created.** `read_notes_text` and `replace_notes_text` work only on existing notes.
+- **Table-cell effective values refuse** until the table-style resolution walk is built.
+- **Chart data replacement supports single-plot category charts.** XY, bubble, stock, surface, radar, 3-D, and multi-plot combos refuse.
+- **Bullet color is not resolved**, and bullet diffing needs `detail="full"` and skips table cells.
+- **`diff_decks` assumes lineage**, matching slides by permanent ID. It is not a visual diff.
+- **Fixture provenance.** The test corpus is generated and LibreOffice round-tripped, not authored by PowerPoint.
 
-A great many refusals are deliberate scope statements, and converting a
-documented typed refusal into a correct operation is the sanctioned growth
-path of this package. Known gaps, honestly:
+Deliberate non-goals: no rendering or layout-geometry computation, no SmartArt authoring (opaque preservation only), and no animation or transition authoring.
 
-- **Notes parts are never created.** `read_notes_text` / `replace_notes_text`
-  work only on existing notes; creating the notes-part graph (notes master
-  included) is a recorded candidate, not yet built.
-- **Table-cell effective values refuse** until the table-style resolution walk
-  lands.
-- **Chart data replacement supports single-plot category charts.** XY, bubble,
-  stock, surface, radar, 3-D, and multi-plot combos refuse rather than risk
-  cache/workbook desynchronization.
-- **Fixture provenance.** The test corpus is generated and
-  LibreOffice-round-tripped, with provenance recorded truthfully;
-  PowerPoint-authored and Google-exported fixtures are still pending, and
-  release sign-off includes a manual desktop-PowerPoint checklist.
-- **Deck diff assumes lineage.** `diff_decks` matches slides by permanent ID,
-  which serves decks derived from a common ancestor (v4 saved from v3);
-  matching independently-authored decks is out of scope today.
-- **Bullet color is not resolved.** `effective_paragraph_format()` reports a
-  bullet's kind, typeface, and size, but not its color. `a:buClr` needs the
-  theme-color walk, and `BulletFormat` can neither read nor write a bullet
-  color, so resolving it would add capability rather than close a gap.
-- **Bullet diffing needs `detail="full"`, and skips table cells.** `bullet_shifts`
-  is resolver-backed, so it only populates at full detail and only covers the
-  paragraphs `effective_paragraph_format` supports — table-cell paragraphs are
-  skipped rather than guessed at. Paragraphs whose text repeats within one shape
-  are skipped too, since content is half their identity across two decks.
+## Testing
 
-Deliberate non-goals: no rendering or layout-geometry computation (appearance
-verification belongs to a harness, not this library), no SmartArt authoring
-(opaque preservation only), no animations/transitions editing, no aspect-ratio
-migration, no bulk template-migration orchestration (`rebind_layout` is the
-primitive), no document-QA `check()` API, and no new runtime dependencies.
-
-## How it's tested
-
-- Upstream's pytest and behave suites run on every change to check
-  compatibility with existing behavior.
-- A frozen, hash-pinned fixture corpus includes generated presentations and
-  LibreOffice round-trips with provenance sidecars.
-- The contract harness in [`tests/paper/`](tests/paper/) saves and reopens
-  before asserting, enforces exact changed-part budgets and refusal atomicity
-  (output bytes equal input bytes on every documented refusal), and validates
-  selected XML fragments against their schemas.
-- Release verification requires a headless LibreOffice load smoke
-  (`pytest -m lo_smoke tests/paper`) and the manual checklist in
-  [`tests/paper/RELEASE-CHECKLIST.md`](tests/paper/RELEASE-CHECKLIST.md).
-- House rule: no fix without a fixture.
+- Upstream's pytest and behave suites run on every change to check compatibility with existing behavior.
+- A frozen, hash-pinned fixture corpus includes generated presentations and LibreOffice round-trips.
+- The contract harness checks refusal atomicity and validates the fixture corpus with a headless LibreOffice load smoke.
 
 ## Contributing
 
-Contributions are welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for dev
-setup, the test matrix, and the safety conventions every mutating API must
-satisfy (validate-fully-then-mutate, save→reopen assertions, changed-part
-budgets). The short version:
+Contributions are welcome — see [CONTRIBUTING.md](https://github.com/paper-instruments/paper-pptx/blob/main/CONTRIBUTING.md) for the engineering discipline this fork runs on. The short version: the upstream suite must remain green; persistence changes need saved-and-reopened assertions and exact package-delta checks; guarded refusals must be atomic and leave bytes unchanged; and a refusal message must name what was found, why it is unsafe, and what to do about it.
 
-```bash
-uv sync --group dev
-uv run pytest
-uv run behave
-```
+## Community
 
-## Community and support
-
-- Bugs and feature requests: [GitHub Issues](https://github.com/paper-instruments/paper-pptx/issues)
-- Release history: [GitHub releases](https://github.com/paper-instruments/paper-pptx/releases)
+- **Bugs and feature requests**: [GitHub Issues](https://github.com/paper-instruments/paper-pptx/issues)
+- **Questions and ideas**: [GitHub Discussions](https://github.com/paper-instruments/paper-pptx/discussions)
 
 ## Citation
 
@@ -587,22 +180,14 @@ If you reference paper-pptx in research or writing:
   title   = {paper-pptx: an agent-first structure editor for PowerPoint files},
   author  = {{Paper Instruments, Inc.}},
   year    = {2026},
-  version = {0.2.0},
   url     = {https://github.com/paper-instruments/paper-pptx}
 }
 ```
 
-## License
-
-MIT, inherited from python-pptx. Original work © 2013 Steve Canny and the
-python-pptx contributors; fork additions © 2026 Paper Instruments, Inc. This
-fork preserves the upstream license and attribution. See
-[`LICENSE`](LICENSE).
-
 ## Acknowledgments
 
-paper-pptx exists because [python-pptx](https://github.com/scanny/python-pptx)
-is excellent. Steve Canny and the python-pptx contributors built the lossless
-package layer, the disciplined XML mapping, and a decade of absorbed edge
-cases that make safe deck editing possible at all — this fork stands on that
-work and gratefully keeps their API intact.
+paper-pptx exists because [python-pptx](https://github.com/scanny/python-pptx) is excellent. Steve Canny and the python-pptx contributors built the lossless package layer, the disciplined XML mapping, and a decade of absorbed edge cases that make safe deck editing possible at all. This fork stands on that work and keeps their API intact.
+
+## License
+
+MIT, inherited from python-pptx. Original work © 2013 Steve Canny and the python-pptx contributors; fork additions © 2026 Paper Instruments, Inc. This fork preserves the upstream license and attribution. See [LICENSE](https://github.com/paper-instruments/paper-pptx/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Contributions are welcome. See [CONTRIBUTING.md](https://github.com/paper-instru
 - **Bugs and feature requests**: [GitHub Issues](https://github.com/paper-instruments/paper-pptx/issues)
 - **Questions and ideas**: [GitHub Discussions](https://github.com/paper-instruments/paper-pptx/discussions)
 
+## Acknowledgments
+
+paper-pptx exists because [python-pptx](https://github.com/scanny/python-pptx) is excellent. Steve Canny and the python-pptx contributors built the lossless package layer, the disciplined XML mapping, and a decade of absorbed edge cases that make safe deck editing possible at all. This fork stands on that work and keeps their API intact.
+
 ## Citation
 
 If you reference paper-pptx in research or writing:
@@ -167,9 +171,7 @@ If you reference paper-pptx in research or writing:
 }
 ```
 
-## Acknowledgments
-
-paper-pptx exists because [python-pptx](https://github.com/scanny/python-pptx) is excellent. Steve Canny and the python-pptx contributors built the lossless package layer, the disciplined XML mapping, and a decade of absorbed edge cases that make safe deck editing possible at all. This fork stands on that work and keeps their API intact.
+Cite it as a fork of *python-pptx* by Steve Canny and contributors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 
 **An import-compatible, agent-first structure editor for PowerPoint files, designed to prevent silent corruption when editing existing decks.**
 
-`paper-pptx` is a drop-in hard fork of [python-pptx](https://github.com/scanny/python-pptx) `v1.0.2` for safely inspecting, editing, composing, and verifying existing PowerPoint (`.pptx`) presentations. It keeps python-pptx's package layer, XML mapping, and object model. It adds the rendered values a deck actually shows, edits that survive PowerPoint's run fragmentation, and refusals in place of guesses.
+`paper-pptx` is a drop-in hard fork of [python-pptx](https://github.com/scanny/python-pptx) `v1.0.2` for safely inspecting, editing, composing, and verifying existing PowerPoint (`.pptx`) presentations. It keeps python-pptx's package layer, XML mapping, and object model. It adds the rendered values a deck shows, edits that survive PowerPoint's run fragmentation, and refusals in place of guesses.
 
 ```python
-from pptx import Presentation   # the import name is unchanged — see "Drop-in by design"
+from pptx import Presentation   # the import name is unchanged (see "Drop-in by design")
 ```
 
-The fork exists to prevent **silent corruption**: a deck that opens fine and is quietly wrong. Automated systems cannot eyeball a slide, so every added operation returns its outcome as typed, machine-readable data, and an operation that cannot proceed safely raises a typed refusal and leaves the presentation byte-for-byte unchanged rather than guessing.
+The fork exists to prevent **silent corruption**: a deck that opens without error but is wrong. Automated systems cannot eyeball a slide, so every added operation returns its outcome as typed, machine-readable data, and an operation that cannot proceed safely raises a typed refusal and leaves the presentation byte-for-byte unchanged rather than guessing.
 
 ---
 
@@ -53,10 +53,10 @@ print(len(delta.slide_changes), "slides changed")
 
 ## What paper-pptx adds
 
-### Perceive: read what the deck actually renders
+### Perceive: read what the deck renders
 
 - **`pptx.inspect` effective values, with provenance.** `effective_font()`, `effective_paragraph_format()`, and `effective_shape_format()` resolve size, typeface, color, alignment, line spacing, and bullets through the run, paragraph, placeholder, layout, master, and theme chain, and report which rung supplied each value. Bullet typeface and size resolve on their own chains, because the schema inherits them separately from the glyph. Unresolved is reported as unresolved rather than guessed.
-- **Visibility-complete text inspection.** `inspect_text()` reaches nested groups and table cells, which iterating top-level shapes misses, and returns content-hash anchors that survive an edit. Regions it cannot survey are reported as blind blocks rather than silently skipped.
+- **Visibility-complete text inspection.** `inspect_text()` reaches nested groups and table cells, which iterating top-level shapes misses, and returns content-hash anchors that survive an edit. Regions it cannot survey are reported as blind blocks rather than skipped.
 - **A deterministic deck manifest.** `inspect_deck()` emits a versioned, JSON-friendly structural manifest: slides, shapes, z-order, geometry, and placeholder identity.
 
 ### Edit: change one deck without flattening it
@@ -64,8 +64,8 @@ print(len(delta.slide_changes), "slides changed")
 - **Anchored, formatting-preserving replacement.** `pptx.edit.replace_text` and `replace_text_at` rewrite text while leaving untouched runs byte-identical. The stock `shape.text = ...` flattens every run's formatting in the paragraph.
 - **Relationship-safe slide lifecycle.** `slides.clone/delete/move/reorder` maintain sections, custom shows, and relationships. Upstream has no public equivalent, and the folk XML recipes strand both.
 - **Real bullets.** `paragraph.bullet` authors genuine `a:buChar` and `a:buAutoNum` state, including bullet typeface and size, instead of typing `-` or `•` into the text.
-- **Autofit made explicit.** `text_frame.normalize_autofit()` freezes PowerPoint's invisible `normAutofit` scale percentages so an edit does not silently resize text.
-- **Notes without side effects.** `slide.read_notes_text()` never creates a notes part; merely reading `slide.notes_slide` upstream does.
+- **Autofit made explicit.** `text_frame.normalize_autofit()` freezes PowerPoint's invisible `normAutofit` scale percentages so an edit does not resize text without warning.
+- **Notes without side effects.** `slide.read_notes_text()` never creates a notes part; reading `slide.notes_slide` upstream does.
 - **Typed, group-aware lookup.** `shape_by_name()`, `picture_by_name()`, `table_by_name()`, and `chart_by_name()` recurse into groups and refuse a duplicate rather than returning the first match.
 - **Surgery that keeps the package consistent.** `SlideShapes.delete/move/add_copy`, table row and column insert and delete, `Picture.replace_image()`, and `Chart.replace_data_safe()` maintain relationships and owned parts.
 - **Batched validation.** `with prs.batch():` validates once at block exit instead of once per mutating call, and discards every edit in the block if that check fails.
@@ -73,7 +73,7 @@ print(len(delta.slide_changes), "slides changed")
 ### Compose: assemble decks across files
 
 - **Cross-deck import with explicit fidelity modes.** `Presentation.import_slide()` and `append_deck()` make the inheritance trade-off a required argument: `adopt_theme`, `keep_appearance`, or `bake`. Each returns an `ImportReport` naming every part added, reused, and dropped.
-- **Layout rebind with a shift report.** `Slide.rebind_layout()` moves a slide under explicit placeholder and orphan policies and reports every run whose resolved font changed. Placeholder geometry and text direction are inherited from the layout too and sit outside that comparison.
+- **Layout rebind with a shift report.** `Slide.rebind_layout()` moves a slide under explicit placeholder and orphan policies and reports every run whose resolved font changed. Placeholder geometry and text direction are inherited from the layout and sit outside that comparison.
 - **Real fields, not static text.** `apply_footers()` writes genuine `a:fld` slide-number and date fields, so PowerPoint refreshes them.
 
 ### Verify: prove what changed
@@ -93,11 +93,11 @@ The public API is a superset of upstream's, but a few narrow behaviors changed o
 
 ## Safety contract
 
-Every added operation either does exactly what it claims or refuses atomically. Mutating operations run inside a package transaction: whatever the operation touched is restored if it refuses, and the deck-wide check runs before anything commits. Some operations, including `apply_footers()`, `append_deck()`, `import_slide()` and slide clone, additionally validate in full before touching anything.
+Every added operation either does exactly what it claims or refuses atomically. Mutating operations run inside a package transaction: whatever the operation touched is restored if it refuses, and the deck-wide check runs before anything commits. Some operations, including `apply_footers()`, `append_deck()`, `import_slide()` and slide clone, also validate in full before touching anything.
 
 A refusal raises a typed error from the hierarchy rooted at `pptx.errors.PaperRefusal` and leaves the presentation byte-for-byte unchanged in memory and on disk. The subclasses say what went wrong: `PackageLimitError`, `TargetNotFoundError`, `StaleAnchorError`, `AmbiguousTargetError`, `UnsupportedStructureError`, `RelationshipPolicyError`, and `BoundaryViolationError`. Programmer mistakes remain plain `ValueError` or `TypeError`, so callers can catch `PaperRefusal` separately.
 
-A refused edit is a success mode; a quietly wrong file is the worst outcome this library can produce. Held proxies survive a refusal, and a stale handle raises `TargetNotFoundError` instead of silently editing a neighbor. Each documented refusal condition has a test asserting both that the typed refusal is raised and that output bytes equal input bytes.
+A refused edit is a success mode; the worst outcome this library can produce is a file that opens without error but is wrong. Held proxies survive a refusal, and a stale handle raises `TargetNotFoundError` instead of editing a neighbor. Each documented refusal condition has a test asserting both that the typed refusal is raised and that output bytes equal input bytes.
 
 ## API surface map
 
@@ -164,7 +164,7 @@ Deliberate non-goals: no rendering or layout-geometry computation, no SmartArt a
 
 ## Contributing
 
-Contributions are welcome — see [CONTRIBUTING.md](https://github.com/paper-instruments/paper-pptx/blob/main/CONTRIBUTING.md) for the engineering discipline this fork runs on. The short version: the upstream suite must remain green; persistence changes need saved-and-reopened assertions and exact package-delta checks; guarded refusals must be atomic and leave bytes unchanged; and a refusal message must name what was found, why it is unsafe, and what to do about it.
+Contributions are welcome. See [CONTRIBUTING.md](https://github.com/paper-instruments/paper-pptx/blob/main/CONTRIBUTING.md) for the engineering discipline this fork runs on. The short version: the upstream suite must remain green; persistence changes need saved-and-reopened assertions and exact package-delta checks; guarded refusals must be atomic and leave bytes unchanged; and a refusal message must name what was found, why it is unsafe, and what to do about it.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -95,19 +95,6 @@ A refusal raises a typed error from the hierarchy rooted at `pptx.errors.PaperRe
 
 A refused edit is a success mode; the worst outcome this library can produce is a file that opens without error but is wrong. Held proxies survive a refusal, and a stale handle raises `TargetNotFoundError` instead of editing a neighbor. Each documented refusal condition has a test asserting both that the typed refusal is raised and that output bytes equal input bytes.
 
-## API surface map
-
-| Module | What it does |
-|---|---|
-| `pptx.inspect` | Effective values with provenance, text inspection with content-hash anchors, deck manifest |
-| `pptx.edit` | Deck-wide and anchored text replacement that preserves run formatting |
-| `pptx.diff` | Semantic deck-to-deck diff (`diff_decks`) |
-| `pptx.compose` | Cross-deck slide import and deck append (via `Presentation.import_slide` / `append_deck`) |
-| `pptx.rebind` | Layout rebinding with shift reports (via `Slide.rebind_layout`) |
-| `pptx.hf` | Real slide-number, date, and footer fields (via `apply_footers`) |
-| `pptx.package` | Semantic package diff and byte-minimal `patch_save` |
-| `pptx.errors` | The `PaperRefusal` typed-refusal hierarchy |
-
 ## Drop-in by design
 
 Only the distribution and repository are renamed. The importable package stays `pptx`. This is the same distribution/import split as Pillow (`pip install pillow`, `import PIL`), and it preserves existing code, snippets, and model priors.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ print(len(delta.slide_changes), "slides changed")
 - **Typed, group-aware lookup.** `shape_by_name()`, `picture_by_name()`, `table_by_name()`, and `chart_by_name()` recurse into groups and refuse a duplicate rather than returning the first match.
 - **Surgery that keeps the package consistent.** `SlideShapes.delete/move/add_copy`, table row and column insert and delete, `Picture.replace_image()`, and `Chart.replace_data_safe()` maintain relationships and owned parts.
 - **Batched validation.** `with prs.batch():` validates once at block exit instead of once per mutating call, and discards every edit in the block if that check fails.
+- **`SlideLayouts.remove()` hardening.** Same signature, stricter semantics: stale or foreign proxies and unsafe states refuse atomically instead of partially mutating.
 
 ### Compose: assemble decks across files
 
@@ -81,15 +82,10 @@ print(len(delta.slide_changes), "slides changed")
 - **A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent slide ID, so a reorder reports as a move rather than a delete plus an add. `detail="text"` adds chart data, text, and notes; `detail="full"` adds per-run and bullet shifts.
 - **Byte-minimal saves and a package oracle.** `pptx.package.patch_save()` writes semantically unchanged parts back with their original bytes, so a one-line edit diffs as a few parts rather than all of them, and `diff_package()` reports exactly which parts differ.
 
-## What is deliberately not additive
+### Package intake and save
 
-The public API is a superset of upstream's, but a few narrow behaviors changed on purpose. Each trades edge-case permissiveness for corruption prevention.
-
-- **Guarded package intake.** Opening a `.pptx` rejects ambiguous or unsafe ZIP archives: duplicate or case-colliding member names, path traversal, encrypted or exotically-compressed members, lying size headers, an archive that does not span its file exactly, and any member that resolves to no content type. A part that nothing references is *not* refused; PowerPoint opens that package and drops the part on its next save, and so does `save()`.
+- **Guarded package intake.** Opening a `.pptx` rejects ambiguous or unsafe ZIP archives: duplicate or case-colliding member names, path traversal, encrypted or exotically-compressed members, lying size headers, an archive that does not span its file exactly, and any member that resolves to no content type. A part that nothing references is kept; PowerPoint opens that package and drops the part on its next save, and so does `save()`.
 - **Atomic save.** Saving to a path writes a sibling temporary file and replaces the destination only after serialization succeeds, preserving the existing file's permission bits and resolving symlinks. Stream saves stage the whole package first, so a serialization failure emits nothing, and restore the destination on failure when it can be read and rewound; a write-only sink keeps whatever landed.
-- **`SlideLayouts.remove()` hardening.** Same signature, stricter semantics: stale or foreign proxies and unsafe states refuse atomically instead of partially mutating.
-- **Python 3.9+ floor.** Upstream `v1.0.2` supported Python 3.8.
-- **Distribution identity.** The distribution is renamed `paper-pptx`, and `import pptx` refuses when both distributions are installed.
 
 ## Safety contract
 
@@ -124,7 +120,7 @@ Every documented upstream API behaves as upstream documents it: `from pptx impor
 
 ## Installation
 
-Requires Python 3.9+.
+Requires Python 3.9+. Upstream `v1.0.2` supported Python 3.8.
 
 ```bash
 python -m pip uninstall -y python-pptx paper-pptx

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 from pptx import Presentation   # the import name is unchanged (see "Drop-in by design")
 ```
 
-The fork exists to prevent **silent corruption**: a deck that opens without error but is wrong. Automated systems cannot eyeball a slide, so every added operation returns its outcome as typed, machine-readable data, and an operation that cannot proceed safely raises a typed refusal and leaves the presentation byte-for-byte unchanged rather than guessing.
+The fork exists to prevent **silent corruption**: a deck that opens without error but is wrong. Automated systems cannot eyeball a slide, so every added operation returns its outcome as typed, machine-readable data, and an operation that cannot proceed safely raises a typed refusal and leaves the presentation byte-for-byte unchanged.
 
 ---
 
@@ -29,7 +29,7 @@ The fork exists to prevent **silent corruption**: a deck that opens without erro
 
 `python-pptx` is excellent at *creating* decks. Its lossless package layer, disciplined XML mapping, and a decade of absorbed edge cases are why this fork builds on it.
 
-The harder problem is changing an existing deck without flattening formatting, stranding relationships, or losing content outside the slide body. Stock `run.font.size` returns `None` for any value inherited through the placeholder chain, the only stock write path flattens every run in a paragraph, and there is no public clone, delete, or reorder for slides. An agent cannot look at the result, so it needs the deck's structure and every edit outcome as typed data, and it needs the library to refuse rather than guess.
+The harder problem is changing an existing deck without flattening formatting, stranding relationships, or losing content outside the slide body. Stock `run.font.size` returns `None` for any value inherited through the placeholder chain, the only stock write path flattens every run in a paragraph, and there is no public clone, delete, or reorder for slides. An agent cannot look at the result, so it needs the deck's structure and every edit outcome as typed data, and it needs the library to refuse unsafe edits.
 
 ## Quick start
 
@@ -55,7 +55,7 @@ print(len(delta.slide_changes), "slides changed")
 
 ### Perceive: read what the deck renders
 
-- **`pptx.inspect` effective values, with provenance.** `effective_font()`, `effective_paragraph_format()`, and `effective_shape_format()` resolve size, typeface, color, alignment, line spacing, and bullets through the run, paragraph, placeholder, layout, master, and theme chain, and report which rung supplied each value. Bullet typeface and size resolve on their own chains, because the schema inherits them separately from the glyph. Unresolved is reported as unresolved rather than guessed.
+- **`pptx.inspect` effective values, with provenance.** `effective_font()`, `effective_paragraph_format()`, and `effective_shape_format()` resolve size, typeface, color, alignment, line spacing, and bullets through the run, paragraph, placeholder, layout, master, and theme chain, and report which rung supplied each value. Bullet typeface and size resolve on their own chains, because the schema inherits them separately from the glyph. Unresolved values are reported as unresolved.
 - **Visibility-complete text inspection.** `inspect_text()` reaches nested groups and table cells, which iterating top-level shapes misses, and returns content-hash anchors that survive an edit. Regions it cannot survey are reported as blind blocks rather than skipped.
 - **A deterministic deck manifest.** `inspect_deck()` emits a versioned, JSON-friendly structural manifest: slides, shapes, z-order, geometry, and placeholder identity.
 


### PR DESCRIPTION
## Summary

The README drops from 608 lines to 193.

One centered header that closes, a bold tagline, the import fence, a single `---`, then left-aligned sections ending Contributing, Community, Citation, Acknowledgments, License.

## Where the 415 lines went

Four subsections carried sixteen code fences between them and accounted for 245 lines, 40% of the file. Perceive, Edit, Compose and Verify are now bullet lists naming the same APIs, with one worked example in Quick start instead of an example per capability.

The table of contents is gone, and so is an in-page anchor link pointing into a section that no longer exists.

## Two non-cosmetic fixes

- **Absolute URLs.** Logo sources were `.github/assets/logo-light.svg` and the license link was `LICENSE`. Relative paths render on GitHub and break on PyPI. Sources now use `raw.githubusercontent.com` and `blob/main`.
- **Badge set.** PyPI, Python versions, Test. License and Downloads dropped.

## Content preserved

All 43 substantive claims from the previous README are present, including every public API, every refusal class, the guarded-intake list, the deliberate non-goals, and the known limitations.

The three corrections from #31 survive verbatim:

- the safety contract describing the **package transaction** instead of validate-first
- `rebind_layout` reporting **resolved font** changes instead of all appearance
- stream saves restoring the destination only **when it can be read and rewound**

## Verified

- **Quick start example executed** against the package: `effective_font().size.value_pt` resolves, `replace_text` reports 1 replacement, `diff_decks` reports 1 changed slide. The illustrative font size in the comment is now unstated, since the value depends on the layout and the old `# e.g. 36.0` did not match a default-template title.
- One `<div>`, one `</div>`, nothing centered after the header, one horizontal rule, fences balanced
- Zero relative links, all image sources absolute, no in-page anchors left dangling
- `CONTRIBUTING.md`, `LICENSE`, both logo assets, and `docs/user/paper-additions.rst` all exist

No claim about what PowerPoint accepts or refuses was added or changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to README.md with no runtime or library behavior impact.
> 
> **Overview**
> **Condenses `README.md` from ~608 lines to ~178** while keeping the same substantive claims (APIs, refusal types, limitations, non-goals). Long Perceive/Edit/Compose/Verify subsections with many code fences become **bullet lists**; **one Quick start example** replaces per-capability samples. The table of contents and most in-page anchors are removed in favor of a shorter section order (centered header block, single `---`, then left-aligned sections).
> 
> **PyPI/rendering fixes:** logo `src`/`srcset` and links to `CONTRIBUTING.md` / `LICENSE` use **absolute GitHub URLs** instead of repo-relative paths. Badge row is trimmed to PyPI, Python versions, and Test (License/Downloads removed). Quick start drops the illustrative `# e.g. 36.0` font-size comment.
> 
> Wording tweaks from prior review are retained (e.g. **package transaction** in the safety contract, **`rebind_layout` resolved-font** reporting, stream-save restore **when readable and rewound**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184e0d79a71590d37f3c1e6526c698d8cc2c787d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->