### PR TITLE
fix: require unique automatic import layouts

### DIFF
--- a/docs/api/compose.rst
+++ b/docs/api/compose.rst
@@ -7,12 +7,21 @@ Slide import and deck merge (``pptx.compose``)
 slide's appearance lives outside the slide, in its layout, master, and theme. Import is therefore
 an *inheritance-reconciliation* problem with three explicit modes:
 
-- **adopt_theme**: rebind the incoming slide to the closest destination layout so it takes the
-  destination theme; appearance shifts are included in the report.
+- **adopt_theme**: rebind the incoming slide to a unique exact-name destination layout, or when
+  none exists, a unique exact non-custom-type layout, so it takes the destination theme;
+  appearance shifts are included in the report.
 - **keep_appearance**: transplant the source layout / master / theme chain, deduplicated by
   content hash so importing ten slides from one source does not create ten masters.
-- **bake**: snapshot the slide's effective values into explicit properties, then attach to a
-  destination layout: visually stable without importing masters.
+- **bake**: snapshot the slide's effective values into explicit properties, then attach through
+  the same unique name/type tiers or a unique blank-layout fallback: visually stable without
+  importing masters. Bake never falls back to the first destination layout.
+
+Automatic tiers are evaluated in that order: an empty tier continues, while the first non-empty
+tier must contain exactly one candidate. Multiple candidates at a stronger tier raise
+|AmbiguousTargetError| before any destination write; the refusal lists each layout's name, type,
+part, and owning master. Pass an enrolled destination ``target_layout`` to
+:meth:`.Presentation.import_slide` to make the choice explicit. A whole-deck append preflights
+every source slide under the same rules, so ambiguity on a later slide appends nothing.
 
 The source presentation remains unchanged. Charts travel with their embedded workbooks, media is
 always copied across packages, and relationships that cannot be resolved refuse

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -244,6 +244,14 @@ masters), or ``"bake"`` (freeze effective values into explicit properties). The 
 presentation remains unchanged. Charts travel with their workbooks, and unresolvable
 relationships raise a typed refusal. Each import returns an |ImportReport|.
 
+Automatic destination-layout binding is conservative: exact name, then exact non-custom type,
+then a bake-only blank fallback, with exactly one candidate required at the first matching tier.
+Ambiguity raises |AmbiguousTargetError| before the write and identifies every candidate; it never
+falls through to a weaker match or chooses the first layout. Pass ``target_layout`` to
+:meth:`~pptx.presentation.Presentation.import_slide` to settle the choice explicitly. Whole-deck
+append preflights every source slide, so an ambiguous later layout leaves the destination
+unchanged.
+
 **Send-safe delivery.** Stripping speaker notes, review comments, and authorship before a deck
 leaves the building needs no dedicated API: a part leaves the package by becoming unreachable, and
 the serializer never writes an unreachable part. Drop the relationship and the part is gone::

--- a/src/pptx/compose.py
+++ b/src/pptx/compose.py
@@ -34,7 +34,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from pptx._transaction import PackageTransaction
-from pptx.errors import RelationshipPolicyError, TargetNotFoundError, UnsupportedStructureError
+from pptx.errors import (
+    AmbiguousTargetError,
+    RelationshipPolicyError,
+    TargetNotFoundError,
+    UnsupportedStructureError,
+)
 from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 from pptx.opc.package import XmlPart
 from pptx.oxml import parse_xml
@@ -99,7 +104,8 @@ class ImportReport:
     * ``position`` -- 0-based index the new slide was inserted at.
     * ``layout_binding`` -- partname of the destination layout the slide is bound to.
     * ``layout_binding_method`` -- how that layout was chosen ("name-match",
-      "type-match", "explicit", "transplant", "blank-fallback", "first-fallback").
+      "type-match", "explicit", "transplant", or "blank-fallback"). Automatic
+      methods always identify a unique candidate at their matching tier.
     * ``parts_added`` -- partnames added to the destination package by this import.
     * ``parts_reused`` -- partnames of existing destination parts reused via
       content-hash deduplication (keep_appearance).
@@ -515,8 +521,9 @@ def _resolved_run_values(shape) -> list:
 @dataclass
 class _LayoutBinding:
     """The destination layout an imported slide binds to, and how that layout was chosen."""
+
     layout: "Optional[SlideLayout]"  # -- None only for keep_appearance (pre-transplant)
-    # -- name-match | type-match | explicit | blank-fallback | first-fallback | transplant
+    # -- name-match | type-match | explicit | blank-fallback | transplant
     method: str
 
 
@@ -524,9 +531,10 @@ def _resolve_layout_binding(dest_prs, source_slide, mode, target_layout) -> _Lay
     """Choose the destination layout for an imported slide, or refuse.
 
     `keep_appearance` short-circuits to a source-chain transplant. Otherwise: explicit
-    `target_layout`, then a layout-name match, then a layout-type match. With no match, `bake` falls
-    back to a blank layout and then the first layout, while `adopt_theme` raises
-    UnsupportedStructureError telling the caller to pass `target_layout`.
+    `target_layout`, then a unique layout-name match, then a unique layout-type match. With no
+    match, `bake` falls back only to a unique blank layout, while `adopt_theme` raises
+    UnsupportedStructureError telling the caller to pass `target_layout`. Ambiguity at any tier
+    refuses rather than weakening the match.
     """
     if mode == "keep_appearance":
         return _LayoutBinding(None, "transplant")
@@ -534,25 +542,66 @@ def _resolve_layout_binding(dest_prs, source_slide, mode, target_layout) -> _Lay
         return _LayoutBinding(target_layout, "explicit")
     source_layout = source_slide.slide_layout
     dest_layouts = [layout for master in dest_prs.slide_masters for layout in master.slide_layouts]
+
+    def unique_candidate(candidates, method, tier):
+        if len(candidates) == 1:
+            return _LayoutBinding(candidates[0], method)
+        if len(candidates) > 1:
+            identities = sorted(
+                [
+                    (
+                        layout.name,
+                        layout._element.get("type"),
+                        str(layout.part.partname),
+                        str(layout.slide_master.part.partname),
+                    )
+                    for layout in candidates
+                ],
+                key=lambda identity: (identity[3], identity[2], identity[0], identity[1] or ""),
+            )
+            details = "; ".join(
+                "name=%r, type=%r, part=%s, master=%s" % identity for identity in identities
+            )
+            raise AmbiguousTargetError(
+                "destination layout %s match is ambiguous; candidates: %s; pass "
+                "target_layout= explicitly" % (tier, details)
+            )
+        return None
+
     source_name = source_layout.name
     if source_name:
-        for layout in dest_layouts:
-            if layout.name == source_name:
-                return _LayoutBinding(layout, "name-match")
+        binding = unique_candidate(
+            [layout for layout in dest_layouts if layout.name == source_name],
+            "name-match",
+            "name",
+        )
+        if binding is not None:
+            return binding
     source_type = source_layout._element.get("type")
     if source_type and source_type != "cust":
-        for layout in dest_layouts:
-            if layout._element.get("type") == source_type:
-                return _LayoutBinding(layout, "type-match")
+        binding = unique_candidate(
+            [layout for layout in dest_layouts if layout._element.get("type") == source_type],
+            "type-match",
+            "type",
+        )
+        if binding is not None:
+            return binding
     if mode == "bake":
-        for layout in dest_layouts:
-            if layout._element.get("type") == "blank":
-                return _LayoutBinding(layout, "blank-fallback")
-        return _LayoutBinding(dest_layouts[0], "first-fallback")
+        binding = unique_candidate(
+            [layout for layout in dest_layouts if layout._element.get("type") == "blank"],
+            "blank-fallback",
+            "blank",
+        )
+        if binding is not None:
+            return binding
     raise UnsupportedStructureError(
-        "no destination layout matches source layout %r by name or type; pass "
+        "no destination layout uniquely matches source layout %r by name or type%s; pass "
         "target_layout= explicitly (or use keep_appearance to transplant the source "
-        "layout chain)" % (source_name or str(source_layout.part.partname))
+        "layout chain)"
+        % (
+            source_name or str(source_layout.part.partname),
+            " or blank fallback" if mode == "bake" else "",
+        )
     )
 
 

--- a/src/pptx/presentation.py
+++ b/src/pptx/presentation.py
@@ -157,15 +157,17 @@ class Presentation(PartElementProxy):
         default, the caller chooses consciously:
 
         - `"adopt_theme"`: content transplants and rebinds to a destination layout
-          (auto by layout name, then layout type; `target_layout` overrides; orphan
-          placeholders bake from their source-resolved look). The slide takes the house
-          style; every run whose resolved values changed is in `run_shifts`.
+          (auto only on a unique exact layout name, then a unique exact non-custom layout
+          type; `target_layout` overrides; orphan placeholders bake from their
+          source-resolved look). The slide takes the house style; every run whose
+          resolved values changed is in `run_shifts`.
         - `"keep_appearance"`: the source layout+master+theme chain transplants,
           fingerprint-deduplicated (ten slides from one source share one master).
         - `"bake"`: resolvable effective values become explicit local properties,
           furniture placeholders (dt/ftr/sldNum) drop, remaining placeholders become
-          free shapes, and the slide attaches to a destination layout. Stable look
-          without importing masters.
+          free shapes, and the slide attaches to a destination layout selected by the
+          same unique name/type tiers, then a unique blank-layout fallback. It never
+          falls back to the first layout. Stable look without importing masters.
 
         The source presentation is never mutated. Media always copies (never shared
         across packages); charts deep-copy with workbooks; SmartArt carries opaquely;
@@ -174,6 +176,9 @@ class Presentation(PartElementProxy):
         `notes` copies the speaker-notes part re-linked to this deck's notes master.
         `section` names an existing destination section to enroll in; None enrolls
         adjacent to the insertion point when this deck has sections.
+        Multiple candidates at any automatic layout tier raise |AmbiguousTargetError|
+        before any write and list the layouts; pass an enrolled destination
+        `target_layout` to resolve that choice explicitly.
         """
         from pptx.compose import import_slide
 

--- a/tests/paper/test_import.py
+++ b/tests/paper/test_import.py
@@ -15,6 +15,7 @@ import pytest
 
 from pptx import Presentation
 from pptx.errors import (
+    AmbiguousTargetError,
     PaperRefusal,
     RelationshipPolicyError,
     TargetNotFoundError,
@@ -50,6 +51,7 @@ def test_import_refuses_a_source_relationship_target_owned_by_another_package():
 
     assert zip_member_map(save_to_bytes(dest)) == before
 
+
 ALPHA = "self_generated/template_alpha.pptx"
 BETA = "self_generated/template_beta.pptx"
 LO_ALPHA = "libreoffice_export/lo_template_alpha.pptx"
@@ -67,6 +69,29 @@ def _assert_clean(saved_bytes):
     assert missing_relationship_references(zip_map) == []
     assert dangling_section_slide_ids(zip_map) == []
     assert duplicate_section_slide_ids(zip_map) == []
+
+
+def _assert_layout_candidates_reported(error, candidates):
+    message = str(error)
+    assert "target_layout" in message
+    for layout in candidates:
+        identity = "name=%r, type=%r, part=%s, master=%s" % (
+            layout.name,
+            layout._element.get("type"),
+            layout.part.partname,
+            layout.slide_master.part.partname,
+        )
+        assert identity in message
+
+
+def _assert_explicit_layout_survives_reopen(dest, source, slide_idx, mode, target_layout):
+    target_partname = str(target_layout.part.partname)
+    report = dest.import_slide(source, slide_idx, mode=mode, target_layout=target_layout)
+    assert report.layout_binding_method == "explicit"
+    reopened = save_reopen(dest)
+    imported = reopened.slides[-1]
+    assert str(imported.slide_layout.part.partname) == target_partname
+    return imported
 
 
 # --------------------------------------------------------------------------- mode contracts
@@ -144,6 +169,8 @@ def test_adopt_theme_falls_back_to_type_match_for_renamed_layout():
     report = dest.import_slide(_open(BETA), 2, mode="adopt_theme")
     assert report.layout_binding_method == "type-match"
     assert report.layout_binding == "/ppt/slideLayouts/slideLayout6.xml"
+    reopened = save_reopen(dest)
+    assert reopened.slides[-1].slide_layout.name == "Title Only"
 
 
 def test_adopt_theme_unmatched_layout_refuses_and_explicit_target_recovers():
@@ -182,6 +209,147 @@ def test_bake_freezes_look_without_importing_masters():
     run = title.text_frame.paragraphs[0].runs[0]
     assert run.font.name == "Courier New"  # -- beta's look, made local
     assert run.font.size is not None
+
+
+def test_bake_uses_unique_blank_only_after_name_and_type_are_absent():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    source_layout = source.slides[2].slide_layout
+    source_layout.name = None
+    source_layout._element.attrib.pop("type", None)
+
+    report = dest.import_slide(source, 2, mode="bake")
+
+    assert report.layout_binding_method == "blank-fallback"
+    reopened = save_reopen(dest)
+    assert reopened.slides[-1].slide_layout.name == "Blank"
+    assert reopened.slides[-1].shapes.chart_by_name("beta_chart") is not None
+
+
+# ----------------------------------------------------------- unique layout selection
+
+
+def test_duplicate_layout_name_on_one_master_refuses_and_explicit_target_recovers():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    first = dest.slide_layouts[0]
+    duplicate = dest.slide_layouts[1]
+    duplicate.name = first.name
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(source, 0, mode="adopt_theme"),
+        AmbiguousTargetError,
+    )
+
+    _assert_layout_candidates_reported(error, (first, duplicate))
+    imported = _assert_explicit_layout_survives_reopen(dest, source, 0, "adopt_theme", first)
+    assert imported.shapes.title.text_frame.text == "Beta Overview"
+
+
+def test_duplicate_layout_name_across_masters_refuses_atomically():
+    dest = _open(ALPHA)
+    dest.import_slide(_open(BETA), 2, mode="keep_appearance")
+    source = _open(BETA)
+    first = dest.slide_masters[0].slide_layouts[0]
+    duplicate = dest.slide_masters[1].slide_layouts[0]
+    duplicate.name = first.name
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(source, 0, mode="adopt_theme"),
+        AmbiguousTargetError,
+    )
+
+    _assert_layout_candidates_reported(error, (first, duplicate))
+
+
+def test_duplicate_layout_type_refuses_before_unique_blank_and_explicit_target_recovers():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    target = dest.slide_layouts[5]
+    duplicate = dest.slide_layouts[4]
+    duplicate._element.set("type", target._element.get("type"))
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(source, 2, mode="bake"),
+        AmbiguousTargetError,
+    )
+
+    _assert_layout_candidates_reported(error, (target, duplicate))
+    imported = _assert_explicit_layout_survives_reopen(dest, source, 2, "bake", target)
+    assert imported.shapes.chart_by_name("beta_chart") is not None
+
+
+def test_duplicate_blank_layout_refuses_and_explicit_target_recovers():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    source_layout = source.slides[2].slide_layout
+    source_layout.name = None
+    source_layout._element.attrib.pop("type", None)
+    target = dest.slide_layouts[6]
+    duplicate = dest.slide_layouts[5]
+    duplicate._element.set("type", "blank")
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(source, 2, mode="bake"),
+        AmbiguousTargetError,
+    )
+
+    _assert_layout_candidates_reported(error, (target, duplicate))
+    imported = _assert_explicit_layout_survives_reopen(dest, source, 2, "bake", target)
+    assert imported.shapes.chart_by_name("beta_chart") is not None
+
+
+def test_layout_ambiguity_diagnostic_is_independent_of_collection_order():
+    def ambiguous_error(reorder):
+        dest = _open(ALPHA)
+        source = _open(BETA)
+        dest.slide_layouts[1].name = dest.slide_layouts[0].name
+        if reorder:
+            id_list = dest.slide_masters[0].slide_layouts._sldLayoutIdLst
+            first_entry = id_list.sldLayoutId_lst[0]
+            id_list.remove(first_entry)
+            id_list.append(first_entry)
+        return str(
+            assert_refusal_atomic(
+                dest,
+                lambda prs: prs.import_slide(source, 0, mode="adopt_theme"),
+                AmbiguousTargetError,
+            )
+        )
+
+    assert ambiguous_error(reorder=False) == ambiguous_error(reorder=True)
+
+
+def test_keep_appearance_ignores_ambiguous_destination_layouts():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    dest.slide_layouts[1].name = dest.slide_layouts[0].name
+
+    report = dest.import_slide(source, 0, mode="keep_appearance")
+
+    assert report.layout_binding_method == "transplant"
+    reopened = save_reopen(dest)
+    assert reopened.slides[-1].shapes.title.text_frame.text == "Beta Overview"
+
+
+def test_bake_with_no_enrolled_destination_layout_refuses_typed_not_index_error():
+    dest = Presentation()
+    for layout in list(dest.slide_layouts):
+        dest.slide_layouts.remove(layout)
+    source = Presentation()
+    source.slides.add_slide(source.slide_layouts[0])
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(source, 0, mode="bake"),
+        UnsupportedStructureError,
+    )
+
+    assert "target_layout" in str(error)
 
 
 def test_bake_drops_furniture_placeholders():
@@ -359,6 +527,24 @@ def test_append_deck_validates_whole_source_before_first_write():
     before = save_to_bytes(dest)
     with pytest.raises(RelationshipPolicyError):
         dest.append_deck(source, mode="keep_appearance")
+    assert_changed_parts(before, save_to_bytes(dest))  # -- empty budget
+
+
+def test_append_deck_later_layout_ambiguity_refuses_before_any_slide_is_added():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    dest.slide_layouts[2].name = dest.slide_layouts[1].name
+    before = save_to_bytes(dest)
+    slide_count = len(dest.slides)
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.append_deck(source, mode="adopt_theme"),
+        AmbiguousTargetError,
+    )
+
+    _assert_layout_candidates_reported(error, (dest.slide_layouts[1], dest.slide_layouts[2]))
+    assert len(dest.slides) == slide_count
     assert_changed_parts(before, save_to_bytes(dest))  # -- empty budget
 
 


### PR DESCRIPTION
## Summary

- require a unique automatic layout match at each existing import tier
- remove arbitrary first-layout fallback behavior
- preserve explicit target_layout and atomic whole-deck import recovery

## Finding

LS-02 — automatic import layout selection used the first matching candidate.

## Stack

- Root: #38
- Base: #40
- This PR: #41
- Next: #42

## Verification

Focused and full pytest, Behave, LibreOffice, documentation, distribution, and Python 3.9–3.13 CI pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core compose layout-selection for import/append, so previously successful first-match imports can now refuse. Behavior is still atomic and explicit `target_layout` remains the recovery path.
> 
> **Overview**
> Automatic destination-layout selection for `import_slide` / `append_deck` no longer takes the first name or type match. Each tier (exact name, then exact non-custom type, then bake-only blank) must have **exactly one** candidate; multiples raise `AmbiguousTargetError` before any write, listing name, type, part, and master. Empty tiers still fall through.
> 
> **Bake** no longer uses a first-layout fallback. If name and type miss, it binds only to a unique blank layout, otherwise `UnsupportedStructureError`. `keep_appearance` still transplants and ignores destination-layout duplicates. Explicit `target_layout` is unchanged. Whole-deck append still preflights every slide, so later ambiguity leaves the destination untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2243c7640f333ce77484e227a705f486fd57530d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->