### PR TITLE
feat: add composable table expansion APIs

### DIFF
--- a/docs/api/table.rst
+++ b/docs/api/table.rst
@@ -13,12 +13,35 @@ Table-related objects
 A |Table| object is added to a slide using the
 :meth:`~.SlideShapes.add_table` method on |SlideShapes|.
 
+Table content and shape geometry have different owners. Group-aware
+:meth:`~pptx.shapes.shapetree.SlideShapes.table_by_name` returns a |Table| directly and is the
+shortest path for cell, row, and column work. When the workflow also needs position, width, height,
+rotation, or other shape properties, use
+:meth:`~pptx.shapes.shapetree.SlideShapes.shape_by_name`, verify the returned graphic frame has a
+table, and access its :attr:`~pptx.shapes.graphfrm.GraphicFrame.table`. Geometry stays on that
+graphic frame; |Table| does not provide owner-navigation or geometry aliases.
+
 .. autoclass:: Table()
    :members:
    :inherited-members:
    :exclude-members:
       notify_height_changed, notify_width_changed, part
    :undoc-members:
+
+
+Direct-format column templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`Table.insert_column` can copy direct cell formatting from an existing column. The source
+index always names a column in the table *before* insertion. Each inserted cell receives the
+complete direct cell-properties subtree from the source cell in the same row, including fills,
+borders, margins, anchors, and producer extension content. Text and merge state are not copied;
+the inserted cells are empty and unmerged.
+
+This is a direct-format copy, not an effective-format calculation. Appearance supplied only by the
+table style or theme is not materialized into the new cells. If the caller supplies a width, it
+wins. Otherwise a selected source column supplies the new width; without a source, the existing
+neighbor-width behavior applies.
 
 
 |_Column| objects
@@ -52,3 +75,21 @@ using the :attr:`_Row.cells` collection.
    :members:
    :member-order: bysource
    :undoc-members:
+
+
+Creating, extending, and splitting merges
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`_Cell.merge` creates a new rectangular merge from unmerged cells.
+:meth:`_Cell.extend_merge` grows an existing merge-origin cell rightward, downward, or in both
+directions in one rollback-safe operation. :meth:`_Cell.split` removes an existing merge.
+
+Merge extension requires the receiver to be the live top-left origin of a canonical rectangular
+merge and the target to be its requested new lower-right corner. It refuses malformed continuation
+topology, stale cells, a target in another table, shrinking or upward/leftward movement, and any
+other merge that intersects the requested rectangle. An unrelated merge elsewhere in the table
+does not block the operation.
+
+Only newly absorbed cell content moves to the origin, in row-major order after the origin's
+existing content. The origin cell and its direct formatting remain in place, and table/frame
+geometry does not change. Requesting the current lower-right corner is a no-op.

--- a/features/steps/table.py
+++ b/features/steps/table.py
@@ -107,9 +107,9 @@ def when_I_assign_origin_cell_eq_table_cell_0_0(context):
     context.origin_cell = context.table_.cell(0, 0)
 
 
-@when("I assign other_cell = table.cell(1, 1)")
-def when_I_assign_other_cell_eq_table_cell_1_1(context):
-    context.other_cell = context.table_.cell(1, 1)
+@when("I assign other_cell = table.cell({row_idx:d}, {col_idx:d})")
+def when_I_assign_other_cell_eq_table_cell(context, row_idx, col_idx):
+    context.other_cell = context.table_.cell(row_idx, col_idx)
 
 
 @when("I assign table.first_col = True")
@@ -150,6 +150,11 @@ def when_I_call_cell_split_other_cell(context):
 @when("I call origin_cell.merge(other_cell)")
 def when_I_call_origin_cell_merge_other_cell(context):
     context.origin_cell.merge(context.other_cell)
+
+
+@when("I call origin_cell.extend_merge(other_cell)")
+def when_I_call_origin_cell_extend_merge_other_cell(context):
+    context.origin_cell.extend_merge(context.other_cell)
 
 
 # then ====================================================
@@ -195,18 +200,18 @@ def then_cell_text_eq_value(context, value):
     assert actual == expected, 'cell.text == "%s"' % actual
 
 
-@then("cell.span_height == {int_lit}")
-def then_cell_span_height_eq(context, int_lit):
+@then("{cell_ref}.span_height == {int_lit}")
+def then_cell_span_height_eq(context, cell_ref, int_lit):
     expected = int(int_lit)
-    actual = context.cell.span_height
-    assert actual is expected, "cell.span_height == %s" % actual
+    actual = getattr(context, cell_ref).span_height
+    assert actual is expected, "%s.span_height == %s" % (cell_ref, actual)
 
 
-@then("cell.span_width == {int_lit}")
-def then_cell_span_width_eq(context, int_lit):
+@then("{cell_ref}.span_width == {int_lit}")
+def then_cell_span_width_eq(context, cell_ref, int_lit):
     expected = int(int_lit)
-    actual = context.cell.span_width
-    assert actual is expected, "cell.span_width == %s" % actual
+    actual = getattr(context, cell_ref).span_width
+    assert actual is expected, "%s.span_width == %s" % (cell_ref, actual)
 
 
 @then("cell.vertical_anchor == {value}")

--- a/features/steps/table.py
+++ b/features/steps/table.py
@@ -204,14 +204,14 @@ def then_cell_text_eq_value(context, value):
 def then_cell_span_height_eq(context, cell_ref, int_lit):
     expected = int(int_lit)
     actual = getattr(context, cell_ref).span_height
-    assert actual is expected, "%s.span_height == %s" % (cell_ref, actual)
+    assert actual == expected, "%s.span_height == %s" % (cell_ref, actual)
 
 
 @then("{cell_ref}.span_width == {int_lit}")
 def then_cell_span_width_eq(context, cell_ref, int_lit):
     expected = int(int_lit)
     actual = getattr(context, cell_ref).span_width
-    assert actual is expected, "%s.span_width == %s" % (cell_ref, actual)
+    assert actual == expected, "%s.span_width == %s" % (cell_ref, actual)
 
 
 @then("cell.vertical_anchor == {value}")

--- a/features/tbl-cell.feature
+++ b/features/tbl-cell.feature
@@ -65,6 +65,21 @@ Feature: Table cell proxy objects
       And other_cell.text == ""
 
 
+  Scenario: _Cell.extend_merge()
+    Given a 3x3 Table object with cells a to i as table
+     When I assign origin_cell = table.cell(0, 0)
+      And I assign other_cell = table.cell(1, 1)
+      And I call origin_cell.merge(other_cell)
+      And I assign other_cell = table.cell(2, 2)
+      And I call origin_cell.extend_merge(other_cell)
+     Then origin_cell.is_merge_origin is True
+      And other_cell.is_spanned is True
+      And origin_cell.span_height == 3
+      And origin_cell.span_width == 3
+      And origin_cell.text == "a\nb\nd\ne\nc\nf\ng\nh\ni"
+      And other_cell.text == ""
+
+
   Scenario: Merged cell size
     Given a 2x3 _MergeOriginCell object as cell
      Then cell.span_height == 2

--- a/src/pptx/table.py
+++ b/src/pptx/table.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Iterator
 
 from pptx.dml.fill import FillFormat
@@ -12,11 +13,47 @@ from pptx.util import Emu, lazyproperty
 
 if TYPE_CHECKING:
     from pptx.enum.text import MSO_VERTICAL_ANCHOR
-    from pptx.oxml.table import CT_Table, CT_TableCell, CT_TableCol, CT_TableRow
+    from pptx.oxml.table import (
+        CT_Table,
+        CT_TableCell,
+        CT_TableCellProperties,
+        CT_TableCol,
+        CT_TableRow,
+    )
     from pptx.parts.slide import BaseSlidePart
     from pptx.shapes.graphfrm import GraphicFrame
     from pptx.types import ProvidesPart
     from pptx.util import Length
+
+
+def _replace_cell_properties(
+    tc: CT_TableCell, tcPr_snapshot: CT_TableCellProperties | None
+) -> None:
+    """Replace `tc` direct properties with a detached snapshot when one exists."""
+    if tcPr_snapshot is None:
+        return
+    existing_tcPr = tc.tcPr
+    if existing_tcPr is not None:
+        tc.remove(existing_tcPr)
+    tc.append(tcPr_snapshot)
+
+
+def _apply_merge_topology(tc_range: TcRange) -> None:
+    """Write canonical rectangular merge attributes for `tc_range`."""
+    row_count, col_count = tc_range.dimensions
+    for tc in tc_range.iter_tcs():
+        tc.rowSpan = 1
+        tc.gridSpan = 1
+        tc.hMerge = False
+        tc.vMerge = False
+    for tc in tc_range.iter_top_row_tcs():
+        tc.rowSpan = row_count
+    for tc in tc_range.iter_left_col_tcs():
+        tc.gridSpan = col_count
+    for tc in tc_range.iter_except_left_col_tcs():
+        tc.hMerge = True
+    for tc in tc_range.iter_except_top_row_tcs():
+        tc.vMerge = True
 
 
 class Table(object):
@@ -156,14 +193,23 @@ class Table(object):
     def horz_banding(self, value: bool):
         self._tbl.bandRow = value
 
-    def insert_column(self, after: int, *, width: Length | None = None) -> _Column:
+    def insert_column(
+        self,
+        after: int,
+        *,
+        width: Length | None = None,
+        copy_format_from: int | None = None,
+    ) -> _Column:
         """Insert a new empty column immediately after 0-based column `after`; return it.
 
         paper-pptx addition. `after=-1` inserts before the first column.
-        `width` (EMU int) defaults to the width of the neighboring column at `after` (the
-        first column when `after=-1`). A new minimal empty cell is inserted at the same grid
-        position in every row - the grid stays consistent by construction - and the graphic
-        frame's width is recalculated.
+        `copy_format_from` is the zero-based index of a column in the table before insertion.
+        When provided, each new cell receives a deep copy of that row's template-cell `a:tcPr`
+        (direct formatting only); text and merge state are never copied. `width` (EMU int) wins
+        when provided, otherwise the template column supplies the width. With no template, width
+        defaults to the neighboring column at `after` (the first column when `after=-1`). A new
+        minimal empty cell is inserted at the same grid position in every row - the grid stays
+        consistent by construction - and the graphic frame's width is recalculated.
 
         Merged-cell guard is cell-wise: refuses (|UnsupportedStructureError|, tree
         untouched) only when the insertion boundary would split a horizontal merge; vertical
@@ -172,6 +218,8 @@ class Table(object):
         self._validate_structure()
         col_count = len(self._tbl.tblGrid.gridCol_lst)
         self._validate_grid_index(after, "after", col_count, lower=-1)
+        if copy_format_from is not None:
+            self._validate_grid_index(copy_format_from, "copy_format_from", col_count)
         if width is not None and (
             isinstance(width, bool) or not isinstance(width, int) or width <= 0
         ):
@@ -189,16 +237,32 @@ class Table(object):
                     conflicts,
                 )
 
-        neighbor_idx = 0 if after == -1 else after
+        template_tcPrs = (
+            tuple(
+                deepcopy(tr.tc_lst[copy_format_from].tcPr)
+                if tr.tc_lst[copy_format_from].tcPr is not None
+                else None
+                for tr in self._tbl.tr_lst
+            )
+            if copy_format_from is not None
+            else None
+        )
+        default_width_idx = (
+            copy_format_from
+            if copy_format_from is not None
+            else (0 if after == -1 else after)
+        )
         new_width = Emu(width) if width is not None else Emu(
-            self._tbl.tblGrid.gridCol_lst[neighbor_idx].w
+            self._tbl.tblGrid.gridCol_lst[default_width_idx].w
         )
         from pptx._transaction import PackageTransaction
 
         with PackageTransaction(self.part.package, self):
             gridCol = self._tbl.tblGrid.insert_gridCol_at(after + 1, new_width)
-            for tr in self._tbl.tr_lst:
-                tr.insert_tc_at(after + 1)
+            for row_idx, tr in enumerate(self._tbl.tr_lst):
+                tc = tr.insert_tc_at(after + 1)
+                if template_tcPrs is not None:
+                    _replace_cell_properties(tc, template_tcPrs[row_idx])
             self.notify_width_changed()
             column = _Column(gridCol, self.columns)
         return column
@@ -218,8 +282,6 @@ class Table(object):
         untouched) only when the insertion boundary would split a vertical merge; a merged
         header row never blocks body-row insertion.
         """
-        from copy import deepcopy
-
         self._validate_structure()
         row_count = len(self._tbl.tr_lst)
         self._validate_grid_index(after, "after", row_count, lower=-1)
@@ -241,19 +303,22 @@ class Table(object):
             0 if after == -1 else after
         )
         template_tr = self._tbl.tr_lst[template_idx]
+        template_tcPrs = (
+            tuple(
+                deepcopy(tc.tcPr) if tc.tcPr is not None else None
+                for tc in template_tr.tc_lst
+            )
+            if copy_format_from is not None
+            else None
+        )
         from pptx._transaction import PackageTransaction
 
         with PackageTransaction(self.part.package, self):
             tr = self._tbl.insert_tr_at(after + 1, Emu(template_tr.h))
             for col_idx in range(len(self._tbl.tblGrid.gridCol_lst)):
                 tc = tr.add_tc()
-                if copy_format_from is not None:
-                    template_tcPr = template_tr.tc_lst[col_idx].tcPr
-                    if template_tcPr is not None:
-                        existing_tcPr = tc.tcPr
-                        if existing_tcPr is not None:
-                            tc.remove(existing_tcPr)
-                        tc.append(deepcopy(template_tcPr))
+                if template_tcPrs is not None:
+                    _replace_cell_properties(tc, template_tcPrs[col_idx])
             self.notify_height_changed()
             row = _Row(tr, self.rows)
         return row
@@ -437,6 +502,114 @@ class _MergeRegion(object):
             self.top, self.left, self.top, self.bottom, self.left, self.right,
         )
 
+    def intersects(self, other: _MergeRegion) -> bool:
+        """True when this region and `other` share at least one grid cell."""
+        return not (
+            self.bottom < other.top
+            or other.bottom < self.top
+            or self.right < other.left
+            or other.right < self.left
+        )
+
+
+def _validate_merge_topology(tbl: CT_Table, region: _MergeRegion) -> None:
+    """Refuse unless `region` has the exact continuation topology for its spans."""
+    from pptx.errors import UnsupportedStructureError
+
+    row_count = len(tbl.tr_lst)
+    col_count = len(tbl.tblGrid.gridCol_lst)
+    if (
+        region.top < 0
+        or region.left < 0
+        or region.rowSpan < 1
+        or region.gridSpan < 1
+        or region.bottom >= row_count
+        or region.right >= col_count
+    ):
+        raise UnsupportedStructureError(
+            "merge origin declares an out-of-bounds region %s; repair the table before "
+            "extending the merge" % region
+        )
+
+    for row_idx in range(region.top, region.bottom + 1):
+        tr = tbl.tr_lst[row_idx]
+        if len(tr.tc_lst) <= region.right:
+            raise UnsupportedStructureError(
+                "merge region %s crosses ragged row %d; repair the table before extending "
+                "the merge" % (region, row_idx)
+            )
+        for col_idx in range(region.left, region.right + 1):
+            tc = tr.tc_lst[col_idx]
+            expected_row_span = region.rowSpan if row_idx == region.top else 1
+            expected_grid_span = region.gridSpan if col_idx == region.left else 1
+            expected_h_merge = col_idx != region.left
+            expected_v_merge = row_idx != region.top
+            if (
+                tc.rowSpan != expected_row_span
+                or tc.gridSpan != expected_grid_span
+                or tc.hMerge is not expected_h_merge
+                or tc.vMerge is not expected_v_merge
+            ):
+                raise UnsupportedStructureError(
+                    "merge region %s has non-canonical continuation state at cell (%d, %d); "
+                    "repair or split the merge before extending it"
+                    % (region, row_idx, col_idx)
+                )
+
+
+def _validate_requested_merge_extension(
+    tbl: CT_Table,
+    origin_tc: CT_TableCell,
+    current_region: _MergeRegion,
+    requested_region: _MergeRegion,
+) -> None:
+    """Refuse unless newly absorbed cells are rectangular, live-grid, and unmerged."""
+    from pptx.errors import UnsupportedStructureError
+
+    row_count = len(tbl.tr_lst)
+    col_count = len(tbl.tblGrid.gridCol_lst)
+    if requested_region.bottom >= row_count or requested_region.right >= col_count:
+        raise UnsupportedStructureError(
+            "requested merge region %s is outside the table grid" % requested_region
+        )
+    for row_idx in range(requested_region.top, requested_region.bottom + 1):
+        if len(tbl.tr_lst[row_idx].tc_lst) <= requested_region.right:
+            raise UnsupportedStructureError(
+                "requested merge region %s crosses ragged row %d; repair the table before "
+                "extending the merge" % (requested_region, row_idx)
+            )
+
+    conflicts = []
+    for row_idx, tr in enumerate(tbl.tr_lst):
+        for col_idx, tc in enumerate(tr.tc_lst):
+            if tc is origin_tc or not tc.is_merge_origin:
+                continue
+            region = _MergeRegion(row_idx, col_idx, tc.rowSpan, tc.gridSpan)
+            if region.intersects(requested_region):
+                conflicts.append(region)
+    if conflicts:
+        raise UnsupportedStructureError(
+            "extending merge %s to %s would overlap merged cell%s %s"
+            % (
+                current_region,
+                requested_region,
+                "" if len(conflicts) == 1 else "s",
+                ", ".join(str(region) for region in conflicts),
+            )
+        )
+
+    for row_idx in range(requested_region.top, requested_region.bottom + 1):
+        for col_idx in range(requested_region.left, requested_region.right + 1):
+            if row_idx <= current_region.bottom and col_idx <= current_region.right:
+                continue
+            tc = tbl.tr_lst[row_idx].tc_lst[col_idx]
+            if tc.rowSpan != 1 or tc.gridSpan != 1 or tc.hMerge or tc.vMerge:
+                raise UnsupportedStructureError(
+                    "extending merge %s to %s would absorb cell (%d, %d) carrying merge "
+                    "state; split or repair that merge first"
+                    % (current_region, requested_region, row_idx, col_idx)
+                )
+
 
 class _Cell(Subshape):
     """Table cell"""
@@ -548,17 +721,77 @@ class _Cell(Subshape):
             raise ValueError("range contains one or more merged cells")
 
         tc_range.move_content_to_origin()
+        _apply_merge_topology(tc_range)
 
-        row_count, col_count = tc_range.dimensions
+    def extend_merge(self, other_cell: _Cell) -> None:
+        """Extend this merge-origin cell through `other_cell` atomically.
 
-        for tc in tc_range.iter_top_row_tcs():
-            tc.rowSpan = row_count
-        for tc in tc_range.iter_left_col_tcs():
-            tc.gridSpan = col_count
-        for tc in tc_range.iter_except_left_col_tcs():
-            tc.hMerge = True
-        for tc in tc_range.iter_except_top_row_tcs():
-            tc.vMerge = True
+        paper-pptx addition. `other_cell` is the requested new lower-right corner. The existing
+        rectangular merge may grow rightward, downward, or in both directions. Only paragraphs
+        from newly absorbed cells move to this origin, in row-major order; existing merged content
+        is not moved again.
+
+        The existing merge must have canonical continuation topology and every newly absorbed cell
+        must be unmerged. Malformed or conflicting merge structure raises
+        |UnsupportedStructureError| without mutation. A stale origin or target raises
+        |TargetNotFoundError|. Passing a non-cell, a cell from another table, a non-origin receiver,
+        or a corner that would shrink or move the merge raises |ValueError|.
+        """
+        if not isinstance(other_cell, _Cell):
+            raise ValueError("other_cell must be a table cell")
+
+        from pptx._ownership import require_element_attached
+
+        require_element_attached(self._tc, self.part, argument="merge origin")
+        require_element_attached(other_cell._tc, other_cell.part, argument="merge target")
+
+        tbl = self._tc.tbl
+        if tbl is not other_cell._tc.tbl:
+            raise ValueError("other_cell from different table")
+        if not self.is_merge_origin:
+            raise ValueError(
+                "cell is not a merge-origin cell; use merge() to create a new merge"
+            )
+
+        current_region = _MergeRegion(
+            self._tc.row_idx,
+            self._tc.col_idx,
+            self._tc.rowSpan,
+            self._tc.gridSpan,
+        )
+        _validate_merge_topology(tbl, current_region)
+
+        requested_region = _MergeRegion(
+            current_region.top,
+            current_region.left,
+            other_cell._tc.row_idx - current_region.top + 1,
+            other_cell._tc.col_idx - current_region.left + 1,
+        )
+        if (
+            requested_region.bottom < current_region.bottom
+            or requested_region.right < current_region.right
+        ):
+            raise ValueError(
+                "other_cell must be at or beyond the current lower-right merge corner; "
+                "merge shrinking and upward/leftward extension are not supported"
+            )
+        if (
+            requested_region.bottom == current_region.bottom
+            and requested_region.right == current_region.right
+        ):
+            return
+
+        _validate_requested_merge_extension(tbl, self._tc, current_region, requested_region)
+
+        from pptx._transaction import PackageTransaction
+
+        requested_range = TcRange(self._tc, other_cell._tc)
+        with PackageTransaction(self.part.package, self, other_cell):
+            for tc in requested_range.iter_tcs():
+                if tc.row_idx <= current_region.bottom and tc.col_idx <= current_region.right:
+                    continue
+                self._tc.append_ps_from(tc)
+            _apply_merge_topology(requested_range)
 
     @property
     def span_height(self) -> int:

--- a/tests/paper/test_table_ops.py
+++ b/tests/paper/test_table_ops.py
@@ -10,9 +10,16 @@ from __future__ import annotations
 import io
 
 import pytest
+from lxml import etree
 
 from pptx import Presentation
-from pptx.errors import PaperRefusal, UnsupportedStructureError
+from pptx.dml.color import RGBColor
+from pptx.errors import (
+    PaperRefusal,
+    TargetNotFoundError,
+    UnsupportedStructureError,
+)
+from pptx.oxml.xmlchemy import OxmlElement
 from pptx.util import Emu, Inches
 
 from . import corpus
@@ -21,9 +28,11 @@ from .contract import (
     assert_refusal_atomic,
     save_reopen,
     save_to_bytes,
+    zip_member_map,
 )
 from .fragval import assert_tbl_fragment_valid
 from .lo import lo_load_smoke
+from .relint import dangling_relationship_targets, missing_relationship_references
 
 MERGED = "self_generated/merged_tables.pptx"
 LO_MERGED = "libreoffice_export/lo_merged_tables.pptx"
@@ -52,6 +61,19 @@ def assert_grid_consistent(table):
 
 def _cell_texts(table, row_idx):
     return [table.cell(row_idx, c).text_frame.text for c in range(len(table.columns))]
+
+
+def _assert_canonical_merge(table, top, left, bottom, right):
+    """Assert exact python-pptx rectangular merge topology."""
+    row_span = bottom - top + 1
+    grid_span = right - left + 1
+    for row_idx in range(top, bottom + 1):
+        for col_idx in range(left, right + 1):
+            tc = table.cell(row_idx, col_idx)._tc
+            assert tc.rowSpan == (row_span if row_idx == top else 1)
+            assert tc.gridSpan == (grid_span if col_idx == left else 1)
+            assert tc.hMerge is (col_idx != left)
+            assert tc.vMerge is (row_idx != top)
 
 
 # ------------------------------------------------------------------------------ insert_row
@@ -242,6 +264,102 @@ def test_insert_column_default_width_copies_neighbor_and_updates_frame():
     assert shape.width == Emu(sum(c.width for c in shape.table.columns))
 
 
+@pytest.mark.parametrize(("after", "copy_format_from"), [(-1, 2), (2, 0)])
+def test_insert_column_copies_preinsertion_direct_format_by_row(after, copy_format_from):
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    template_width = Emu(654321)
+    table.columns[copy_format_from].width = template_width
+
+    for row_idx in range(3):
+        cell = table.cell(row_idx, copy_format_from)
+        cell.margin_left = Emu(100000 + row_idx)
+        cell.fill.solid()
+        cell.fill.fore_color.rgb = RGBColor(0x10 + row_idx, 0x20, 0x30)
+    template_tcPr_xml = [
+        etree.tostring(table.cell(row_idx, copy_format_from)._tc.tcPr)
+        for row_idx in range(3)
+    ]
+
+    table.insert_column(after, copy_format_from=copy_format_from)
+    reopened_table = _gauntlet_table(save_reopen(prs))
+    inserted_idx = after + 1
+    assert reopened_table.columns[inserted_idx].width == template_width
+    for row_idx in range(3):
+        inserted_cell = reopened_table.cell(row_idx, inserted_idx)
+        assert etree.tostring(inserted_cell._tc.tcPr) == template_tcPr_xml[row_idx]
+        assert inserted_cell.text == ""
+        assert inserted_cell._tc.rowSpan == 1
+        assert inserted_cell._tc.gridSpan == 1
+        assert not inserted_cell._tc.hMerge
+        assert not inserted_cell._tc.vMerge
+
+
+def test_insert_column_preserves_minimal_properties_when_template_has_no_tcPr():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    template_tc = table.cell(1, 1)._tc
+    assert template_tc.tcPr is not None
+    template_tc.remove(template_tc.tcPr)
+
+    table.insert_column(2, copy_format_from=1)
+    reopened_table = _gauntlet_table(save_reopen(prs))
+    inserted_tcPr = reopened_table.cell(1, 3)._tc.tcPr
+    assert inserted_tcPr is not None
+    assert len(inserted_tcPr) == 0
+    assert dict(inserted_tcPr.attrib) == {}
+
+
+def test_insert_column_explicit_width_wins_over_template_width():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    table.columns[1].width = Emu(456789)
+
+    table.insert_column(2, width=Emu(987654), copy_format_from=1)
+
+    reopened_table = _gauntlet_table(save_reopen(prs))
+    assert reopened_table.columns[3].width == Emu(987654)
+
+
+def test_insert_column_copies_opaque_tcPr_extension_verbatim():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    template_tcPr = table.cell(1, 1)._tc.get_or_add_tcPr()
+    extLst = OxmlElement("a:extLst")
+    ext = OxmlElement("a:ext")
+    ext.set("uri", "urn:paper:test:opaque-cell-properties")
+    opaque = etree.SubElement(ext, "{urn:paper:test}opaque")
+    opaque.set("producer-token", "keep-exactly")
+    extLst.append(ext)
+    template_tcPr.append(extLst)
+    expected_extension = etree.tostring(extLst)
+
+    table.insert_column(2, copy_format_from=1)
+
+    reopened_table = _gauntlet_table(save_reopen(prs))
+    copied_extLst = reopened_table.cell(1, 3)._tc.tcPr.find(
+        "{http://schemas.openxmlformats.org/drawingml/2006/main}extLst"
+    )
+    assert copied_extLst is not None
+    assert etree.tostring(copied_extLst) == expected_extension
+
+
+def test_insert_column_template_never_copies_text_or_merge_state():
+    prs = _open(MERGED)
+    table = _merged_table(prs)
+
+    table.insert_column(3, copy_format_from=0)
+
+    reopened_table = _merged_table(save_reopen(prs))
+    for row_idx in range(len(reopened_table.rows)):
+        cell = reopened_table.cell(row_idx, 4)
+        assert cell.text == ""
+        assert cell._tc.rowSpan == 1
+        assert cell._tc.gridSpan == 1
+        assert not cell._tc.hMerge
+        assert not cell._tc.vMerge
+
+
 @pytest.mark.parametrize("after", [0, 1, 2])
 def test_insert_column_boundary_inside_horizontal_merge_refuses_atomically(after):
     """Every interior boundary of the header merge (cols 0..3) must refuse - including
@@ -333,6 +451,7 @@ def test_bad_indices_raise_valueerror_before_any_change(bad):
     ]
     if bad is not None:  # -- None is copy_format_from's legitimate default
         operations.append(lambda: table.insert_row(0, copy_format_from=bad))
+        operations.append(lambda: table.insert_column(3, copy_format_from=bad))
     for operation in operations:
         with pytest.raises(ValueError):
             operation()
@@ -386,6 +505,278 @@ def test_operations_on_libreoffice_authored_merged_table():
     assert reopened_table.cell(0, 0)._tc.gridSpan == 4
 
 
+# --------------------------------------------------------------------------- extend_merge
+
+
+@pytest.mark.parametrize(
+    ("initial_corner", "requested_corner"),
+    [((1, 0), (1, 1)), ((0, 1), (1, 1)), ((1, 1), (2, 2))],
+)
+def test_extend_merge_grows_right_down_or_both_and_survives_reopen(
+    initial_corner, requested_corner
+):
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(*initial_corner))
+
+    origin.extend_merge(table.cell(*requested_corner))
+
+    reopened_table = _gauntlet_table(save_reopen(prs))
+    _assert_canonical_merge(reopened_table, 0, 0, *requested_corner)
+
+
+def test_extend_merge_moves_only_new_cells_in_row_major_order_and_preserves_origin():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    frame = prs.slides[2].shapes.shape_by_name("gauntlet_table")
+    frame_geometry = (frame.left, frame.top, frame.width, frame.height)
+    table_style_xml = etree.tostring(table._tbl.tblPr)
+    origin = table.cell(0, 0)
+    origin.fill.solid()
+    origin.fill.fore_color.rgb = RGBColor(0x12, 0x34, 0x56)
+    origin.merge(table.cell(1, 1))
+    origin_tc = origin._tc
+    origin_tcPr_xml = etree.tostring(origin_tc.tcPr)
+    expected_text = "\n".join(
+        ["r0c0", "r0c1", "r1c0", "r1c1", "r0c2", "r1c2", "r2c0", "r2c1", "r2c2"]
+    )
+    before = save_to_bytes(prs)
+
+    target = table.cell(2, 2)
+    origin.extend_merge(target)
+
+    assert origin._tc is origin_tc
+    assert etree.tostring(origin._tc.tcPr) == origin_tcPr_xml
+    assert target._tc.getparent() is not None
+    assert (frame.left, frame.top, frame.width, frame.height) == frame_geometry
+    after = save_to_bytes(prs)
+    assert_changed_parts(before, after, expect_changed=["ppt/slides/slide3.xml"])
+    zip_map = zip_member_map(after)
+    assert dangling_relationship_targets(zip_map) == []
+    assert missing_relationship_references(zip_map) == []
+
+    reopened = Presentation(io.BytesIO(after))
+    reopened_frame = reopened.slides[2].shapes.shape_by_name("gauntlet_table")
+    reopened_table = reopened_frame.table
+    assert reopened_table.cell(0, 0).text == expected_text
+    assert etree.tostring(reopened_table._tbl.tblPr) == table_style_xml
+    reopened_geometry = (
+        reopened_frame.left,
+        reopened_frame.top,
+        reopened_frame.width,
+        reopened_frame.height,
+    )
+    assert reopened_geometry == frame_geometry
+    _assert_canonical_merge(reopened_table, 0, 0, 2, 2)
+
+
+def test_extend_merge_preserves_an_unrelated_merge():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(0, 1))
+    unrelated = table.cell(1, 2)
+    unrelated.merge(table.cell(2, 2))
+
+    origin.extend_merge(table.cell(1, 1))
+
+    reopened_table = _gauntlet_table(save_reopen(prs))
+    _assert_canonical_merge(reopened_table, 0, 0, 1, 1)
+    _assert_canonical_merge(reopened_table, 1, 2, 2, 2)
+
+
+def test_extend_merge_clears_explicit_default_attributes_from_canonical_topology():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(0, 1))
+    for col_idx in (0, 1):
+        tc = table.cell(1, col_idx)._tc
+        tc.set("rowSpan", "1")
+        tc.set("gridSpan", "1")
+        tc.set("hMerge", "false")
+        tc.set("vMerge", "false")
+
+    origin.extend_merge(table.cell(1, 1))
+
+    reopened_table = _gauntlet_table(save_reopen(prs))
+    for row_idx in range(2):
+        for col_idx in range(2):
+            tc = reopened_table.cell(row_idx, col_idx)._tc
+            if row_idx != 0:
+                assert "rowSpan" not in tc.attrib
+            if col_idx != 0:
+                assert "gridSpan" not in tc.attrib
+            if col_idx == 0:
+                assert "hMerge" not in tc.attrib
+            if row_idx == 0:
+                assert "vMerge" not in tc.attrib
+    _assert_canonical_merge(reopened_table, 0, 0, 1, 1)
+
+
+def test_extend_merge_at_current_corner_is_an_exact_noop():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(1, 1))
+    before = save_to_bytes(prs)
+
+    origin.extend_merge(table.cell(1, 1))
+
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+def test_extend_merge_rejects_wrong_type_nonorigin_and_other_table_atomically():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(0, 1))
+
+    for operation in (
+        lambda: origin.extend_merge("not a cell"),
+        lambda: table.cell(2, 0).extend_merge(table.cell(2, 1)),
+    ):
+        before = save_to_bytes(prs)
+        with pytest.raises(ValueError):
+            operation()
+        assert_changed_parts(before, save_to_bytes(prs))
+
+    other_shape = prs.slides[2].shapes.add_table(
+        2, 2, Inches(0), Inches(0), Inches(1), Inches(1)
+    )
+    before = save_to_bytes(prs)
+    with pytest.raises(ValueError, match="different table"):
+        origin.extend_merge(other_shape.table.cell(1, 1))
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+@pytest.mark.parametrize("requested_corner", [(0, 2), (2, 0), (0, 0)])
+def test_extend_merge_rejects_shrink_or_up_left_request_atomically(requested_corner):
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(1, 1))
+    before = save_to_bytes(prs)
+
+    with pytest.raises(ValueError, match="current lower-right"):
+        origin.extend_merge(table.cell(*requested_corner))
+
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+def test_extend_merge_rejects_stale_origin_before_stale_target():
+    prs = _open(GAUNTLET)
+    slide = prs.slides[2]
+    shape = slide.shapes.shape_by_name("gauntlet_table")
+    table = shape.table
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(0, 1))
+    target = table.cell(1, 1)
+    slide.shapes.delete(shape)
+
+    with pytest.raises(TargetNotFoundError, match="merge origin is stale"):
+        origin.extend_merge(target)
+
+
+def test_extend_merge_rejects_a_stale_target_before_table_ownership():
+    prs = _open(GAUNTLET)
+    slide = prs.slides[2]
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(0, 1))
+    target_shape = slide.shapes.add_table(2, 2, Inches(0), Inches(0), Inches(1), Inches(1))
+    target = target_shape.table.cell(1, 1)
+    slide.shapes.delete(target_shape)
+
+    with pytest.raises(TargetNotFoundError, match="merge target is stale"):
+        origin.extend_merge(target)
+
+
+def test_extend_merge_rejects_an_intersecting_merge_but_not_an_unrelated_one():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(0, 1))
+    conflict = table.cell(1, 1)
+    conflict.merge(table.cell(1, 2))
+
+    raised = assert_refusal_atomic(
+        prs,
+        lambda p: _gauntlet_table(p).cell(0, 0).extend_merge(
+            _gauntlet_table(p).cell(1, 2)
+        ),
+        UnsupportedStructureError,
+    )
+    assert "spanning rows 1..1, columns 1..2" in str(raised)
+
+
+@pytest.mark.parametrize(
+    ("corruption", "expected"),
+    [
+        (lambda table: setattr(table.cell(0, 1)._tc, "hMerge", False), "non-canonical"),
+        (lambda table: setattr(table.cell(1, 0)._tc, "hMerge", True), "non-canonical"),
+        (lambda table: setattr(table.cell(0, 1)._tc, "rowSpan", 3), "non-canonical"),
+        (lambda table: setattr(table.cell(0, 0)._tc, "rowSpan", 99), "out-of-bounds"),
+    ],
+)
+def test_extend_merge_refuses_malformed_current_topology_atomically(corruption, expected):
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    table.cell(0, 0).merge(table.cell(1, 1))
+    corruption(table)
+    before = save_to_bytes(prs)
+
+    with pytest.raises(UnsupportedStructureError, match=expected):
+        table.cell(0, 0).extend_merge(table.cell(2, 2))
+
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+def test_extend_merge_refuses_orphan_merge_state_in_new_area_atomically():
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(0, 1))
+    table.cell(1, 1)._tc.hMerge = True
+    before = save_to_bytes(prs)
+
+    with pytest.raises(UnsupportedStructureError, match=r"cell \(1, 1\) carrying merge state"):
+        origin.extend_merge(table.cell(1, 1))
+
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+@pytest.mark.parametrize("failure_stage", ["after-content", "after-topology"])
+def test_extend_merge_rolls_back_late_failure_and_retained_proxies(monkeypatch, failure_stage):
+    import pptx.table as table_module
+
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(1, 1))
+    target = table.cell(2, 2)
+    origin_tc = origin._tc
+    target_tc = target._tc
+    before = save_to_bytes(prs)
+    apply_topology = table_module._apply_merge_topology
+
+    def fail_topology(tc_range):
+        if failure_stage == "after-topology":
+            apply_topology(tc_range)
+        raise RuntimeError("forced late merge-extension failure")
+
+    monkeypatch.setattr(table_module, "_apply_merge_topology", fail_topology)
+    with pytest.raises(RuntimeError, match="forced late merge-extension failure"):
+        origin.extend_merge(target)
+
+    assert_changed_parts(before, save_to_bytes(prs))
+    assert origin._tc is origin_tc
+    assert target._tc is target_tc
+    assert origin.text == "r0c0\nr0c1\nr1c0\nr1c1"
+    _assert_canonical_merge(table, 0, 0, 1, 1)
+
+
 # ------------------------------------------------------- anchored writes reach table cells
 
 
@@ -433,6 +824,10 @@ def test_column_surgery_refuses_a_ragged_table_before_mutation():
         (lambda table: table.insert_row(2), "notify_height_changed"),
         (lambda table: table.delete_row(1), "notify_height_changed"),
         (lambda table: table.insert_column(2), "notify_width_changed"),
+        (
+            lambda table: table.insert_column(2, copy_format_from=1),
+            "notify_width_changed",
+        ),
         (lambda table: table.delete_column(1), "notify_width_changed"),
     ],
 )
@@ -475,11 +870,12 @@ def test_table_surgery_refuses_a_table_on_a_deleted_shape():
 
 @pytest.mark.lo_smoke
 def test_surgered_table_loads_in_libreoffice(tmp_path):
-    prs = _open(MERGED)
-    table = _merged_table(prs)
-    table.insert_row(4, copy_format_from=1)
-    table.insert_column(3)
-    table.delete_row(1)
+    prs = _open(GAUNTLET)
+    table = _gauntlet_table(prs)
+    table.insert_column(2, copy_format_from=1)
+    origin = table.cell(0, 0)
+    origin.merge(table.cell(1, 1))
+    origin.extend_merge(table.cell(2, 2))
     assert_grid_consistent(table)
     out = tmp_path / "surgered.pptx"
     prs.save(str(out))


### PR DESCRIPTION
## Summary

- add Table.insert_column(copy_format_from=...) with pre-insertion snapshots and explicit width precedence
- copy complete direct cell formatting without copying text, merge state, or computed table-style appearance
- add atomic _Cell.extend_merge() for rightward and downward rectangular growth
- validate malformed topology, stale proxies, conflicts, and rollback behavior before exposing mutations

## Testing

- 232 table and related tests passed
- 24 table Behave scenarios and 85 steps passed
- save/reopen, changed-part-budget, failure-injection, LibreOffice, Sphinx, Ruff, and diff checks passed

## Stack

1. #36 OPC package preservation
2. This PR: table editing APIs
3. #38 Documentation and compatibility integration

Base this PR on #36 so GitHub shows only the table phase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates table XML (column insertion and merge topology) with new public APIs. Risk is moderated by pre-mutation validation, atomic PackageTransaction rollback, and extensive save/reopen and refusal tests.
> 
> **Overview**
> Adds composable table-expansion APIs so callers can insert formatted columns and grow existing rectangular merges without rebuilding the table.
> 
> `Table.insert_column` now accepts `copy_format_from` (pre-insertion column index). New cells get a deep copy of that row’s direct `a:tcPr` only—fills, borders, margins, extensions—not text, merge state, or style/theme appearance. Explicit `width` still wins; otherwise the template column’s width is used.
> 
> `_Cell.extend_merge` grows a live merge-origin right, down, or both in one transactional step. Only newly absorbed content is moved; origin formatting and frame geometry stay put. It refuses shrink/up-left, stale proxies, non-canonical topology, and intersecting merges, and is a no-op at the current corner. `merge()` now shares the same canonical topology writer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ec500504af9e983fe50be87de97ea2681655b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->