### PR TITLE
docs: document editing and compatibility contracts

### DIFF
--- a/docs/api/edit.rst
+++ b/docs/api/edit.rst
@@ -9,6 +9,47 @@ anchor carries a hash of the block's text, an edit aimed at content that has sin
 |StaleAnchorError| rather than being silently misapplied. :func:`refind` is the explicit recovery
 path.
 
+Matching and boundaries
+-----------------------
+
+Both replacement functions use literal, case-sensitive, non-overlapping matches, processed from
+left to right. ``find`` must be a non-empty string; ``replace`` is a string and may be empty. Tabs
+are valid text. Line breaks (CR, LF, and vertical tab), other XML control characters, and text that
+cannot be encoded for XML are refused before mutation.
+
+A match may span adjacent text runs in one paragraph. It never crosses a paragraph boundary or an
+intervening non-run element, including ``a:br`` line breaks and ``a:fld`` fields. This remains true
+when the concatenated visible text appears to contain ``find`` across that boundary.
+
+Formatting preservation
+-----------------------
+
+Fragments before and after a match keep the run properties of their source runs. Replacement text
+uses the run properties of the run where the match begins. Runs untouched by a match remain
+byte-identical. Any run left with no text after replacement is removed, so formatting that existed
+only on that run is intentionally lost.
+
+The caller therefore chooses the semantic span and which neighboring formatting remains. Suppose
+``"Draft total"`` has ``"Draft "`` in regular text and ``"total"`` in bold. Replacing the whole
+span with ``"Final total"`` gives the replacement the regular formatting at the start of the
+match. Replacing only ``"Draft"`` with ``"Final"`` preserves the separate bold ``"total"`` run.
+
+Results and refusal
+-------------------
+
+:func:`replace_text` traverses slide shapes, grouped shapes, and table cells, and optionally
+existing notes slides. No match is a successful :class:`ReplaceResult` with zero replacements.
+Unsupported markup-compatibility regions are blind to complete traversal, so their presence
+refuses the deck-wide operation before any write.
+
+:func:`replace_text_at` limits replacement to one anchored paragraph. A changed content hash raises
+|StaleAnchorError|; a missing match (including one found only across a prohibited boundary) raises
+|TargetNotFoundError|. An anchor addressing an unsupported blind region also refuses without
+mutation; unrelated blind regions elsewhere do not block the anchored edit. On success both
+functions return a :class:`ReplaceResult` containing the count and post-edit anchors for the blocks
+that changed. Use :func:`refind` explicitly to recover the unique current location of stale
+anchored content; it refuses when no block or more than one block has the requested content hash.
+
 .. currentmodule:: pptx.edit
 
 .. autofunction:: replace_text

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -155,6 +155,38 @@ guess. On tables, :meth:`~pptx.table.Table.insert_row` /
 :meth:`~pptx.table.Table.delete_column` keep the grid definition consistent and guard merged
 regions cell-wise. A merged header row does not block body-row operations.
 
+Choose lookup by ownership. ``table_by_name()`` returns table content directly. If the edit also
+needs width, height, position, or other geometry, retain the owning graphic frame with
+``shape_by_name()``, check :attr:`~pptx.shapes.graphfrm.GraphicFrame.has_table`, and then use its
+:attr:`~pptx.shapes.graphfrm.GraphicFrame.table`. Geometry belongs to the frame, not to |Table|::
+
+    from pptx import Presentation
+    from pptx.package import patch_save
+
+    prs = Presentation("input.pptx")
+    slide = prs.slides[0]
+    frame = slide.shapes.shape_by_name("Plan Matrix")
+    if not frame.has_table:
+        raise ValueError("Plan Matrix is not a table")
+    table = frame.table
+
+    inserted_column_idx = 2
+    table.insert_column(1, copy_format_from=1)
+    table.cell(0, inserted_column_idx).text = "Current"
+    delta = patch_save("input.pptx", prs, "output.pptx")
+
+The returned |PackageDiff| is the residual package delta after unchanged original bytes have been
+restored. Column insertion recalculates the owning frame's width; other shape geometry remains on
+``frame``.
+
+``copy_format_from`` names a pre-insertion column. It copies each source cell's direct formatting
+into an empty, unmerged cell in the corresponding row; it does not materialize appearance inherited
+from a table style or theme. An explicit ``width`` wins over the template width. Use
+:meth:`~pptx.table._Cell.merge` to create a merge, :meth:`~pptx.table._Cell.extend_merge` to grow an
+existing rectangular merge rightward, downward, or both, and :meth:`~pptx.table._Cell.split` to
+remove one. Merge extension validates the entire requested rectangle before mutation, so malformed
+topology, conflicts, and stale cells refuse without a partial edit.
+
 **Text, notes, images, and charts** (:ref:`text_api`, :ref:`shape_api`, :ref:`chart-api`). Real
 bullets and numbering via :attr:`~pptx.text.text._Paragraph.bullet` (a |BulletFormat|); autofit
 you can read and freeze with :meth:`~pptx.text.text.TextFrame.normalize_autofit`; speaker-notes
@@ -166,10 +198,16 @@ handles workbook-less charts, including those in the LibreOffice fixture corpus.
 
 **Package comparison and narrow saves** (:ref:`package_api`).
 :func:`~pptx.package.diff_package` reports what changed between two files, part by part, using
-semantic XML comparison. Indentation is noise; a trailing space inside a text run is content.
+semantic XML comparison. Indentation is noise; a trailing space inside a text run is content. Valid
+relationship registries compare complete bindings rather than child order, and valid content-type
+registries compare the effective assignments for package members. Unknown or ambiguous registry
+structures fall back conservatively; real relationship, content-type, member, and ordinary XML
+ordering changes remain visible.
 :func:`~pptx.package.patch_save` writes the edit and restores original bytes for every part that
 did not semantically change. A one-line edit to a sixty-slide deck therefore diffs as one part,
-not sixty.
+not sixty. Table and shape APIs edit an in-memory |Presentation|; use ``save()`` for normal
+serialization or ``patch_save(original_path, prs, out_path)`` when unchanged package members should
+retain their original bytes.
 
 
 Compose across decks

--- a/src/pptx/edit.py
+++ b/src/pptx/edit.py
@@ -63,11 +63,22 @@ class ReplaceResult:
 def replace_text(
     prs: "Presentation", find: str, replace: str, *, include_notes: bool = False
 ) -> ReplaceResult:
-    """Replace every occurrence of `find` with `replace` across `prs`, preserving formatting.
+    """Replace literal `find` with `replace` across `prs`; return a |ReplaceResult|.
 
-    Deck-wide and visibility-complete: slide shapes, grouped shapes, and table cells (and
-    existing notes slides when `include_notes=True`). Zero matches is a normal
-    `ReplaceResult(0)`, not a refusal. Validation completes before the first write.
+    Matching is case-sensitive, left-to-right, and non-overlapping. A match may span consecutive
+    text runs in one paragraph, but never a paragraph boundary or an intervening non-run element
+    such as a line break or field. `find` must be a non-empty string; `replace` may be empty. Tabs
+    are accepted, while line breaks, XML control characters, and non-encodable text are refused.
+
+    Boundary fragments retain their original run properties, and replacement text receives the
+    run properties of the run where its match starts. Untouched runs remain byte-identical. Any
+    run left with no text after replacement is removed, so formatting found only on that run is
+    not retained.
+
+    Traversal covers slide shapes, grouped shapes, and table cells, plus existing notes slides
+    when `include_notes=True`. An unsupported blind region refuses the whole operation before any
+    write. Zero matches is a successful result with ``replacements == 0`` and no block anchors.
+    Each returned block anchor describes the post-edit text of a block that changed.
     """
     _validate_find_replace(find, replace)
     _require_presentation_root(prs)
@@ -92,12 +103,18 @@ def replace_text(
 def replace_text_at(
     prs: "Presentation", anchor: BlockAnchor, find: str, replace: str
 ) -> ReplaceResult:
-    """Replace `find` with `replace` inside the single block addressed by `anchor`.
+    """Replace literal `find` in the block at `anchor`; return a |ReplaceResult|.
 
-    The block's current text must hash to `anchor.content_hash` — a mismatch means the
-    document changed since the anchor was produced and raises |StaleAnchorError| (recover
-    explicitly with :func:`refind`). `find` absent from the block raises
-    |TargetNotFoundError|. Formatting-preservation semantics as :func:`replace_text`.
+    Matching, validation, run-boundary formatting, and non-run boundaries are the same as
+    :func:`replace_text`. The block's current text must hash to `anchor.content_hash`; otherwise
+    |StaleAnchorError| is raised and :func:`refind` is the explicit recovery path. An anchor that
+    addresses an unsupported blind region, or a missing target, refuses without mutation; blind
+    regions elsewhere do not block this anchored operation. `find` absent from the block, or
+    present only across a boundary a match cannot cross, raises |TargetNotFoundError| rather than
+    returning a zero count.
+
+    On success the result contains the number of occurrences replaced in that block and its one
+    post-edit anchor.
     """
     _validate_find_replace(find, replace)
     if not isinstance(anchor, BlockAnchor):

--- a/tests/paper/test_contract_harness.py
+++ b/tests/paper/test_contract_harness.py
@@ -430,5 +430,5 @@ def test_lo_smoke_helper_rejects_non_presentation_bytes(tmp_path):
     plain-text fallback 'converts' arbitrary garbage to a valid PDF with exit code 0."""
     garbage = tmp_path / "garbage.pptx"
     garbage.write_bytes(b"this is not a zip file at all " * 100)
-    with pytest.raises(AssertionError, match="could not load"):
+    with pytest.raises(AssertionError, match=r"could not (?:be )?load"):
         lo_load_smoke(garbage, tmp_path)


### PR DESCRIPTION
## Summary

- publish exact mixed-run text replacement, boundary, refusal, and stale-anchor behavior
- document table-content versus graphic-frame ownership and the end-to-end edit and narrow-save workflow
- record the executed specification and phase plans
- accept both supported LibreOffice load-rejection message variants in the independent-loader harness

## Testing

- 3,742 pytest tests passed; 1 skipped under the repository CI warning policy
- 974 Behave scenarios passed
- 58 LibreOffice-marked tests passed
- Sphinx warnings-as-errors, Ruff, git diff checks, build, and strict Twine validation passed

## Stack

1. #36 OPC package preservation
2. #37 Table editing APIs
3. This PR: documentation and compatibility integration

Base this PR on #37 so GitHub shows only the final integration phase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and docstring updates plus a one-line test regex; no production logic changes.
> 
> **Overview**
> Publishes the exact contracts for mixed-run text replacement, table vs graphic-frame ownership, and semantic package comparison. Runtime behavior is unchanged aside from a LibreOffice harness match.
> 
> `replace_text` / `replace_text_at` docs now spell out literal case-sensitive matching, run vs paragraph/`a:br`/`a:fld` boundaries, formatting inheritance (replacement takes the start-run `rPr`; empty runs are dropped), blind-region refusal, and stale-anchor recovery via `refind`.
> 
> User docs add how to keep the graphic frame when geometry matters, `copy_format_from` / merge-extend semantics, and that relationship and content-type registries compare bindings and effective assignments rather than child order. The LO smoke test accepts both “could not load” and “could not be loaded.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 679ad50a2b40cf4f70a76675f977d93b44020b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents exact text-replacement, table/frame ownership, and package-preservation contracts; widens the LibreOffice smoke-test message match. Behavior is unchanged.

- Replacement semantics: literal, case-sensitive, left-to-right, non-overlapping; matches may span adjacent runs within a paragraph but never cross paragraphs or non-run elements (line breaks, fields). Tabs are allowed; CR/LF/VT, other XML control chars, and non-encodable text are refused. Boundary fragments keep source run formatting; replacement inherits the start-run’s properties; empty runs are removed; untouched runs remain byte-identical. `find` must be non-empty; `replace` may be empty.
- Results and refusal: `replace_text` traverses slides, groups, and table cells (optionally notes); zero matches succeeds; unsupported blind regions refuse the deck-wide edit before any write. `replace_text_at` targets one paragraph; stale content raises `StaleAnchorError`; missing intra-block targets raise `TargetNotFoundError`; blind regions block only if the anchor targets them. Both return a `ReplaceResult` with post-edit anchors; use `refind` to recover stale anchors.
- Ownership and edits: use `table_by_name()` for content; use `shape_by_name()` → `GraphicFrame.table` when geometry is needed. `insert_column(..., copy_format_from=...)` copies direct cell formatting (style/theme inheritance is not materialized); explicit `width` wins over a template width; `extend_merge()` grows rectangular merges and validates the full rectangle before mutation; column insertion recalculates the owning frame’s width. Use `patch_save(original, prs, out)` for narrow saves.
- Package comparison: relationship registries compare complete bindings (not child order); content-type registries compare effective assignments; ambiguous structures fall back conservatively so real ordering changes remain visible. `patch_save` preserves original bytes for unchanged parts.
- Tests: the LibreOffice loader harness accepts both “could not load” and “could not be loaded.”

<sup>Written for commit 679ad50a2b40cf4f70a76675f977d93b44020b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

