### PR TITLE
fix: require unique placeholder reconciliation

### DIFF
--- a/docs/api/compose.rst
+++ b/docs/api/compose.rst
@@ -23,6 +23,20 @@ part, and owning master. Pass an enrolled destination ``target_layout`` to
 :meth:`.Presentation.import_slide` to make the choice explicit. A whole-deck append preflights
 every source slide under the same rules, so ambiguity on a later slide appends nothing.
 
+Adopt-theme placeholder reconciliation uses the same exact-first, unique-only matcher as layout
+rebind. Same-type and compatible-family fallbacks bind only when their current unclaimed candidate
+set has one member; ambiguity raises |AmbiguousTargetError| without trying a weaker tier. Supply a
+partial ``placeholder_map={source_idx: target_idx | None}`` to
+:meth:`.Presentation.import_slide` to settle selected sources explicitly while the rest reconcile
+automatically. ``None`` deliberately orphans that source placeholder, which adopt-theme bakes from
+its source-resolved appearance. The argument is rejected for keep-appearance and bake. Whole-deck
+append deliberately remains automatic-only and refuses atomically if any staged slide needs a map.
+
+``paper-import-report`` version 2 always serializes ``placeholder_map_used``. Adopt-theme reports
+the complete resolved source-to-target mapping, including ``null`` orphan targets, in source-index
+order. Keep-appearance and bake serialize an empty list because they do not reconcile
+placeholders.
+
 The source presentation remains unchanged. Charts travel with their embedded workbooks, media is
 always copied across packages, and relationships that cannot be resolved refuse
 (|RelationshipPolicyError|).

--- a/docs/api/rebind.rst
+++ b/docs/api/rebind.rst
@@ -6,8 +6,17 @@ Layout rebind (``pptx.rebind``)
 *paper-pptx addition.* Move a slide to another layout in the same presentation, matching
 placeholders by type and index with an explicit map and an orphan policy for the rest.
 
+Automatic reconciliation first settles every exact type-and-index match across the slide. It
+then considers same-type matches, followed by the compatible title and content families. A
+fallback tier binds only when exactly one unclaimed target placeholder exists. Multiple candidates
+raise |AmbiguousTargetError| before mutation and list each target type/index; pass a partial
+``placeholder_map={source_idx: target_idx | None}`` to choose explicitly. Unlisted sources still
+use automatic matching, and ``None`` deliberately orphans a source so ``orphan_policy`` controls
+whether it refuses or bakes to a free shape.
+
 The report is required. The effective-value resolver runs before and after, and every text run
-whose *resolved* appearance changed appears in it.
+whose *resolved* appearance changed appears in it. ``paper-rebind-report`` remains version 1 and
+records the complete resolved mapping in ``placeholder_map_used``.
 
 The entry point is a method on |Slide|; see :meth:`.Slide.rebind_layout`. This page documents the
 report it returns.

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -230,9 +230,12 @@ The package authors the fields. PowerPoint or LibreOffice refreshes their values
 slide number written this way stays correct after a reorder.
 
 **Layout rebind** (:ref:`rebind_api`). :meth:`~pptx.slide.Slide.rebind_layout` moves a slide to
-another layout, matching placeholders by type and
-index with an explicit map and orphan policy for the rest. Its |RebindReport| is required. The
-resolver runs before and after, and every run whose *resolved* appearance changed is reported.
+another layout. Placeholder matching settles exact type-and-index matches globally, then accepts a
+same-type or compatible-family fallback only when it has one unclaimed candidate. Ambiguity raises
+|AmbiguousTargetError| before mutation; a partial
+``placeholder_map={source_idx: target_idx | None}`` chooses selected slots while the rest remain
+automatic, and ``None`` deliberately invokes the orphan policy. Its |RebindReport| is required.
+The resolver runs before and after, and every run whose *resolved* appearance changed is reported.
 
 **Slide import and deck merge** (:ref:`compose_api`).
 :meth:`~pptx.presentation.Presentation.import_slide` and
@@ -251,6 +254,14 @@ falls through to a weaker match or chooses the first layout. Pass ``target_layou
 :meth:`~pptx.presentation.Presentation.import_slide` to settle the choice explicitly. Whole-deck
 append preflights every source slide, so an ambiguous later layout leaves the destination
 unchanged.
+
+Adopt-theme import applies the same exact-first, unique-only placeholder reconciliation. Pass a
+partial ``placeholder_map`` to :meth:`~pptx.presentation.Presentation.import_slide` when a
+same-type or compatible-family tier is ambiguous; a ``None`` target deliberately bakes that
+source placeholder. Keep-appearance and bake reject the argument because they do not reconcile
+placeholder bindings. :meth:`~pptx.presentation.Presentation.append_deck` remains automatic-only
+and atomically refuses if any staged slide needs an explicit map. ``paper-import-report`` version
+2 always records ``placeholder_map_used``; non-reconciling modes use an empty list.
 
 **Send-safe delivery.** Stripping speaker notes, review comments, and authorship before a deck
 leaves the building needs no dedicated API: a part leaves the package by becoming unreachable, and

--- a/src/pptx/compose.py
+++ b/src/pptx/compose.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from pptx.slide import Slide, SlideLayout
 
 SCHEMA_NAME = "paper-import-report"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 class _ComposeTransaction(PackageTransaction):
@@ -106,6 +106,9 @@ class ImportReport:
     * ``layout_binding_method`` -- how that layout was chosen ("name-match",
       "type-match", "explicit", "transplant", or "blank-fallback"). Automatic
       methods always identify a unique candidate at their matching tier.
+    * ``placeholder_map_used`` -- the complete resolved ``(source_idx, target_idx)``
+      mapping for adopt-theme reconciliation; ``target_idx`` is ``None`` for an
+      orphan. Empty for keep-appearance and bake.
     * ``parts_added`` -- partnames added to the destination package by this import.
     * ``parts_reused`` -- partnames of existing destination parts reused via
       content-hash deduplication (keep_appearance).
@@ -127,6 +130,7 @@ class ImportReport:
     position: int
     layout_binding: str
     layout_binding_method: str
+    placeholder_map_used: Tuple[Tuple[int, Optional[int]], ...]
     parts_added: Tuple[str, ...]
     parts_reused: Tuple[str, ...]
     notes_copied: bool
@@ -148,6 +152,10 @@ class ImportReport:
             "position": self.position,
             "layout_binding": self.layout_binding,
             "layout_binding_method": self.layout_binding_method,
+            "placeholder_map_used": [
+                {"source_idx": src, "target_idx": tgt}
+                for src, tgt in self.placeholder_map_used
+            ],
             "parts_added": list(self.parts_added),
             "parts_reused": list(self.parts_reused),
             "notes_copied": self.notes_copied,
@@ -172,14 +180,23 @@ def import_slide(
     notes: bool = True,
     section: "Optional[str]" = None,
     target_layout: "Optional[SlideLayout]" = None,
+    placeholder_map="auto",
 ) -> ImportReport:
     """Import one slide from `source_prs` into `dest_prs`; return the |ImportReport|."""
     source_slide = _validate_arguments(
-        dest_prs, source_prs, slide, mode, position, notes, section, target_layout
+        dest_prs,
+        source_prs,
+        slide,
+        mode,
+        position,
+        notes,
+        section,
+        target_layout,
+        placeholder_map,
     )
     plan = _validated_transplant_plan(source_slide.part, notes)
     binding = _resolve_layout_binding(dest_prs, source_slide, mode, target_layout)
-    prep = _validate_mode_preparation(source_slide, mode, binding)
+    prep = _validate_mode_preparation(source_slide, mode, binding, placeholder_map)
     with _ComposeTransaction(dest_prs):
         return _perform_import(
             dest_prs, source_slide, plan, mode, binding, prep, position, notes, section
@@ -206,7 +223,7 @@ def append_deck(
     staged = []
     for source_slide in materialize_slides(source_prs, "append_deck"):
         source_slide = _validate_arguments(
-            dest_prs, source_prs, source_slide, mode, None, notes, None, None
+            dest_prs, source_prs, source_slide, mode, None, notes, None, None, "auto"
         )
         plan = _validated_transplant_plan(source_slide.part, notes)
         binding = _resolve_layout_binding(dest_prs, source_slide, mode, None)
@@ -228,7 +245,15 @@ def append_deck(
 
 
 def _validate_arguments(
-    dest_prs, source_prs, slide, mode, position, notes, section, target_layout
+    dest_prs,
+    source_prs,
+    slide,
+    mode,
+    position,
+    notes,
+    section,
+    target_layout,
+    placeholder_map,
 ) -> "Slide":
     """Check the import arguments and return the resolved source slide.
 
@@ -297,6 +322,8 @@ def _validate_arguments(
         if target_layout.part.package is not dest_prs.part.package:
             raise ValueError("target_layout must belong to the destination presentation")
         _require_layout_enrolled(target_layout, argument="target_layout")
+    if mode != "adopt_theme" and placeholder_map != "auto":
+        raise ValueError("placeholder_map applies only to mode='adopt_theme'")
     if mode in ("adopt_theme", "bake") and any(
         True for _ in slide._element.spTree.iterchildren(_MC_ALTERNATE_CONTENT)
     ):
@@ -360,7 +387,7 @@ def _validate_dgm_rels(dgm_part) -> None:
             )
 
 
-def _validate_mode_preparation(source_slide, mode, binding):
+def _validate_mode_preparation(source_slide, mode, binding, placeholder_map="auto"):
     """Pre-compute everything the mode needs from the SOURCE, refusing before any write."""
     from pptx.rebind import _compute_mapping, _resolution_state
 
@@ -373,7 +400,7 @@ def _validate_mode_preparation(source_slide, mode, binding):
     content_phs = [shape for shape in slide_phs if shape not in hf_phs]
 
     if mode == "adopt_theme":
-        mapping = _compute_mapping(slide_phs, binding.layout, "auto")
+        mapping = _compute_mapping(slide_phs, binding.layout, placeholder_map)
         orphans = [s for s in slide_phs if mapping[s.element.ph_idx] is None]
     else:  # -- bake: every content placeholder converts; furniture drops
         mapping = None
@@ -702,6 +729,10 @@ def _perform_import(
         position=final_position,
         layout_binding=str(dest_layout_part.partname),
         layout_binding_method=binding.method,
+        placeholder_map_used=tuple(
+            (source_idx, target[1] if target else None)
+            for source_idx, target in sorted((prep.get("mapping") or {}).items())
+        ),
         parts_added=parts_added,
         parts_reused=tuple(sorted(set(reused))),
         notes_copied=notes_copied,

--- a/src/pptx/presentation.py
+++ b/src/pptx/presentation.py
@@ -150,6 +150,7 @@ class Presentation(PartElementProxy):
         notes: bool = True,
         section: str | None = None,
         target_layout=None,
+        placeholder_map="auto",
     ) -> "ImportReport":
         """Import `slide` from `source_prs` into this presentation; return the report.
 
@@ -179,6 +180,11 @@ class Presentation(PartElementProxy):
         Multiple candidates at any automatic layout tier raise |AmbiguousTargetError|
         before any write and list the layouts; pass an enrolled destination
         `target_layout` to resolve that choice explicitly.
+        Adopt-theme placeholder reconciliation first preserves exact type+idx matches,
+        then accepts same-type or compatible-family fallbacks only when unique. Pass a
+        partial `placeholder_map={source_idx: target_idx | None}` to resolve ambiguity;
+        `None` deliberately orphans and bakes that source placeholder. The argument does
+        not apply to keep-appearance or bake imports. Whole-deck append remains automatic-only.
         """
         from pptx.compose import import_slide
 
@@ -191,6 +197,7 @@ class Presentation(PartElementProxy):
             notes=notes,
             section=section,
             target_layout=target_layout,
+            placeholder_map=placeholder_map,
         )
 
     @property

--- a/src/pptx/rebind.py
+++ b/src/pptx/rebind.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from pptx.enum.shapes import PP_PLACEHOLDER
-from pptx.errors import UnsupportedStructureError
+from pptx.errors import AmbiguousTargetError, UnsupportedStructureError
 from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 from pptx.oxml.ns import qn
 from pptx.util import Emu
@@ -356,9 +356,10 @@ def _compute_mapping(slide_phs, target_layout, placeholder_map):
     for shape in unmatched:
         source_type = shape.element.ph_type
         same_type = [slot for slot in slots if slot[0] == source_type and slot[1] not in claimed]
-        if same_type:
-            mapping[shape.element.ph_idx] = same_type[0]
-            claimed.add(same_type[0][1])
+        match = _unique_fallback(shape, same_type, "same-type")
+        if match is not None:
+            mapping[shape.element.ph_idx] = match
+            claimed.add(match[1])
         else:
             still_unmatched.append(shape)
 
@@ -370,12 +371,29 @@ def _compute_mapping(slide_phs, target_layout, placeholder_map):
             if family is not None
             else []
         )
-        if familial:
-            mapping[shape.element.ph_idx] = familial[0]
-            claimed.add(familial[0][1])
+        match = _unique_fallback(shape, familial, "compatible-family")
+        if match is not None:
+            mapping[shape.element.ph_idx] = match
+            claimed.add(match[1])
         else:
             mapping[shape.element.ph_idx] = None
     return mapping
+
+
+def _unique_fallback(shape, candidates, tier):
+    """Return the sole candidate in `tier`, or refuse when that tier is ambiguous."""
+    if len(candidates) > 1:
+        raise AmbiguousTargetError(
+            "placeholder type %s, idx %d has multiple unclaimed %s fallback targets: %s; "
+            "pass placeholder_map={source_idx: target_idx | None} to choose explicitly"
+            % (
+                shape.element.ph_type.name,
+                shape.element.ph_idx,
+                tier,
+                ", ".join("type %s, idx %d" % (ph_type.name, idx) for ph_type, idx in candidates),
+            )
+        )
+    return candidates[0] if candidates else None
 
 
 # ------------------------------------------------------------------------ resolve and bake

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -296,7 +296,9 @@ class Slide(_BaseSlide):
         paper-pptx addition — the template-migration *primitive* (bulk-migration
         workflows are left to the caller). Placeholders reconcile against the
         target layout: auto-matching binds by exact type+idx, then same type, then
-        interchangeable type family (title/ctrTitle; body/object/subTitle); pass
+        interchangeable type family (title/ctrTitle; body/object/subTitle). The two
+        fallback tiers bind only when exactly one unclaimed target exists; ambiguity
+        refuses and requires an explicit map. Pass
         `placeholder_map={source_idx: target_idx | None}` to override any of it (None
         force-orphans a source). Source placeholders with no destination follow
         `orphan_policy`: "refuse" (default; typed, atomic) or "bake" — convert to a free

--- a/tests/paper/goldens/import_beta_keep.import.json
+++ b/tests/paper/goldens/import_beta_keep.import.json
@@ -1,6 +1,6 @@
 {
   "schema": "paper-import-report",
-  "version": 1,
+  "version": 2,
   "mode": "keep_appearance",
   "source_slide": "/ppt/slides/slide1.xml",
   "dest_slide": "/ppt/slides/slide4.xml",
@@ -8,6 +8,7 @@
   "position": 3,
   "layout_binding": "/ppt/slideLayouts/slideLayout12.xml",
   "layout_binding_method": "transplant",
+  "placeholder_map_used": [],
   "parts_added": [
     "/ppt/slideLayouts/slideLayout12.xml",
     "/ppt/slideMasters/slideMaster2.xml",

--- a/tests/paper/test_import.py
+++ b/tests/paper/test_import.py
@@ -8,12 +8,14 @@ determinism goldens on the import report.
 
 from __future__ import annotations
 
+import copy
 import io
 import json
 
 import pytest
 
 from pptx import Presentation
+from pptx.enum.shapes import PP_PLACEHOLDER
 from pptx.errors import (
     AmbiguousTargetError,
     PaperRefusal,
@@ -61,6 +63,28 @@ GAUNTLET = "self_generated/gauntlet.pptx"
 
 def _open(relpath):
     return Presentation(str(corpus.fixture_path(relpath)))
+
+
+def _set_content_slots(layout, slots):
+    placeholders = sorted(
+        (ph for ph in layout.placeholders if ph.element.ph_type == PP_PLACEHOLDER.OBJECT),
+        key=lambda ph: ph.element.ph_idx,
+    )
+    assert len(placeholders) == len(slots)
+    for placeholder, (ph_type, idx) in zip(placeholders, slots):
+        placeholder.element.ph.type = ph_type
+        placeholder.element.ph.idx = idx
+
+
+def _duplicate_content_slot(layout, idx):
+    source = next(
+        ph for ph in layout.placeholders if ph.element.ph_type == PP_PLACEHOLDER.OBJECT
+    )
+    duplicate = copy.deepcopy(source._element)
+    duplicate.nvSpPr.cNvPr.set("id", "99")
+    duplicate.nvSpPr.cNvPr.set("name", "Additional Content Placeholder")
+    duplicate.ph.idx = idx
+    source._element.addnext(duplicate)
 
 
 def _assert_clean(saved_bytes):
@@ -160,6 +184,172 @@ def test_adopt_theme_takes_house_style_and_reports_shifts():
     imported = reopened.slides[3]
     title_font = imported.shapes.title.text_frame.paragraphs[0].runs[0].effective_font()
     assert title_font.name.value == "Georgia"  # -- the house look
+
+
+def test_adopt_theme_report_records_complete_automatic_placeholder_mapping():
+    dest = _open(ALPHA)
+
+    report = dest.import_slide(_open(BETA), 0, mode="adopt_theme")
+
+    assert report.placeholder_map_used == ((0, 0), (1, 1))
+    assert report.to_dict()["placeholder_map_used"] == [
+        {"source_idx": 0, "target_idx": 0},
+        {"source_idx": 1, "target_idx": 1},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("target_type", "tier"),
+    [
+        (PP_PLACEHOLDER.OBJECT, "same-type fallback"),
+        (PP_PLACEHOLDER.BODY, "compatible-family fallback"),
+    ],
+)
+def test_adopt_theme_placeholder_ambiguity_refuses_atomically(target_type, tier):
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    source_before = save_to_bytes(source)
+    target = dest.slide_layouts[3]
+    _set_content_slots(target, [(target_type, 3), (target_type, 2)])
+    before = save_to_bytes(dest)
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(
+            source, 1, mode="adopt_theme", target_layout=prs.slide_layouts[3]
+        ),
+        AmbiguousTargetError,
+    )
+
+    message = str(error)
+    assert "type OBJECT, idx 1" in message
+    assert tier in message
+    assert "idx 2" in message
+    assert "idx 3" in message
+    assert "placeholder_map" in message
+    assert_changed_parts(before, save_to_bytes(dest))
+    assert zip_member_map(save_to_bytes(source)) == zip_member_map(source_before)
+
+
+def test_adopt_theme_partial_placeholder_map_disambiguates_and_persists():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    source_before = save_to_bytes(source)
+    target = dest.slide_layouts[3]
+    _set_content_slots(
+        target,
+        [(PP_PLACEHOLDER.OBJECT, 3), (PP_PLACEHOLDER.OBJECT, 2)],
+    )
+    before = save_to_bytes(dest)
+
+    report = dest.import_slide(
+        source,
+        1,
+        mode="adopt_theme",
+        target_layout=target,
+        placeholder_map={1: 2},
+    )
+
+    assert report.placeholder_map_used == ((0, 0), (1, 2))
+    after = save_to_bytes(dest)
+    assert_changed_parts(
+        before,
+        after,
+        expect_added=["ppt/slides/_rels/slide4.xml.rels", "ppt/slides/slide4.xml"],
+        expect_changed=[
+            "[Content_Types].xml",
+            "ppt/_rels/presentation.xml.rels",
+            "ppt/presentation.xml",
+        ],
+    )
+    _assert_clean(after)
+    reopened = Presentation(io.BytesIO(after))
+    imported = reopened.slides[-1]
+    assert imported.slide_layout.name == "Two Content"
+    placeholders = {
+        shape.element.ph_idx: shape for shape in imported.shapes if shape.is_placeholder
+    }
+    assert set(placeholders) == {0, 2}
+    assert placeholders[0].text_frame.text == "Beta Content"
+    assert "Beta point one" in placeholders[2].text_frame.text
+    assert zip_member_map(save_to_bytes(source)) == zip_member_map(source_before)
+
+
+def test_adopt_theme_explicit_none_bakes_orphan_and_reports_null_target():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+
+    report = dest.import_slide(
+        source, 1, mode="adopt_theme", placeholder_map={1: None}
+    )
+
+    assert report.placeholder_map_used == ((0, 0), (1, None))
+    assert {"source_idx": 1, "target_idx": None} in report.to_dict()[
+        "placeholder_map_used"
+    ]
+    reopened = save_reopen(dest)
+    imported = reopened.slides[-1]
+    body = next(shape for shape in imported.shapes if shape.name == "Content Placeholder 2")
+    assert not body.is_placeholder
+    assert "Beta point one" in body.text_frame.text
+
+
+def test_adopt_theme_automatic_orphan_reports_null_target():
+    dest = _open(ALPHA)
+
+    report = dest.import_slide(
+        _open(BETA),
+        1,
+        mode="adopt_theme",
+        target_layout=dest.slide_layouts[5],  # -- Title Only has no content slot
+    )
+
+    assert report.placeholder_map_used == ((0, 0), (1, None))
+    assert report.to_dict()["placeholder_map_used"] == [
+        {"source_idx": 0, "target_idx": 0},
+        {"source_idx": 1, "target_idx": None},
+    ]
+
+
+@pytest.mark.parametrize("mode", ["keep_appearance", "bake"])
+def test_placeholder_map_is_rejected_for_non_reconciling_import_modes(mode):
+    dest = _open(ALPHA)
+    source = _open(BETA)
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(source, 0, mode=mode, placeholder_map={0: 0}),
+        ValueError,
+    )
+
+    assert "only to mode='adopt_theme'" in str(error)
+
+
+@pytest.mark.parametrize(
+    ("placeholder_map", "message"),
+    [
+        ({99: 1}, "not a placeholder on this slide"),
+        ({1: 99}, "not a placeholder on the target"),
+        ({0: 2, 1: 2}, "one target"),
+    ],
+)
+def test_adopt_theme_placeholder_map_validation_is_atomic(placeholder_map, message):
+    dest = _open(ALPHA)
+    source = _open(BETA)
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(
+            source,
+            1,
+            mode="adopt_theme",
+            target_layout=prs.slide_layouts[3],
+            placeholder_map=placeholder_map,
+        ),
+        ValueError,
+    )
+
+    assert message in str(error)
 
 
 def test_adopt_theme_falls_back_to_type_match_for_renamed_layout():
@@ -548,6 +738,29 @@ def test_append_deck_later_layout_ambiguity_refuses_before_any_slide_is_added():
     assert_changed_parts(before, save_to_bytes(dest))  # -- empty budget
 
 
+def test_append_deck_later_placeholder_ambiguity_refuses_before_any_slide_is_added():
+    dest = _open(ALPHA)
+    source = _open(BETA)
+    target = dest.slide_layouts[1]
+    _duplicate_content_slot(target, 2)
+    _set_content_slots(
+        target,
+        [(PP_PLACEHOLDER.OBJECT, 3), (PP_PLACEHOLDER.OBJECT, 2)],
+    )
+    before = save_to_bytes(dest)
+    slide_count = len(dest.slides)
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.append_deck(source, mode="adopt_theme"),
+        AmbiguousTargetError,
+    )
+
+    assert "placeholder_map" in str(error)
+    assert len(dest.slides) == slide_count
+    assert_changed_parts(before, save_to_bytes(dest))
+
+
 # ------------------------------------------------------------------------------- refusals
 
 
@@ -614,6 +827,15 @@ def test_import_report_matches_frozen_golden():
     actual = (json.dumps(report.to_dict(), indent=2, ensure_ascii=False) + "\n").encode("utf-8")
     golden_path = corpus.FIXTURES_DIR.parent / "goldens" / "import_beta_keep.import.json"
     assert actual == golden_path.read_bytes()
+
+
+@pytest.mark.parametrize("mode", ["keep_appearance", "bake"])
+def test_non_reconciling_reports_always_serialize_empty_placeholder_map(mode):
+    report = _open(ALPHA).import_slide(_open(BETA), 0, mode=mode)
+
+    assert report.placeholder_map_used == ()
+    assert report.to_dict()["placeholder_map_used"] == []
+    assert report.to_dict()["version"] == 2
 
 
 def test_import_report_is_deterministic_across_runs():

--- a/tests/paper/test_rebind.py
+++ b/tests/paper/test_rebind.py
@@ -16,7 +16,8 @@ import pytest
 from lxml import etree
 
 from pptx import Presentation
-from pptx.errors import PaperRefusal, UnsupportedStructureError
+from pptx.enum.shapes import PP_PLACEHOLDER
+from pptx.errors import AmbiguousTargetError, PaperRefusal, UnsupportedStructureError
 from pptx.util import Emu
 
 from . import corpus
@@ -36,6 +37,17 @@ BETA = "self_generated/template_beta.pptx"
 
 def _open(relpath):
     return Presentation(str(corpus.fixture_path(relpath)))
+
+
+def _set_target_content_slots(target, slots):
+    placeholders = sorted(
+        (ph for ph in target.placeholders if ph.element.ph_type == PP_PLACEHOLDER.OBJECT),
+        key=lambda ph: ph.element.ph_idx,
+    )
+    assert len(placeholders) == len(slots)
+    for placeholder, (ph_type, idx) in zip(placeholders, slots):
+        placeholder.element.ph.type = ph_type
+        placeholder.element.ph.idx = idx
 
 
 # ------------------------------------------------------------------------------- happy path
@@ -106,12 +118,48 @@ def test_family_matching_rewrites_placeholder_type_and_idx():
     assert reopened.slides[0].slide_layout.name == "Title and Content"
 
 
+@pytest.mark.parametrize(
+    ("layout_idx", "target_type", "target_type_name"),
+    [
+        (7, PP_PLACEHOLDER.OBJECT, "OBJECT"),
+        (2, PP_PLACEHOLDER.BODY, "BODY"),
+    ],
+)
+def test_unique_same_type_and_family_fallbacks_persist(
+    layout_idx, target_type, target_type_name
+):
+    prs = _open(GAUNTLET)
+    target = prs.slide_layouts[layout_idx]
+    slot = next(ph for ph in target.placeholders if ph.element.ph_idx == 1)
+    slot.element.ph.type = target_type
+    slot.element.ph.idx = 9
+    before = save_to_bytes(prs)
+
+    report = prs.slides[0].rebind_layout(target)
+
+    assert report.placeholder_map_used == ((0, 0), (1, 9))
+    after = save_to_bytes(prs)
+    assert_changed_parts(
+        before,
+        after,
+        expect_changed=["ppt/slides/_rels/slide1.xml.rels", "ppt/slides/slide1.xml"],
+    )
+    reopened = Presentation(io.BytesIO(after))
+    rebound = next(
+        shape for shape in reopened.slides[0].shapes if shape.name == "Content Placeholder 2"
+    )
+    assert rebound.element.ph_idx == 9
+    assert rebound.element.ph_type.name == target_type_name
+
+
 def test_rebind_report_is_deterministic():
     prs_a = _open(GAUNTLET)
     prs_b = _open(GAUNTLET)
     report_a = prs_a.slides[0].rebind_layout(prs_a.slide_layouts[3]).to_dict()
     report_b = prs_b.slides[0].rebind_layout(prs_b.slide_layouts[3]).to_dict()
     assert report_a == report_b
+    assert report_a["schema"] == "paper-rebind-report"
+    assert report_a["version"] == 1
 
 
 def test_rebind_report_run_indices_include_hard_line_breaks():
@@ -247,6 +295,119 @@ def test_post_mutation_report_failure_rolls_rebind_back(monkeypatch):
 
 
 # --------------------------------------------------------------------------- explicit map
+
+
+def test_ambiguous_same_type_fallback_refuses_atomically_and_lists_every_candidate():
+    prs = _open(GAUNTLET)
+    _set_target_content_slots(
+        prs.slide_layouts[3],
+        [(PP_PLACEHOLDER.OBJECT, 3), (PP_PLACEHOLDER.OBJECT, 2)],
+    )
+    before = save_to_bytes(prs)
+
+    raised = assert_refusal_atomic(
+        prs,
+        lambda p: p.slides[0].rebind_layout(p.slide_layouts[3]),
+        AmbiguousTargetError,
+    )
+
+    message = str(raised)
+    assert "type OBJECT, idx 1" in message
+    assert "same-type fallback" in message
+    assert message.index("type OBJECT, idx 2") < message.index("type OBJECT, idx 3")
+    assert "placeholder_map" in message
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+def test_ambiguous_family_fallback_refuses_without_falling_through():
+    prs = _open(GAUNTLET)
+    _set_target_content_slots(
+        prs.slide_layouts[3],
+        [(PP_PLACEHOLDER.BODY, 3), (PP_PLACEHOLDER.BODY, 2)],
+    )
+    before = save_to_bytes(prs)
+
+    raised = assert_refusal_atomic(
+        prs,
+        lambda p: p.slides[0].rebind_layout(p.slide_layouts[3]),
+        AmbiguousTargetError,
+    )
+
+    message = str(raised)
+    assert "type OBJECT, idx 1" in message
+    assert "compatible-family fallback" in message
+    assert "type BODY, idx 2" in message
+    assert "type BODY, idx 3" in message
+    assert "placeholder_map" in message
+    assert_changed_parts(before, save_to_bytes(prs))
+
+
+def test_placeholder_ambiguity_diagnostic_is_independent_of_layout_traversal_order():
+    def diagnostic(reorder):
+        prs = _open(GAUNTLET)
+        target = prs.slide_layouts[3]
+        _set_target_content_slots(
+            target,
+            [(PP_PLACEHOLDER.OBJECT, 3), (PP_PLACEHOLDER.OBJECT, 2)],
+        )
+        if reorder:
+            first = next(ph for ph in target.placeholders if ph.element.ph_idx == 3)
+            second = next(ph for ph in target.placeholders if ph.element.ph_idx == 2)
+            second._element.addnext(first._element)
+        before = save_to_bytes(prs)
+        message = str(
+            assert_refusal_atomic(
+                prs,
+                lambda p: p.slides[0].rebind_layout(p.slide_layouts[3]),
+                AmbiguousTargetError,
+            )
+        )
+        assert_changed_parts(before, save_to_bytes(prs))
+        return message
+
+    assert diagnostic(reorder=False) == diagnostic(reorder=True)
+
+
+@pytest.mark.parametrize("target_type", [PP_PLACEHOLDER.OBJECT, PP_PLACEHOLDER.BODY])
+def test_partial_explicit_map_disambiguates_and_auto_completes_exact_matches(target_type):
+    prs = _open(GAUNTLET)
+    _set_target_content_slots(
+        prs.slide_layouts[3],
+        [(target_type, 3), (target_type, 2)],
+    )
+
+    report = prs.slides[0].rebind_layout(
+        prs.slide_layouts[3], placeholder_map={1: 2}
+    )
+
+    assert report.placeholder_map_used == ((0, 0), (1, 2))
+    reopened = save_reopen(prs)
+    assert {
+        shape.element.ph_idx for shape in reopened.slides[0].shapes if shape.is_placeholder
+    } == {0, 2}
+
+
+def test_explicit_none_deliberately_orphans_under_refuse_and_bake_policies():
+    refusing = _open(GAUNTLET)
+    raised = assert_refusal_atomic(
+        refusing,
+        lambda p: p.slides[0].rebind_layout(
+            p.slide_layouts[3], placeholder_map={1: None}
+        ),
+        UnsupportedStructureError,
+    )
+    assert "orphan_policy" in str(raised)
+
+    baking = _open(GAUNTLET)
+    report = baking.slides[0].rebind_layout(
+        baking.slide_layouts[3], placeholder_map={1: None}, orphan_policy="bake"
+    )
+    assert report.placeholder_map_used == ((0, 0), (1, None))
+    reopened = save_reopen(baking)
+    baked = next(
+        shape for shape in reopened.slides[0].shapes if shape.name == "Content Placeholder 2"
+    )
+    assert not baked.is_placeholder
 
 
 def test_explicit_map_overrides_auto():


### PR DESCRIPTION
## Summary

- require uniqueness in placeholder fallback tiers while preserving exact type/index matching
- expose placeholder_map through adopt-theme import
- record the resolved mapping in import-report schema v2

## Finding

LS-03 — placeholder rebind selected the first compatible fallback.

## Stack

- Root: #38
- Base: #41
- This PR: #42
- Next: #43

## Verification

Focused and full pytest, Behave, LibreOffice, documentation, distribution, and Python 3.9–3.13 CI pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes placeholder matching for rebind and adopt-theme import, so previously successful auto-matches can now refuse. Also bumps the import-report schema, which can break consumers of the JSON payload.
> 
> **Overview**
> Stops layout rebind and adopt-theme import from silently picking the first same-type or family fallback. Those tiers now bind only when exactly one unclaimed target remains; multiple candidates raise `AmbiguousTargetError` before mutation.
> 
> `import_slide(..., mode="adopt_theme")` accepts a partial `placeholder_map` (including `None` to orphan/bake a source). Keep-appearance, bake, and `append_deck` stay automatic-only. Import reports bump to schema v2 and always include `placeholder_map_used`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef73936239241400dc12b3da0c2a6baa05966449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->