### PR TITLE
fix: match deck diff shapes by stable identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ print(len(delta.slide_changes), "slides changed")
 
 ### Verify: prove what changed
 
-- **A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent slide ID, so a reorder reports as a move rather than a delete plus an add. `detail="text"` adds chart data, text, and notes; `detail="full"` adds per-run and bullet shifts.
+- **A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent slide ID and top-level shapes within them by slide-wide shape ID, so slide or shape z-order does not manufacture add/remove or facet changes. Schema v4 shape facets carry `{"shape_id": ..., "name": ...}` references. `detail="text"` adds chart data, text, and notes; `detail="full"` adds per-run and bullet shifts.
 - **Byte-minimal saves and a package oracle.** `pptx.package.patch_save()` writes semantically unchanged parts back with their original bytes, so a one-line edit diffs as a few parts rather than all of them, and `diff_package()` reports exactly which parts differ.
 
 ### Package intake and save
@@ -134,7 +134,7 @@ Converting a documented typed refusal into a correct operation is the sanctioned
 - **Table-cell effective values refuse** until the table-style resolution walk is built.
 - **Chart data replacement supports single-plot category charts.** XY, bubble, stock, surface, radar, 3-D, and multi-plot combos refuse.
 - **Bullet color is not resolved**, and bullet diffing needs `detail="full"` and skips table cells.
-- **`diff_decks` assumes lineage**, matching slides by permanent ID. It is not a visual diff.
+- **`diff_decks` assumes lineage**, matching slides by permanent ID and top-level shapes by slide-wide shape ID. It is not a visual diff; group-boundary moves remain add/remove, and deleted IDs reused by new same-kind shapes cannot be distinguished without a persistent identifier general PPTX files do not carry.
 - **Fixture provenance.** The test corpus is generated and LibreOffice round-tripped, not authored by PowerPoint.
 
 Deliberate non-goals: no rendering or layout-geometry computation, no SmartArt authoring (opaque preservation only), and no animation or transition authoring.

--- a/docs/api/diff.rst
+++ b/docs/api/diff.rst
@@ -18,7 +18,27 @@ Contract tests compare operation reports with ``diff_decks(input, output)`` for 
 import, rebind, and refresh workflows.
 
 Matching uses the permanent slide id, which serves lineage-derived decks (v4 saved from v3).
-Independently built decks can reuse the same numeric ids and are outside that matching contract.
+Within a matched slide, top-level shapes match by their slide-wide ``shape_id`` and compatible
+structural kind. A shape's name is display metadata only: duplicate, empty, or renamed shapes keep
+their identity, and changing z-order alone produces no specialized shape addition, removal,
+geometry, image, or chart entry. The real XML-order change remains available in
+``package_changes``.
+
+The top-level boundary is deliberate. Moving a leaf into a group reports a removal; moving one out
+reports an addition. The diff does not recursively rescue that association. Independently built
+decks can reuse numeric ids and are outside the lineage contract. Deleting a shape and later
+reusing its id for a new shape of the same structural kind is also indistinguishable without a
+persistent identifier that general PPTX files do not provide.
+
+``paper-deck-diff`` schema version 4 uses one structured shape reference everywhere. Entries in
+``shapes_added``, ``shapes_removed``, and ``images_replaced`` are
+``{"shape_id": ..., "name": ...}``; the ``shape`` value in ``geometry_changes`` and the ``chart``
+value in ``chart_data_changes`` use that same structure. Additions use the after-side name,
+removals use the before-side name, and matched facets use the after/current name. Consumers
+migrating from version 3 should compare ``entry["shape_id"]`` (or
+``entry["shape"]["shape_id"]`` / ``entry["chart"]["shape_id"]``) rather than the former string
+label. A rename alone remains observable through ``package_changes`` and does not manufacture a
+specialized shape change.
 
 .. currentmodule:: pptx.diff
 
@@ -30,6 +50,11 @@ Independently built decks can reuse the same numeric ids and are outside that ma
    :member-order: bysource
 
 .. autoclass:: SlideChange()
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
+.. autoclass:: ShapeRef()
    :members:
    :undoc-members:
    :member-order: bysource

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -306,6 +306,20 @@ Verify what changed
 reorder is reported as a move rather than delete-plus-add), and within matched slides the shape,
 chart-data, image, and notes deltas. At ``detail="full"``, it also reports per-run
 effective-value shifts.
+Within each lineage-matched slide, top-level shapes match by slide-wide shape ID and compatible
+structural kind; display names and z-order are not identity. Duplicate, empty, or renamed names
+therefore do not create fictional shape changes. Moving a leaf across a group boundary retains the
+top-level interpretation: into a group is a removal and out of a group is an addition.
+
+Deck-diff schema version 4 represents shape additions, removals, image replacements, and the
+``shape``/``chart`` values of geometry and chart changes as
+``{"shape_id": ..., "name": ...}``. Version-3 consumers that compared string labels should compare
+the nested ``shape_id`` instead and use ``name`` only for display. Additions use the after-side
+name, removals the before-side name, and matched facets the after/current name. A rename or z-order
+change alone remains visible in ``package_changes``. Shape IDs are a lineage identity, not visual
+matching: independently authored decks are out of scope, and deleting a shape then reusing its ID
+for a new same-kind shape cannot be detected without a persistent identifier general PPTX files do
+not carry.
 Callers can use the result to check a session's changes. Release job evaluations compare the
 operation report with ``diff_decks(input, output)`` for every import/rebind/refresh job and
 require them to agree.

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -6,12 +6,14 @@ provides it as a typed report beside the file - the deck-format analogue of a
 redline - assembled from the permanent slide ids, the visibility-complete text layer,
 the effective-value resolver, and the kernel's semantic XML comparison.
 
-The matching contract, declared honestly: slides match by their PERMANENT slide id,
-which serves lineage-derived decks (v4 saved from v3 - the actual use case). Independently
-built decks can reuse the same numeric ids, so unrelated decks are outside this matching
-contract. One documented hazard: deleting the max-id slide then adding a new one recycles
-the id (upstream allocates max+1), which id-based matching reads as one edited slide -
-order add-before-delete when building lineage.
+The matching contract, declared honestly: slides match by their PERMANENT slide id and
+top-level shapes within them match by slide-wide shape id, which serves lineage-derived
+decks (v4 saved from v3 - the actual use case). Independently built decks can reuse the
+same numeric ids, so unrelated decks are outside this matching contract. Deleting an id
+and reusing it for a new same-kind object is likewise indistinguishable. One documented
+hazard: deleting the max-id slide then adding a new one recycles the id (upstream allocates
+max+1), which id-based matching reads as one edited slide - order add-before-delete when
+building lineage.
 
 Report-only: no annotated-copy rendering, no visual diffing, no similarity scoring -
 those are harness products built ON this report.
@@ -26,7 +28,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 SCHEMA_NAME = "paper-deck-diff"
-SCHEMA_VERSION = 3  # -- was 2: bullet_shifts added
+SCHEMA_VERSION = 4  # -- was 3: shape facets use stable structured references
 
 _DETAIL_LEVELS = ("structure", "text", "full")
 
@@ -86,6 +88,18 @@ class SlideRef:
 
 
 @dataclass(frozen=True)
+class ShapeRef:
+    """Identifies a slide-scoped shape by stable id and display name."""
+
+    shape_id: int
+    name: str
+
+    def to_dict(self) -> dict:
+        """Return this shape reference as a JSON-ready dict."""
+        return {"shape_id": self.shape_id, "name": self.name}
+
+
+@dataclass(frozen=True)
 class MovedSlide:
     """A slide that kept its identity and changed position."""
     slide_id: int
@@ -107,10 +121,10 @@ class SlideChange:
     from the payload, so an all-empty change never appears in `slide_changes`."""
 
     slide_id: int
-    shapes_added: Tuple[str, ...] = ()
-    shapes_removed: Tuple[str, ...] = ()
+    shapes_added: Tuple[ShapeRef, ...] = ()
+    shapes_removed: Tuple[ShapeRef, ...] = ()
     geometry_changes: Tuple[dict, ...] = ()
-    images_replaced: Tuple[str, ...] = ()
+    images_replaced: Tuple[ShapeRef, ...] = ()
     chart_data_changes: Tuple[dict, ...] = ()
     text_changes: Tuple[dict, ...] = ()
     notes_change: Optional[dict] = None
@@ -137,15 +151,19 @@ class SlideChange:
         """
         payload: dict = {"slide_id": self.slide_id}
         if self.shapes_added:
-            payload["shapes_added"] = list(self.shapes_added)
+            payload["shapes_added"] = [ref.to_dict() for ref in self.shapes_added]
         if self.shapes_removed:
-            payload["shapes_removed"] = list(self.shapes_removed)
+            payload["shapes_removed"] = [ref.to_dict() for ref in self.shapes_removed]
         if self.geometry_changes:
-            payload["geometry_changes"] = list(self.geometry_changes)
+            payload["geometry_changes"] = [
+                _shape_refs_to_dict(change) for change in self.geometry_changes
+            ]
         if self.images_replaced:
-            payload["images_replaced"] = list(self.images_replaced)
+            payload["images_replaced"] = [ref.to_dict() for ref in self.images_replaced]
         if self.chart_data_changes:
-            payload["chart_data_changes"] = list(self.chart_data_changes)
+            payload["chart_data_changes"] = [
+                _shape_refs_to_dict(change) for change in self.chart_data_changes
+            ]
         if self.text_changes:
             payload["text_changes"] = list(self.text_changes)
         if self.notes_change is not None:
@@ -155,6 +173,17 @@ class SlideChange:
         if self.bullet_shifts:
             payload["bullet_shifts"] = [s.to_dict() for s in self.bullet_shifts]
         return payload
+
+
+def _shape_refs_to_dict(value):
+    """Recursively replace |ShapeRef| values with JSON-ready dictionaries."""
+    if isinstance(value, ShapeRef):
+        return value.to_dict()
+    if isinstance(value, dict):
+        return {key: _shape_refs_to_dict(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_shape_refs_to_dict(item) for item in value]
+    return value
 
 
 @dataclass(frozen=True)
@@ -207,10 +236,13 @@ def diff_decks(path_a, path_b, *, detail: str = "structure") -> DeckDiff:
     to read; when both sides are a path or a file-like object, the packages are compared
     exactly.
 
-    Matching is by permanent slide id and is intended for lineage-derived decks.
-    Independently built decks can reuse ids and are outside this contract. One declared
-    hazard: slide ids allocate as max+1, so deleting the highest-id slide and then adding
-    a new one RECYCLES the id, and this diff will read that delete-plus-add as one edited
+    Matching is by permanent slide id and, within matched slides, top-level shapes match by
+    slide-wide shape id and compatible structural kind. Display names are labels only. Moving a
+    shape across a group boundary remains a top-level removal or addition. Independently built
+    decks can reuse ids and are outside this contract. A deleted shape id reused by a new
+    same-kind shape is likewise indistinguishable without a persistent identifier not present in
+    general PPTX files. Slide ids allocate as max+1, so deleting the highest-id slide and then
+    adding a new one RECYCLES the id, and this diff will read that delete-plus-add as one edited
     slide - order add-before-delete when producing lineage decks you intend to diff.
     """
     if detail not in _DETAIL_LEVELS:
@@ -451,34 +483,50 @@ def _title_of(slide) -> "Optional[str]":
 # ---------------------------------------------------------------------- within one slide
 
 
-def _shape_keys(slide) -> dict:
-    """Deterministic shape key map: unique name, else `<kind>#<ordinal>` (declared
-    fallback for unnamed shapes; duplicate names get the synthetic key too - honest
-    ambiguity handling rather than a guess)."""
+def _shape_kind(shape) -> str:
+    """Return the structural element kind used to decide shape compatibility."""
     from lxml import etree
 
-    shapes = list(slide.shapes)
-    names = [shape.name for shape in shapes]
-    keyed = {}
-    kind_counters: "Dict[str, int]" = {}
-    for shape, name in zip(shapes, names):
-        kind = etree.QName(shape._element.tag).localname
-        ordinal = kind_counters.get(kind, 0)
-        kind_counters[kind] = ordinal + 1
-        if name and names.count(name) == 1:
-            keyed[("name", name)] = shape
-        else:
-            keyed[("fallback", kind, ordinal)] = shape
-    return keyed
+    return etree.QName(shape._element.tag).localname
 
 
-def _shape_key_text(key) -> str:
-    """Render a shape key for a report.
+def _iter_shape_tree(shapes):
+    """Yield shapes in deterministic tree order for slide-wide id validation."""
+    for shape in shapes:
+        yield shape
+        nested = getattr(shape, "shapes", None)
+        if nested is not None:
+            for descendant in _iter_shape_tree(nested):
+                yield descendant
 
-    The shape name, or `kind#ordinal` when the name is missing or shared with another shape on the
-    same slide.
-    """
-    return key[1] if key[0] == "name" else "%s#%d" % (key[1], key[2])
+
+def _shape_inventory(slide, slide_id: int, side: str) -> dict:
+    """Return top-level shapes by id after validating slide-wide id uniqueness."""
+    from pptx.errors import UnsupportedStructureError
+
+    candidates: "Dict[int, List[object]]" = {}
+    for shape in _iter_shape_tree(slide.shapes):
+        candidates.setdefault(shape.shape_id, []).append(shape)
+    duplicates = {shape_id: shapes for shape_id, shapes in candidates.items() if len(shapes) > 1}
+    if duplicates:
+        details = []
+        for shape_id in sorted(duplicates):
+            shapes = duplicates[shape_id]
+            rendered = ", ".join(
+                "%s name=%r" % (_shape_kind(shape), shape.name) for shape in shapes
+            )
+            details.append("id %d: %d candidates [%s]" % (shape_id, len(shapes), rendered))
+        raise UnsupportedStructureError(
+            "diff_decks refused: %s side of slide %d has duplicate shape IDs (%s); "
+            "shape IDs must be unique across the slide"
+            % (side, slide_id, "; ".join(details))
+        )
+    return {shape.shape_id: shape for shape in slide.shapes}
+
+
+def _shape_ref(shape) -> ShapeRef:
+    """Return the stable report reference for `shape` using its current-side name."""
+    return ShapeRef(shape_id=shape.shape_id, name=shape.name)
 
 
 def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
@@ -489,30 +537,42 @@ def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
     match at the top level only, so a shape moved into a group reads as one removal plus one
     addition.
     """
-    shapes_a = _shape_keys(slide_a)
-    shapes_b = _shape_keys(slide_b)
-    shapes_added = tuple(_shape_key_text(key) for key in sorted(set(shapes_b) - set(shapes_a)))
-    shapes_removed = tuple(_shape_key_text(key) for key in sorted(set(shapes_a) - set(shapes_b)))
+    shapes_a = _shape_inventory(slide_a, slide_id, "before")
+    shapes_b = _shape_inventory(slide_b, slide_id, "after")
+    ids_a, ids_b = set(shapes_a), set(shapes_b)
+    added_ids = ids_b - ids_a
+    removed_ids = ids_a - ids_b
+    matched_ids = []
+    for shape_id in sorted(ids_a & ids_b):
+        if _shape_kind(shapes_a[shape_id]) != _shape_kind(shapes_b[shape_id]):
+            removed_ids.add(shape_id)
+            added_ids.add(shape_id)
+        else:
+            matched_ids.append(shape_id)
+
+    shapes_added = tuple(_shape_ref(shapes_b[shape_id]) for shape_id in sorted(added_ids))
+    shapes_removed = tuple(_shape_ref(shapes_a[shape_id]) for shape_id in sorted(removed_ids))
 
     geometry_changes: "List[dict]" = []
-    images_replaced: "List[str]" = []
+    images_replaced: "List[ShapeRef]" = []
     chart_changes: "List[dict]" = []
-    for key in sorted(set(shapes_a) & set(shapes_b)):
-        shape_a, shape_b = shapes_a[key], shapes_b[key]
-        key_text = _shape_key_text(key)
+    for shape_id in matched_ids:
+        shape_a, shape_b = shapes_a[shape_id], shapes_b[shape_id]
+        shape_ref = _shape_ref(shape_b)
         for facet in ("left", "top", "width", "height", "rotation"):
             value_a = getattr(shape_a, facet, None)
             value_b = getattr(shape_b, facet, None)
             if value_a != value_b:
                 geometry_changes.append(
-                    {"shape": key_text, "facet": facet, "before": value_a, "after": value_b}
+                    {"shape": shape_ref, "facet": facet, "before": value_a, "after": value_b}
                 )
-        if _image_hash(shape_a) is not None and _image_hash(shape_a) != _image_hash(shape_b):
-            images_replaced.append(key_text)
+        image_hash_a = _image_hash(shape_a)
+        if image_hash_a is not None and image_hash_a != _image_hash(shape_b):
+            images_replaced.append(shape_ref)
         if detail in ("text", "full") and getattr(shape_a, "has_chart", False) and getattr(
             shape_b, "has_chart", False
         ):
-            chart_changes.extend(_diff_chart(key_text, shape_a.chart, shape_b.chart))
+            chart_changes.extend(_diff_chart(shape_ref, shape_a.chart, shape_b.chart))
 
     text_changes: "List[dict]" = []
     notes_change = None

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -487,7 +487,14 @@ def _shape_kind(shape) -> str:
     """Return the structural element kind used to decide shape compatibility."""
     from lxml import etree
 
-    return etree.QName(shape._element.tag).localname
+    localname = etree.QName(shape._element.tag).localname
+    if localname != "graphicFrame":
+        return localname
+    # -- p:graphicFrame is only the generic container. Its graphic-data URI distinguishes
+    # -- tables, charts, OLE objects, SmartArt, and other extension payloads whose shape IDs
+    # -- can be reused after delete-then-add just like any other top-level shape.
+    graphic_data_uri = shape._element.graphicData_uri
+    return "graphicFrame[%s]" % (graphic_data_uri or "unknown")
 
 
 def _iter_shape_tree(shapes):

--- a/tests/paper/goldens/lineage_v1_v2.diff.json
+++ b/tests/paper/goldens/lineage_v1_v2.diff.json
@@ -1,6 +1,6 @@
 {
   "schema": "paper-deck-diff",
-  "version": 3,
+  "version": 4,
   "detail": "text",
   "slides_added": [
     {
@@ -47,7 +47,10 @@
       "slide_id": 258,
       "chart_data_changes": [
         {
-          "chart": "lineage_chart",
+          "chart": {
+            "shape_id": 3,
+            "name": "lineage_chart"
+          },
           "series": "FY",
           "category": "South",
           "before": 20.0,
@@ -59,14 +62,20 @@
       "slide_id": 259,
       "geometry_changes": [
         {
-          "shape": "lineage_box",
+          "shape": {
+            "shape_id": 3,
+            "name": "lineage_box"
+          },
           "facet": "left",
           "before": 3657600,
           "after": 4572000
         }
       ],
       "images_replaced": [
-        "lineage_pic"
+        {
+          "shape_id": 2,
+          "name": "lineage_pic"
+        }
       ]
     }
   ],

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -629,6 +629,38 @@ def test_incompatible_shape_kind_reuse_is_removal_plus_addition():
     assert change.chart_data_changes == ()
 
 
+def test_incompatible_graphic_frame_payload_reuse_is_removal_plus_addition():
+    from pptx.chart.data import CategoryChartData
+    from pptx.enum.chart import XL_CHART_TYPE
+
+    before = Presentation()
+    slide = before.slides.add_slide(before.slide_layouts[6])
+    table = slide.shapes.add_table(2, 2, 0, 0, 914400, 914400)
+    table.name = "Reused"
+    shape_id = table.shape_id
+    before_bytes = _serialized(before)
+
+    after = Presentation(io.BytesIO(before_bytes))
+    after_slide = after.slides[0]
+    after_slide.shapes.delete(after_slide.shapes[0])
+    chart_data = CategoryChartData()
+    chart_data.categories = ["A"]
+    chart_data.add_series("Series", (1,))
+    chart = after_slide.shapes.add_chart(
+        XL_CHART_TYPE.COLUMN_CLUSTERED, 0, 0, 914400, 914400, chart_data
+    )
+    chart.name = "Reused"
+    assert chart.shape_id == shape_id
+
+    report = diff_decks(io.BytesIO(before_bytes), after)
+    change = report.slide_changes[0]
+    expected = (ShapeRef(shape_id=shape_id, name="Reused"),)
+    assert change.shapes_removed == expected
+    assert change.shapes_added == expected
+    assert change.geometry_changes == ()
+    assert change.chart_data_changes == ()
+
+
 def test_duplicate_shape_ids_refuse_with_deterministic_candidate_details():
     before = Presentation(_path("self_generated/minimal_clean.pptx"))
     after = Presentation(_path("self_generated/minimal_clean.pptx"))

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -16,7 +16,7 @@ import pytest
 from lxml import etree
 
 from pptx import Presentation
-from pptx.diff import diff_decks
+from pptx.diff import ShapeRef, diff_decks
 from pptx.errors import UnsupportedStructureError
 from pptx.oxml.ns import qn
 
@@ -93,17 +93,23 @@ def test_lineage_pair_reports_the_exact_edit_list():
     }
     assert changes[258].chart_data_changes == (
         {
-            "chart": "lineage_chart",
+            "chart": ShapeRef(shape_id=3, name="lineage_chart"),
             "series": "FY",
             "category": "South",
             "before": 20.0,
             "after": 25.0,
         },
     )
-    assert changes[259].images_replaced == ("lineage_pic",)
+    assert changes[259].images_replaced == (ShapeRef(shape_id=2, name="lineage_pic"),)
     assert changes[259].geometry_changes == (
-        {"shape": "lineage_box", "facet": "left", "before": 3657600, "after": 4572000},
+        {
+            "shape": ShapeRef(shape_id=3, name="lineage_box"),
+            "facet": "left",
+            "before": 3657600,
+            "after": 4572000,
+        },
     )
+    assert report.to_dict()["version"] == 4
 
 
 def test_diff_matches_frozen_golden():
@@ -455,8 +461,7 @@ def test_id_matching_contract_on_rebuilt_and_re_idd_decks():
     assert [ref.slide_id for ref in report2.slides_removed] == [256]
 
 
-def test_unnamed_shape_fallback_keys_are_deterministic():
-    """Shapes with empty or duplicated names key as `<kind>#<ordinal>` (declared)."""
+def test_duplicate_named_shape_additions_use_stable_references():
     prs_a = Presentation(_path("self_generated/minimal_clean.pptx"))
     slide = prs_a.slides[0]
     box_one = slide.shapes.add_textbox(0, 0, 914400, 914400)
@@ -472,10 +477,17 @@ def test_unnamed_shape_fallback_keys_are_deterministic():
         prs_a.save(str(out))
         report = diff_decks(_path("self_generated/minimal_clean.pptx"), str(out))
     change = report.slide_changes[0]
-    assert set(change.shapes_added) == {"sp#2", "sp#3"}  # -- synthetic keys, stable
+    assert change.shapes_added == (
+        ShapeRef(shape_id=4, name="Duplicate"),
+        ShapeRef(shape_id=5, name="Duplicate"),
+    )
+    assert change.to_dict()["shapes_added"] == [
+        {"shape_id": 4, "name": "Duplicate"},
+        {"shape_id": 5, "name": "Duplicate"},
+    ]
 
 
-def test_user_shape_name_cannot_collide_with_a_fallback_key():
+def test_user_shape_name_is_display_only_in_geometry_reference():
     base = Presentation(_path("self_generated/minimal_clean.pptx"))
     slide = base.slides[0]
     named = slide.shapes.add_textbox(0, 0, 914400, 914400)
@@ -494,7 +506,171 @@ def test_user_shape_name_cannot_collide_with_a_fallback_key():
         for change in report.slide_changes
         for delta in change.geometry_changes
     ]
-    assert any(delta["shape"] == "sp#1" for delta in geometry)
+    assert any(delta["shape"] == ShapeRef(shape_id=4, name="sp#1") for delta in geometry)
+
+
+def _serialized(prs) -> bytes:
+    stream = io.BytesIO()
+    prs.save(stream)
+    return stream.getvalue()
+
+
+def test_duplicate_name_z_order_change_has_no_specialized_shape_facets():
+    before = Presentation(_path("self_generated/minimal_clean.pptx"))
+    slide = before.slides[0]
+    first = slide.shapes.add_textbox(0, 0, 914400, 914400)
+    second = slide.shapes.add_textbox(1828800, 0, 914400, 914400)
+    first.name = second.name = "Duplicate"
+    first.text = "First"
+    second.text = "Second"
+    before_bytes = _serialized(before)
+
+    after = Presentation(io.BytesIO(before_bytes))
+    after_slide = after.slides[0]
+    after_slide.shapes.move(after_slide.shapes[-2], len(after_slide.shapes) - 1)
+    report = diff_decks(io.BytesIO(before_bytes), after, detail="full")
+
+    assert report.slide_changes == ()
+    assert "/ppt/slides/slide1.xml" in {
+        change.partname for change in report.package_changes
+    }
+
+
+def test_empty_and_renamed_shape_names_do_not_change_identity():
+    before = Presentation(_path("self_generated/minimal_clean.pptx"))
+    box = before.slides[0].shapes.add_textbox(0, 0, 914400, 914400)
+    box.name = ""
+    before_bytes = _serialized(before)
+
+    after = Presentation(io.BytesIO(before_bytes))
+    after.slides[0].shapes[-1].name = "Current display name"
+    report = diff_decks(io.BytesIO(before_bytes), after)
+
+    assert report.slide_changes == ()
+    assert report.package_changes
+
+
+def test_matched_geometry_uses_after_side_name_and_stable_id():
+    before = Presentation(_path("self_generated/minimal_clean.pptx"))
+    box = before.slides[0].shapes.add_textbox(0, 0, 914400, 914400)
+    box.name = "Before name"
+    shape_id = box.shape_id
+    before_bytes = _serialized(before)
+
+    after = Presentation(io.BytesIO(before_bytes))
+    changed = after.slides[0].shapes[-1]
+    changed.name = "After name"
+    changed.left += 100
+    report = diff_decks(io.BytesIO(before_bytes), after)
+    change = report.slide_changes[0]
+
+    assert change.shapes_added == ()
+    assert change.shapes_removed == ()
+    assert change.geometry_changes == (
+        {
+            "shape": ShapeRef(shape_id=shape_id, name="After name"),
+            "facet": "left",
+            "before": 0,
+            "after": 100,
+        },
+    )
+    assert change.to_dict()["geometry_changes"][0]["shape"] == {
+        "shape_id": shape_id,
+        "name": "After name",
+    }
+
+
+def test_addition_and_removal_use_their_own_side_names():
+    before = Presentation(_path("self_generated/minimal_clean.pptx"))
+    before_bytes = _serialized(before)
+    removed = before.slides[0].shapes.title
+
+    after = Presentation(io.BytesIO(before_bytes))
+    after.slides[0].shapes.delete(after.slides[0].shapes.title)
+    added = after.slides[0].shapes.add_textbox(0, 0, 914400, 914400)
+    added.name = "After only"
+    report = diff_decks(before, after)
+    change = report.slide_changes[0]
+
+    assert change.shapes_removed == (
+        ShapeRef(shape_id=removed.shape_id, name=removed.name),
+    )
+    assert change.shapes_added == (
+        ShapeRef(shape_id=added.shape_id, name="After only"),
+    )
+
+
+def test_incompatible_shape_kind_reuse_is_removal_plus_addition():
+    from PIL import Image as PILImage
+
+    before = Presentation()
+    slide = before.slides.add_slide(before.slide_layouts[6])
+    box = slide.shapes.add_textbox(0, 0, 914400, 914400)
+    box.name = "Reused"
+    shape_id = box.shape_id
+    before_bytes = _serialized(before)
+
+    after = Presentation(io.BytesIO(before_bytes))
+    after_slide = after.slides[0]
+    after_slide.shapes.delete(after_slide.shapes[0])
+    image = io.BytesIO()
+    PILImage.new("RGB", (2, 2), (10, 20, 30)).save(image, format="PNG")
+    picture = after_slide.shapes.add_picture(io.BytesIO(image.getvalue()), 0, 0)
+    picture.name = "Reused"
+    assert picture.shape_id == shape_id
+
+    report = diff_decks(io.BytesIO(before_bytes), after, detail="text")
+    change = report.slide_changes[0]
+    expected = (ShapeRef(shape_id=shape_id, name="Reused"),)
+    assert change.shapes_removed == expected
+    assert change.shapes_added == expected
+    assert change.geometry_changes == ()
+    assert change.images_replaced == ()
+    assert change.chart_data_changes == ()
+
+
+def test_duplicate_shape_ids_refuse_with_deterministic_candidate_details():
+    before = Presentation(_path("self_generated/minimal_clean.pptx"))
+    after = Presentation(_path("self_generated/minimal_clean.pptx"))
+    first = after.slides[0].shapes.add_textbox(0, 0, 914400, 914400)
+    group = after.slides[0].shapes.add_group_shape()
+    second = group.shapes.add_textbox(914400, 0, 914400, 914400)
+    first.name = "First duplicate"
+    second.name = "Second duplicate"
+    second._element._nvXxPr.cNvPr.set("id", str(first.shape_id))
+
+    messages = []
+    for _ in range(2):
+        with pytest.raises(UnsupportedStructureError) as exc_info:
+            diff_decks(before, after)
+        messages.append(str(exc_info.value))
+    assert messages[0] == messages[1]
+    assert messages[0] == (
+        "diff_decks refused: after side of slide 256 has duplicate shape IDs "
+        "(id 4: 2 candidates [sp name='First duplicate', sp name='Second duplicate']); "
+        "shape IDs must be unique across the slide"
+    )
+
+
+def test_moving_leaf_into_group_remains_a_top_level_removal():
+    before = Presentation()
+    slide = before.slides.add_slide(before.slide_layouts[6])
+    leaf = slide.shapes.add_textbox(0, 0, 914400, 914400)
+    leaf.name = "Leaf"
+    group = slide.shapes.add_group_shape()
+    before_bytes = _serialized(before)
+
+    after = Presentation(io.BytesIO(before_bytes))
+    after_slide = after.slides[0]
+    after_leaf = next(shape for shape in after_slide.shapes if shape.shape_id == leaf.shape_id)
+    after_group = next(shape for shape in after_slide.shapes if shape.shape_id == group.shape_id)
+    after_group._element.append(after_leaf._element)
+
+    report = diff_decks(io.BytesIO(before_bytes), after)
+    change = report.slide_changes[0]
+    assert change.shapes_removed == (ShapeRef(shape_id=leaf.shape_id, name="Leaf"),)
+    assert change.shapes_added == ()
+    assert change.geometry_changes == ()
 
 
 # ------------------------------------------------------------- regressions
@@ -614,7 +790,7 @@ def test_shape_removal_does_not_misattribute_later_blocks():
     slide.shapes.delete(title)
     diff = diff_decks(_path("self_generated/gauntlet.pptx"), prs_b, detail="full")
     change = next(c for c in diff.slide_changes)
-    assert "Title 1" in change.shapes_removed
+    assert ShapeRef(shape_id=2, name="Title 1") in change.shapes_removed
     # -- the title's block reads as removed (after=None); the body blocks are untouched
     for delta in change.text_changes:
         assert delta["after"] is None, delta

--- a/tests/paper/test_walkthrough_qbr.py
+++ b/tests/paper/test_walkthrough_qbr.py
@@ -268,10 +268,16 @@ def test_walkthrough_self_consistency_against_deck_diff(tmp_path):
         "after": "Walk through Q4 revenue; flag the Alpha renewal.",
     }
     # -- the decorative picture delete on the chart slide
-    assert "gauntlet_img_1" in changes[chart_slide_id].shapes_removed
+    assert any(
+        ref.shape_id == 4 and ref.name == "gauntlet_img_1"
+        for ref in changes[chart_slide_id].shapes_removed
+    )
     # -- the closing slide's image swap reads as replacement, not move/resize
     closing_id = 259  # -- gauntlet slide 4
-    assert "gauntlet_img_2" in changes[closing_id].images_replaced
+    assert any(
+        ref.shape_id == 4 and ref.name == "gauntlet_img_2"
+        for ref in changes[closing_id].images_replaced
+    )
 
 
 @pytest.mark.lo_smoke
@@ -331,5 +337,4 @@ def _bytes_of(prs):
     buf = io.BytesIO()
     prs.save(buf)
     return buf.getvalue()
-
 


### PR DESCRIPTION
## Summary

- match top-level lineage shapes by slide-wide shape ID instead of display names or ordinal fallbacks
- refuse malformed duplicate IDs and report incompatible kind reuse as remove plus add
- carry structured shape references through all shape facets in deck-diff schema v4

## Finding

LS-04 — shape diff ordinal fallback fabricated changes for duplicate-named shapes.

## Stack

- Root: #38
- Base: #43
- This PR: #44
- Next: #45

## Verification

85 focused tests plus full pytest, Behave, LibreOffice, documentation, distribution, and Python 3.9–3.13 CI pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking change to the deck-diff JSON contract (schema 3 → 4) and matching semantics used by verification/eval consumers. Duplicate shape IDs now refuse rather than guess.
> 
> **Overview**
> Stops `diff_decks` from inventing add/remove or facet changes when shapes share names, are unnamed, or only change z-order. Top-level shapes now match by **slide-wide `shape_id` plus compatible structural kind**; display names are labels only.
> 
> **Schema v4** replaces string shape keys with `ShapeRef` (`{"shape_id", "name"}`) on additions, removals, image replacements, geometry, and chart facets. Duplicate IDs refuse with `UnsupportedStructureError`. Kind-incompatible ID reuse (e.g. textbox vs picture, table vs chart) is reported as remove+add. Group-boundary moves stay top-level add/remove; same-kind ID recycle remains indistinguishable.
> 
> v3 consumers that compared string labels must switch to `shape_id`. Rename/z-order-only edits still show up in `package_changes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58ddcb4a77d0136261e5ba4093e8300b7d8c9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->