### PR TITLE
fix: select import sections by stable identity

### DIFF
--- a/docs/api/compose.rst
+++ b/docs/api/compose.rst
@@ -32,10 +32,20 @@ automatically. ``None`` deliberately orphans that source placeholder, which adop
 its source-resolved appearance. The argument is rejected for keep-appearance and bake. Whole-deck
 append deliberately remains automatic-only and refuses atomically if any staged slide needs a map.
 
-``paper-import-report`` version 2 always serializes ``placeholder_map_used``. Adopt-theme reports
-the complete resolved source-to-target mapping, including ``null`` orphan targets, in source-index
-order. Keep-appearance and bake serialize an empty list because they do not reconcile
-placeholders.
+An explicit ``section`` selector matches existing destination section names exactly and succeeds
+only when the name is unique. If duplicate names exist, import raises |AmbiguousTargetError|
+before writing and lists every candidate's exact GUID and section-list order; pass ``section_id``
+to select one by its exact stored ``p14:section/@id`` value. ``section`` and ``section_id`` are
+mutually exclusive, missing matches raise |TargetNotFoundError|, and IDs are not case-folded or
+brace-normalized. With neither selector, import retains adjacent enrollment: it follows the slide
+preceding the insertion point, falling back to the first destination section when no predecessor
+is enrolled. This is import targeting only; it does not expose section authoring or management.
+
+``paper-import-report`` version 3 always serializes the actual enrolled ``section`` name and
+``section_id``, using ``null`` for both when the destination has no sections. It retains version
+2's fixed ``placeholder_map_used`` representation unchanged: adopt-theme reports the complete
+resolved source-to-target mapping, including ``null`` orphan targets, in source-index order, while
+keep-appearance and bake serialize an empty list because they do not reconcile placeholders.
 
 The source presentation remains unchanged. Charts travel with their embedded workbooks, media is
 always copied across packages, and relationships that cannot be resolved refuse

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -260,8 +260,19 @@ partial ``placeholder_map`` to :meth:`~pptx.presentation.Presentation.import_sli
 same-type or compatible-family tier is ambiguous; a ``None`` target deliberately bakes that
 source placeholder. Keep-appearance and bake reject the argument because they do not reconcile
 placeholder bindings. :meth:`~pptx.presentation.Presentation.append_deck` remains automatic-only
-and atomically refuses if any staged slide needs an explicit map. ``paper-import-report`` version
-2 always records ``placeholder_map_used``; non-reconciling modes use an empty list.
+and atomically refuses if any staged slide needs an explicit map.
+
+Section targeting is exact and conservative. ``section="Name"`` enrolls only when that destination
+name is unique; duplicate names raise |AmbiguousTargetError| with every candidate GUID and deck
+order. Pass the mutually exclusive ``section_id="{...}"`` selector to choose the intended section
+by its exact stored GUID. Missing exact names or IDs raise |TargetNotFoundError|, and IDs are never
+case-folded or brace-normalized. With neither selector, import keeps its adjacent-section behavior,
+following the slide before the insertion point and otherwise using the first destination section.
+This does not add general section authoring APIs.
+
+``paper-import-report`` version 3 always records the actual enrolled ``section`` and
+``section_id`` (or ``null`` for both). It preserves version 2's ``placeholder_map_used`` shape
+exactly; non-reconciling modes still use an empty list.
 
 **Send-safe delivery.** Stripping speaker notes, review comments, and authorship before a deck
 leaves the building needs no dedicated API: a part leaves the package by becoming unreachable, and

--- a/src/pptx/compose.py
+++ b/src/pptx/compose.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from pptx.slide import Slide, SlideLayout
 
 SCHEMA_NAME = "paper-import-report"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 class _ComposeTransaction(PackageTransaction):
@@ -114,7 +114,8 @@ class ImportReport:
       content-hash deduplication (keep_appearance).
     * ``notes_copied`` -- whether the source slide's speaker-notes part was imported.
     * ``comments_dropped`` -- count of comment parts dropped (comments never travel).
-    * ``section`` -- name of the destination section the slide was enrolled in, or None.
+    * ``section`` / ``section_id`` -- name and exact GUID of the destination section the
+      slide was enrolled in, or None when it was not enrolled in a section.
     * ``baked_shapes`` -- names of placeholders converted to free baked shapes.
     * ``dropped_placeholders`` -- names of furniture placeholders (dt/ftr/sldNum)
       removed under "bake".
@@ -136,6 +137,7 @@ class ImportReport:
     notes_copied: bool
     comments_dropped: int
     section: Optional[str]
+    section_id: Optional[str]
     baked_shapes: Tuple[str, ...]
     dropped_placeholders: Tuple[str, ...]
     run_shifts: tuple
@@ -161,6 +163,7 @@ class ImportReport:
             "notes_copied": self.notes_copied,
             "comments_dropped": self.comments_dropped,
             "section": self.section,
+            "section_id": self.section_id,
             "baked_shapes": list(self.baked_shapes),
             "dropped_placeholders": list(self.dropped_placeholders),
             "run_shifts": [shift.to_dict() for shift in self.run_shifts],
@@ -179,11 +182,12 @@ def import_slide(
     position: "Optional[int]" = None,
     notes: bool = True,
     section: "Optional[str]" = None,
+    section_id: "Optional[str]" = None,
     target_layout: "Optional[SlideLayout]" = None,
     placeholder_map="auto",
 ) -> ImportReport:
     """Import one slide from `source_prs` into `dest_prs`; return the |ImportReport|."""
-    source_slide = _validate_arguments(
+    source_slide, resolved_section = _validate_arguments(
         dest_prs,
         source_prs,
         slide,
@@ -191,6 +195,7 @@ def import_slide(
         position,
         notes,
         section,
+        section_id,
         target_layout,
         placeholder_map,
     )
@@ -199,7 +204,15 @@ def import_slide(
     prep = _validate_mode_preparation(source_slide, mode, binding, placeholder_map)
     with _ComposeTransaction(dest_prs):
         return _perform_import(
-            dest_prs, source_slide, plan, mode, binding, prep, position, notes, section
+            dest_prs,
+            source_slide,
+            plan,
+            mode,
+            binding,
+            prep,
+            position,
+            notes,
+            resolved_section,
         )
 
 
@@ -222,8 +235,8 @@ def append_deck(
         raise ValueError("source_prs must be a Presentation, got %r" % (source_prs,))
     staged = []
     for source_slide in materialize_slides(source_prs, "append_deck"):
-        source_slide = _validate_arguments(
-            dest_prs, source_prs, source_slide, mode, None, notes, None, None, "auto"
+        source_slide, _ = _validate_arguments(
+            dest_prs, source_prs, source_slide, mode, None, notes, None, None, None, "auto"
         )
         plan = _validated_transplant_plan(source_slide.part, notes)
         binding = _resolve_layout_binding(dest_prs, source_slide, mode, None)
@@ -252,10 +265,11 @@ def _validate_arguments(
     position,
     notes,
     section,
+    section_id,
     target_layout,
     placeholder_map,
-) -> "Slide":
-    """Check the import arguments and return the resolved source slide.
+) -> "Tuple[Slide, object]":
+    """Check import arguments and return the source slide and resolved explicit section.
 
     Runs before any part is copied, so a bad call cannot leave the destination half-imported.
     """
@@ -306,11 +320,7 @@ def _validate_arguments(
         )
     if not isinstance(notes, bool):
         raise ValueError("notes must be True or False")
-    if section is not None:
-        if not isinstance(section, str):
-            raise ValueError("section must be a str section name or None")
-        if _find_section(dest_prs._element, section) is None:
-            raise TargetNotFoundError("destination has no section named %r" % (section,))
+    resolved_section = _resolve_explicit_section(dest_prs._element, section, section_id)
     if target_layout is not None:
         if mode == "keep_appearance":
             raise ValueError(
@@ -332,7 +342,7 @@ def _validate_arguments(
             "to placeholder reconciliation and baking - import it with "
             "mode='keep_appearance' (opaque transplant) instead"
         )
-    return slide
+    return slide, resolved_section
 
 
 def _validated_transplant_plan(source_part, notes: bool):
@@ -633,7 +643,7 @@ def _resolve_layout_binding(dest_prs, source_slide, mode, target_layout) -> _Lay
 
 
 def _perform_import(
-    dest_prs, source_slide, plan, mode, binding, prep, position, notes, section
+    dest_prs, source_slide, plan, mode, binding, prep, position, notes, resolved_section
 ) -> ImportReport:
     """Copy the source slide into the destination and report what changed."""
     from pptx.parts.slide import SlidePart
@@ -713,7 +723,9 @@ def _perform_import(
         sldIdLst.sldId_lst[final_position].addprevious(sldId)
     new_slide_id = int(sldId.get("id"))
 
-    enrolled_section = _enroll_in_section(dest_prs._element, new_slide_id, final_position, section)
+    enrolled_section = _enroll_in_section(
+        dest_prs._element, new_slide_id, final_position, resolved_section
+    )
 
     # -- report ----------------------------------------------------------------------------
     after_state = _resolution_state(new_slide_part.slide)
@@ -737,7 +749,8 @@ def _perform_import(
         parts_reused=tuple(sorted(set(reused))),
         notes_copied=notes_copied,
         comments_dropped=comments_dropped,
-        section=enrolled_section,
+        section=enrolled_section.get("name") if enrolled_section is not None else None,
+        section_id=enrolled_section.get("id") if enrolled_section is not None else None,
         baked_shapes=tuple(baked_names),
         dropped_placeholders=tuple(dropped_names),
         run_shifts=shifts,
@@ -1110,32 +1123,64 @@ def _next_layout_or_master_id(dest_prs) -> int:
 # ---------------------------------------------------------------------------- sections
 
 
-def _find_section(presentation_elm, name: str):
-    """The `p14:section` named `name`, or None when the deck has no section by that name."""
-    for section in presentation_elm.findall(".//{%s}sectionLst/{%s}section" % (_P14_NS, _P14_NS)):
-        if section.get("name") == name:
-            return section
-    return None
+def _resolve_explicit_section(presentation_elm, name, section_id):
+    """Resolve one exact explicit section selector before import mutation, or refuse."""
+    if name is not None and not isinstance(name, str):
+        raise ValueError("section must be a str section name or None")
+    if section_id is not None and not isinstance(section_id, str):
+        raise ValueError("section_id must be a str section id or None")
+    if name is not None and section_id is not None:
+        raise ValueError("section and section_id are mutually exclusive")
+    if name is None and section_id is None:
+        return None
+
+    sections = presentation_elm.findall(".//{%s}sectionLst/{%s}section" % (_P14_NS, _P14_NS))
+    attribute, value = ("name", name) if name is not None else ("id", section_id)
+    matches = [
+        (order, section)
+        for order, section in enumerate(sections)
+        if section.get(attribute) == value
+    ]
+    if not matches:
+        if name is not None:
+            raise TargetNotFoundError("destination has no section named %r" % (name,))
+        raise TargetNotFoundError("destination has no section with id %r" % (section_id,))
+    if len(matches) > 1:
+        if name is not None:
+            details = "; ".join(
+                "order=%d, id=%r" % (order, section.get("id"))
+                for order, section in matches
+            )
+            raise AmbiguousTargetError(
+                "destination section name %r is ambiguous; candidates: %s; pass section_id= "
+                "explicitly" % (name, details)
+            )
+        details = "; ".join(
+            "order=%d, name=%r, id=%r"
+            % (order, section.get("name"), section.get("id"))
+            for order, section in matches
+        )
+        raise AmbiguousTargetError(
+            "destination section id %r is ambiguous; candidates: %s; pass section= with a "
+            "unique exact name" % (section_id, details)
+        )
+    return matches[0][1]
 
 
-def _enroll_in_section(presentation_elm, new_slide_id, final_position, section_name):
-    """Enroll the imported slide: named section, or adjacent to the insertion point.
-
-    Returns the name of the section actually enrolled in (None when the destination has
-    no sections) so the report can carry the real disposition, not the argument.
-    """
+def _enroll_in_section(presentation_elm, new_slide_id, final_position, explicit_section):
+    """Enroll in the resolved explicit section or by unchanged adjacent placement."""
     sections = presentation_elm.findall(".//{%s}sectionLst/{%s}section" % (_P14_NS, _P14_NS))
     if not sections:
         return None
-    if section_name is not None:
-        section = _find_section(presentation_elm, section_name)
+    if explicit_section is not None:
+        section = explicit_section
         sldIdLst = section.find("{%s}sldIdLst" % _P14_NS)
         if sldIdLst is None:
             sldIdLst = section.makeelement("{%s}sldIdLst" % _P14_NS, {})
             section.insert(0, sldIdLst)
         entry = sldIdLst.makeelement("{%s}sldId" % _P14_NS, {"id": str(new_slide_id)})
         sldIdLst.append(entry)
-        return section_name
+        return section
     # -- adjacent enrollment: after the preceding slide's entry; first section if none
     P = "{http://schemas.openxmlformats.org/presentationml/2006/main}"
     deck_sldIds = presentation_elm.findall(".//%ssldIdLst/%ssldId" % (P, P))
@@ -1148,11 +1193,11 @@ def _enroll_in_section(presentation_elm, new_slide_id, final_position, section_n
                 if entry.get("id") == preceding_id:
                     new_entry = entry.makeelement("{%s}sldId" % _P14_NS, {"id": str(new_slide_id)})
                     entry.addnext(new_entry)
-                    return section.get("name")
+                    return section
     first_sldIdLst = sections[0].find("{%s}sldIdLst" % _P14_NS)
     if first_sldIdLst is None:
         first_sldIdLst = sections[0].makeelement("{%s}sldIdLst" % _P14_NS, {})
         sections[0].insert(0, first_sldIdLst)
     entry = first_sldIdLst.makeelement("{%s}sldId" % _P14_NS, {"id": str(new_slide_id)})
     first_sldIdLst.insert(0, entry)
-    return sections[0].get("name")
+    return sections[0]

--- a/src/pptx/presentation.py
+++ b/src/pptx/presentation.py
@@ -149,6 +149,7 @@ class Presentation(PartElementProxy):
         position: int | None = None,
         notes: bool = True,
         section: str | None = None,
+        section_id: str | None = None,
         target_layout=None,
         placeholder_map="auto",
     ) -> "ImportReport":
@@ -175,8 +176,12 @@ class Presentation(PartElementProxy):
         comments drop (reported); OLE objects, controls, internal slide links, and
         unknown relationship types refuse (`RelationshipPolicyError`) before any write.
         `notes` copies the speaker-notes part re-linked to this deck's notes master.
-        `section` names an existing destination section to enroll in; None enrolls
-        adjacent to the insertion point when this deck has sections.
+        `section` selects an existing destination section by unique exact name;
+        `section_id` selects by exact stored GUID when names collide. They are mutually
+        exclusive. With neither selector, enrollment remains adjacent to the insertion
+        point when this deck has sections. Missing selectors raise
+        |TargetNotFoundError| and duplicate matches raise |AmbiguousTargetError| before
+        any write.
         Multiple candidates at any automatic layout tier raise |AmbiguousTargetError|
         before any write and list the layouts; pass an enrolled destination
         `target_layout` to resolve that choice explicitly.
@@ -196,6 +201,7 @@ class Presentation(PartElementProxy):
             position=position,
             notes=notes,
             section=section,
+            section_id=section_id,
             target_layout=target_layout,
             placeholder_map=placeholder_map,
         )

--- a/tests/paper/goldens/import_beta_keep.import.json
+++ b/tests/paper/goldens/import_beta_keep.import.json
@@ -1,6 +1,6 @@
 {
   "schema": "paper-import-report",
-  "version": 2,
+  "version": 3,
   "mode": "keep_appearance",
   "source_slide": "/ppt/slides/slide1.xml",
   "dest_slide": "/ppt/slides/slide4.xml",
@@ -19,6 +19,7 @@
   "notes_copied": false,
   "comments_dropped": 0,
   "section": null,
+  "section_id": null,
   "baked_shapes": [],
   "dropped_placeholders": [],
   "run_shifts": []

--- a/tests/paper/test_import.py
+++ b/tests/paper/test_import.py
@@ -59,10 +59,28 @@ BETA = "self_generated/template_beta.pptx"
 LO_ALPHA = "libreoffice_export/lo_template_alpha.pptx"
 SECTIONS = "self_generated/sections.pptx"
 GAUNTLET = "self_generated/gauntlet.pptx"
+P14 = "http://schemas.microsoft.com/office/powerpoint/2010/main"
+SECTION_IDS = {
+    "Intro": "{11111111-1111-4111-8111-111111111111}",
+    "Body": "{22222222-2222-4222-8222-222222222222}",
+    "Close": "{33333333-3333-4333-8333-333333333333}",
+}
 
 
 def _open(relpath):
     return Presentation(str(corpus.fixture_path(relpath)))
+
+
+def _sections(prs):
+    return prs._element.findall(".//{%s}sectionLst/{%s}section" % (P14, P14))
+
+
+def _section_by_id(prs, section_id):
+    return next(section for section in _sections(prs) if section.get("id") == section_id)
+
+
+def _section_slide_ids(section):
+    return [int(entry.get("id")) for entry in section.findall(".//{%s}sldId" % P14)]
 
 
 def _set_content_slots(layout, slots):
@@ -649,41 +667,176 @@ def test_position_inserts_at_index():
     assert len(reopened.slides) == 4
 
 
-def test_section_enrollment_named_and_adjacent():
+def test_unique_named_section_enrollment_persists_and_reports_identity():
     dest = _open(SECTIONS)
     source = _open(BETA)
+    source_before = zip_member_map(save_to_bytes(source))
+    before = save_to_bytes(dest)
+
     report = dest.import_slide(source, 0, mode="adopt_theme", section="Close")
+
     assert report.section == "Close"
-    saved = save_to_bytes(dest)
-    _assert_clean(saved)  # -- the id-list scan proves every section id resolves
+    assert report.section_id == SECTION_IDS["Close"]
+    after = save_to_bytes(dest)
+    assert_changed_parts(
+        before,
+        after,
+        expect_added=["ppt/slides/_rels/slide6.xml.rels", "ppt/slides/slide6.xml"],
+        expect_changed=[
+            "[Content_Types].xml",
+            "ppt/_rels/presentation.xml.rels",
+            "ppt/presentation.xml",
+        ],
+    )
+    _assert_clean(after)
+    reopened = Presentation(io.BytesIO(after))
+    close_ids = _section_slide_ids(_section_by_id(reopened, SECTION_IDS["Close"]))
+    assert close_ids[-1] == report.dest_slide_id
+    assert reopened.slides[-1].shapes.title.text_frame.text == "Beta Overview"
+    assert zip_member_map(save_to_bytes(source)) == source_before
+
+
+def test_exact_section_id_selects_intended_duplicate_name_and_persists():
+    dest = _open(SECTIONS)
+    source = _open(BETA)
+    _sections(dest)[1].set("name", "Close")
+
+    report = dest.import_slide(
+        source, 0, mode="adopt_theme", section_id=SECTION_IDS["Close"]
+    )
+
+    assert report.section == "Close"
+    assert report.section_id == SECTION_IDS["Close"]
+    reopened = save_reopen(dest)
+    selected = _section_by_id(reopened, SECTION_IDS["Close"])
+    other = _section_by_id(reopened, SECTION_IDS["Body"])
+    assert _section_slide_ids(selected)[-1] == report.dest_slide_id
+    assert report.dest_slide_id not in _section_slide_ids(other)
+    assert reopened.slides[-1].shapes.title.text_frame.text == "Beta Overview"
+    _assert_clean(save_to_bytes(dest))
+
+
+def test_duplicate_section_name_refuses_atomically_with_all_candidates():
+    dest = _open(SECTIONS)
+    _sections(dest)[1].set("name", "Close")
+    before = zip_member_map(save_to_bytes(dest))
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(_open(BETA), 0, mode="adopt_theme", section="Close"),
+        AmbiguousTargetError,
+    )
+
+    message = str(error)
+    assert "section_id" in message
+    assert "order=1, id=%r" % SECTION_IDS["Body"] in message
+    assert "order=2, id=%r" % SECTION_IDS["Close"] in message
+    assert zip_member_map(save_to_bytes(dest)) == before
+
+
+def test_duplicate_section_id_refuses_atomically_instead_of_selecting_first():
+    dest = _open(SECTIONS)
+    _sections(dest)[1].set("id", SECTION_IDS["Intro"])
+    before = zip_member_map(save_to_bytes(dest))
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(
+            _open(BETA), 0, mode="adopt_theme", section_id=SECTION_IDS["Intro"]
+        ),
+        AmbiguousTargetError,
+    )
+
+    message = str(error)
+    assert "section=" in message
+    assert "order=0, name='Intro', id=%r" % SECTION_IDS["Intro"] in message
+    assert "order=1, name='Body', id=%r" % SECTION_IDS["Intro"] in message
+    assert zip_member_map(save_to_bytes(dest)) == before
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"section": "No Such Section"},
+        {"section_id": "{99999999-9999-4999-8999-999999999999}"},
+        {"section_id": SECTION_IDS["Intro"].strip("{}")},
+    ],
+)
+def test_missing_or_nonexact_section_selector_refuses_atomically(selector):
+    dest = _open(SECTIONS)
+    before = zip_member_map(save_to_bytes(dest))
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(_open(BETA), 0, mode="adopt_theme", **selector),
+        TargetNotFoundError,
+    )
+
+    assert "section" in str(error)
+    assert zip_member_map(save_to_bytes(dest)) == before
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"section": 1},
+        {"section_id": 1},
+        {"section": "Intro", "section_id": SECTION_IDS["Intro"]},
+    ],
+)
+def test_section_selector_argument_errors_are_atomic(selector):
+    dest = _open(SECTIONS)
+    before = zip_member_map(save_to_bytes(dest))
+
+    error = assert_refusal_atomic(
+        dest,
+        lambda prs: prs.import_slide(_open(BETA), 0, mode="adopt_theme", **selector),
+        ValueError,
+    )
+
+    assert "section" in str(error)
+    assert zip_member_map(save_to_bytes(dest)) == before
+
+
+def test_implicit_section_enrollment_remains_adjacent_and_reports_identity():
+    dest = _open(SECTIONS)
+    source = _open(BETA)
 
     # -- adjacent enrollment: inserting at position 1 lands in "Intro" (slide 1's
     # -- section), DIRECTLY AFTER slide 1's entry, and the report says which section
-    dest2 = _open(SECTIONS)
-    report2 = dest2.import_slide(source, 0, mode="adopt_theme", position=1)
-    assert report2.section == "Intro"  # -- actual enrollment, not the (None) argument
-    saved2 = save_to_bytes(dest2)
-    _assert_clean(saved2)
-    from lxml import etree
-
-    presentation = etree.fromstring(zip_member_map(saved2)["ppt/presentation.xml"])
-    P14 = "http://schemas.microsoft.com/office/powerpoint/2010/main"
-    intro = next(
-        s for s in presentation.findall(".//{%s}section" % P14) if s.get("name") == "Intro"
-    )
-    intro_ids = [e.get("id") for e in intro.findall(".//{%s}sldId" % P14)]
-    P = "http://schemas.openxmlformats.org/presentationml/2006/main"
-    deck_ids = [e.get("id") for e in presentation.findall(".//{%s}sldIdLst/{%s}sldId" % (P, P))]
+    report = dest.import_slide(source, 0, mode="adopt_theme", position=1)
+    assert report.section == "Intro"  # -- actual enrollment, not the (None) argument
+    assert report.section_id == SECTION_IDS["Intro"]
+    reopened = save_reopen(dest)
+    intro_ids = _section_slide_ids(_section_by_id(reopened, SECTION_IDS["Intro"]))
+    deck_ids = [slide.slide_id for slide in reopened.slides]
     # -- section order mirrors deck order: [slide 1's id, the imported slide's id]
     assert intro_ids == [deck_ids[0], deck_ids[1]]
+    _assert_clean(save_to_bytes(dest))
 
 
-def test_missing_section_refuses_atomically():
+def test_implicit_section_enrollment_keeps_first_section_fallback():
     dest = _open(SECTIONS)
-    before = save_to_bytes(dest)
-    with pytest.raises(TargetNotFoundError):
-        dest.import_slide(_open(BETA), 0, mode="adopt_theme", section="No Such Section")
-    assert_changed_parts(before, save_to_bytes(dest))  # -- empty budget
+    report = dest.import_slide(_open(BETA), 0, mode="adopt_theme", position=0)
+
+    assert report.section == "Intro"
+    assert report.section_id == SECTION_IDS["Intro"]
+    reopened = save_reopen(dest)
+    intro_ids = _section_slide_ids(_section_by_id(reopened, SECTION_IDS["Intro"]))
+    deck_ids = [slide.slide_id for slide in reopened.slides]
+    assert intro_ids[:2] == deck_ids[:2]
+    _assert_clean(save_to_bytes(dest))
+
+
+def test_import_without_destination_sections_reports_null_section_identity():
+    dest = _open(ALPHA)
+
+    report = dest.import_slide(_open(BETA), 0, mode="adopt_theme")
+
+    assert report.section is None
+    assert report.section_id is None
+    reopened = save_reopen(dest)
+    assert _sections(reopened) == []
 
 
 # --------------------------------------------------------------------------- append_deck
@@ -835,7 +988,9 @@ def test_non_reconciling_reports_always_serialize_empty_placeholder_map(mode):
 
     assert report.placeholder_map_used == ()
     assert report.to_dict()["placeholder_map_used"] == []
-    assert report.to_dict()["version"] == 2
+    assert report.to_dict()["version"] == 3
+    assert report.to_dict()["section"] is None
+    assert report.to_dict()["section_id"] is None
 
 
 def test_import_report_is_deterministic_across_runs():


### PR DESCRIPTION
## Summary

- resolve destination sections once by unique exact name or stable section GUID
- expose section_id as the explicit recovery path for duplicate names
- carry the resolved identity through enrollment and import-report schema v3

## Finding

LS-06 — duplicate section names were silently resolved by first match.

## Stack

- Root: #38
- Base: #42
- This PR: #43
- Next: #44

## Verification

Focused and full pytest, Behave, LibreOffice, documentation, distribution, and Python 3.9–3.13 CI pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes slide-import section targeting and the import-report schema. Duplicate-name behavior is now a refusal instead of first-match, which is the intended safety fix but is a breaking API/report change for callers that relied on the old silent match.
> 
> **Overview**
> Stops `import_slide` from silently picking the first destination section when names collide. Named targeting now requires a unique exact match; duplicate names raise `AmbiguousTargetError` with each candidate’s GUID and list order.
> 
> Adds mutually exclusive `section_id` to select by the exact stored `p14:section/@id` (no case-folding or brace-normalization). Missing selectors still raise `TargetNotFoundError` before any write. Implicit adjacent enrollment is unchanged.
> 
> `paper-import-report` is now version 3: it always records the enrolled `section` and `section_id` (or `null` when the deck has no sections).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e6db0587ca01838a9ca54c2a8c49d4736ee4ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->