### PR TITLE
fix: simplify paragraph and table diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ print(len(delta.slide_changes), "slides changed")
 
 ### Verify: prove what changed
 
-- **A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent slide ID and top-level shapes within them by slide-wide shape ID, so slide or shape z-order does not manufacture add/remove or facet changes. Schema v5 aligns text exactly within stable shape or table containers and reports table-grid changes without ordinal cascades; repeated ambiguous content is reported conservatively. `detail="text"` adds chart data, text, and notes; `detail="full"` adds per-run and bullet shifts.
+- **A semantic deck diff.** `pptx.diff.diff_decks()` matches slides by permanent slide ID and top-level shapes within them by slide-wide shape ID, so slide or shape z-order does not manufacture add/remove or facet changes. Within each stable text container, schema v5 reports one exact snapshot hunk bounded by the longest common prefix and suffix: `insertion`, `deletion`, one-paragraph `replacement`, or `changed_region`. It never infers paragraph moves or a historical location for duplicate content. Table changes report exact dimensions, while `detail="full"` limits per-run and bullet shifts to unique unchanged paragraphs. `package_changes` retains semantic package-level evidence for unsupported facets.
 - **Byte-minimal saves and a package oracle.** `pptx.package.patch_save()` writes semantically unchanged parts back with their original bytes, so a one-line edit diffs as a few parts rather than all of them, and `diff_package()` reports exactly which parts differ.
 
 ### Package intake and save
@@ -134,7 +134,7 @@ Converting a documented typed refusal into a correct operation is the sanctioned
 - **Table-cell effective values refuse** until the table-style resolution walk is built.
 - **Chart data replacement supports single-plot category charts.** XY, bubble, stock, surface, radar, 3-D, and multi-plot combos refuse.
 - **Bullet color is not resolved**, and bullet diffing needs `detail="full"` and skips table cells.
-- **`diff_decks` assumes lineage**, matching slides by permanent ID and top-level shapes by slide-wide shape ID. It is not a visual diff; group-boundary moves remain add/remove, and deleted IDs reused by new same-kind shapes cannot be distinguished without a persistent identifier general PPTX files do not carry.
+- **`diff_decks` assumes lineage**, matching slides by permanent ID and top-level shapes by slide-wide shape ID. It is not a visual or edit-history diff; group-boundary shape moves remain add/remove, paragraph moves are not inferred, and deleted IDs reused by new same-kind shapes cannot be distinguished without a persistent identifier general PPTX files do not carry.
 - **Fixture provenance.** The test corpus is generated and LibreOffice round-tripped, not authored by PowerPoint.
 
 Deliberate non-goals: no rendering or layout-geometry computation, no SmartArt authoring (opaque preservation only), and no animation or transition authoring.

--- a/docs/api/diff.rst
+++ b/docs/api/diff.rst
@@ -30,6 +30,12 @@ decks can reuse numeric ids and are outside the lineage contract. Deleting a sha
 reusing its id for a new shape of the same structural kind is also indistinguishable without a
 persistent identifier that general PPTX files do not provide.
 
+Text inspection is visibility-complete even though the public shape facets are intentionally
+top-level. Ordinary text and recursively grouped leaf text use the inspection-visible leaf's exact
+slide-wide shape ID and compatible structural kind as their text-container boundary. Table text
+uses the table graphic-frame ID. Group display names, group order, shape geometry, and text
+similarity are never identity.
+
 ``paper-deck-diff`` schema version 5 uses one structured shape reference everywhere. Entries in
 ``shapes_added``, ``shapes_removed``, and ``images_replaced`` are
 ``{"shape_id": ..., "name": ...}``; the ``shape`` value in ``geometry_changes`` and the ``chart``
@@ -40,29 +46,74 @@ migrating from version 3 should compare ``entry["shape_id"]`` (or
 label. A rename alone remains observable through ``package_changes`` and does not manufacture a
 specialized shape change.
 
-Text comparison is likewise lineage-scoped. Paragraphs are partitioned by the slide-wide ID of
-their ordinary/grouped leaf shape or table frame, then aligned by the exact inspection-v3
-fingerprint (NFC-normalized literal segments plus field type and position). The matcher does not
-use paragraph ordinal, display name, geometry, edit distance, or fuzzy text. Insertions and
-deletions therefore do not shift unchanged neighbors into fictional replacements. Exact unique
-reorders can be reported as ``kind="move"``; a uniquely bounded one-for-one change is a
-``replacement``. Repeated regions that cannot be associated from exact context use one
-``ambiguity`` event rather than an arbitrary pairing.
+Text comparison is a deterministic snapshot comparison, not recovered edit history. Within each
+stable container, paragraphs are ordered values made from raw literal text and positioned field
+markers. Run boundaries and formatting do not participate. The matcher consumes the longest exact
+prefix first and then the longest non-overlapping exact suffix. It emits at most one event for the
+remaining middle:
 
-Every text event carries a structured ``shape`` reference and separate ``before_location`` and
-``after_location``. A location contains the container kind and container-local paragraph index;
-table-cell locations also contain row and column. Insertions and deletions use ``null`` on the
-absent side. Ambiguity events keep the singular locations null and list the exact candidates.
-Version-4 consumers must migrate from ``shape_id``/``shape_name``/``block_ordinal`` to these
-version-5 fields.
+* ``insertion`` when only the after range contains paragraphs;
+* ``deletion`` when only the before range contains paragraphs;
+* ``replacement`` when each range contains exactly one paragraph; or
+* ``changed_region`` for every larger two-sided change, including paragraph reorders.
 
-At ``detail="structure"``, ``table_structure_changes`` reports stable table-frame identity and
-before/after row and column counts. A provably located row or column insertion/deletion includes
-its index; duplicate or blank cells retain candidate indexes and an ambiguity marker. At
-``detail="text"`` the same frame-scoped alignment retains separate cell coordinates. At
-``detail="full"`` effective-font and bullet shifts reuse those exact paragraph pairs and have
-before/after locations. Table effective formatting and table bullets remain unsupported and are
-not inferred. Speaker notes retain the separate flat ``notes_change`` comparison.
+The comparison is exact: whitespace and Unicode representation are content, so canonically
+equivalent but differently encoded strings remain different. There is no paragraph ``move`` or
+``ambiguity`` event and no claim that equal text denotes one persistent paragraph. For repeated
+values, consuming the prefix before the suffix gives one canonical hunk location. That location may
+differ from where a user historically inserted or removed a duplicate paragraph.
+
+An unmatched text-bearing container contributes one whole-container insertion or deletion event
+alongside any shape addition or removal. It is not paired with another unmatched container.
+
+All four kinds use the same version-5 payload::
+
+    {
+        "kind": "replacement",
+        "shape": {"shape_id": 12, "name": "Summary"},
+        "before_range": {"start": 0, "end": 1},
+        "after_range": {"start": 0, "end": 1},
+        "before": [
+            {
+                "location": {"container": "shape", "paragraph_index": 0},
+                "text": "Old summary",
+                "fields": [],
+            }
+        ],
+        "after": [
+            {
+                "location": {"container": "shape", "paragraph_index": 0},
+                "text": "New summary",
+                "fields": [{"offset": 11, "type": "slidenum"}],
+            }
+        ],
+    }
+
+``before_range`` and ``after_range`` are zero-based, half-open paragraph indexes in that side's
+container sequence. ``before`` and ``after`` are always arrays; an absent side is ``[]``, never
+``null``. Every block has raw ``text``, an always-present ``fields`` array of positioned
+``{offset, type}`` records, and its exact container-local ``location``. A table-cell location also
+has ``row`` and ``column``; its paragraph index is local to that cell. Table container ranges index
+the frame's complete row-major paragraph sequence, while block locations retain their snapshot
+coordinates.
+
+Version-4 consumers must replace scalar ``before``/``after`` values and
+``shape_id``/``shape_name``/``block_ordinal`` keys with the regular version-5 arrays, ranges,
+structured ``shape``, and per-block locations. Version 5 has no scalar compatibility form.
+
+At ``detail="structure"``, ``table_structure_changes`` reports only stable table-frame identity
+and exact before/after row and column counts. It does not infer which row or column was historically
+inserted or deleted. At ``detail="text"``, the row-major hunk provides exact cell evidence but its
+coordinates identify snapshot positions, not persistent cells; column growth can therefore produce
+one broad ``changed_region``. At ``detail="full"``, effective-font and bullet comparison is limited
+to an unchanged prefix/suffix paragraph whose complete text-and-field value occurs exactly once in
+each container. Runs then match only by a non-empty exact text identity or exact field type that is
+itself unique within each paragraph. Repeated paragraphs, changed-region paragraphs, table
+effective formatting, and table bullets deliberately produce no specialized shift.
+
+Speaker notes retain the separate flat ``notes_change`` comparison. ``package_changes`` remains
+the authoritative semantic package-level fallback when a specialized facet is intentionally
+coarse or unsupported, including formatting inside changed text and table-style formatting.
 
 .. currentmodule:: pptx.diff
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -321,16 +321,34 @@ matching: independently authored decks are out of scope, and deleting a shape th
 for a new same-kind shape cannot be detected without a persistent identifier general PPTX files do
 not carry.
 
-Within a stable leaf shape or table frame, paragraphs align by the exact structural fingerprint
-emitted by text inspection, never by paragraph ordinal, fuzzy text, display name, or geometry.
-Text events identify insertion, deletion, replacement, exact move, or ambiguity and carry separate
-structured before/after locations. Table-cell locations retain row and column, so inserting a row
-does not turn every later cell into a replacement. ``detail="structure"`` reports before/after
-table dimensions and an insertion/deletion index only when exact grid evidence makes it unique;
-otherwise it records the ambiguity. Version-4 consumers must replace the former
-``shape_id``/``shape_name``/``block_ordinal`` text keys with ``shape``, ``before_location``, and
-``after_location``. Notes remain one flat ``notes_change``. Table effective formatting and table
-bullets remain outside the resolver and are not reported.
+Text comparison below that shape boundary is an exact snapshot diff, not reconstructed edit
+history. Ordinary and recursively grouped leaf text uses the leaf's slide-wide shape ID and
+compatible kind; table text uses the stable table-frame ID. Within each container, version 5
+consumes the longest equal text-and-field prefix, then the longest non-overlapping suffix, and
+reports the remaining middle as one ``insertion``, ``deletion``, one-paragraph ``replacement``, or
+``changed_region``. A paragraph reorder is therefore a changed region, never a paragraph move.
+
+Every text event has ``before_range`` and ``after_range`` half-open container indexes plus
+array-valued ``before`` and ``after`` evidence. An absent side is an empty array. Each block carries
+its exact location, raw text, and positioned field markers; table-cell locations include row,
+column, and the paragraph index within that cell. Whitespace and Unicode representation remain
+content. With duplicate paragraphs the prefix-first rule chooses one deterministic endpoint hunk,
+but it does not claim that this was the historical edit location or that equal paragraphs share
+persistent identity. An unmatched text-bearing container contributes one whole-container insertion
+or deletion event; it is not paired with another unmatched container.
+
+Version-4 consumers must replace scalar text values and the former
+``shape_id``/``shape_name``/``block_ordinal`` keys with structured ``shape``, ranges, and per-block
+locations. Version 5 has no scalar compatibility payload. ``detail="structure"`` reports exact
+before/after table dimensions but does not infer an inserted row or column index. Coordinates in a
+row-major table hunk describe each snapshot rather than persistent cells.
+
+At ``detail="full"``, effective-font and bullet shifts require an unchanged prefix/suffix paragraph
+whose complete text-and-field value is unique on each side, followed by an exact run identity that
+is unique within each paragraph. Repeated paragraphs and changed regions are intentionally skipped.
+Notes remain one flat ``notes_change``; table effective formatting and table bullets remain outside
+the resolver. ``package_changes`` is the authoritative semantic package-level fallback for
+unsupported or deliberately coarse facets.
 Callers can use the result to check a session's changes. Release job evaluations compare the
 operation report with ``diff_decks(input, output)`` for every import/rebind/refresh job and
 require them to agree.

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -889,7 +889,7 @@ def _slide_text_hunks(slide_a, slide_b) -> tuple:
             hunks.append(_container_hunk(_shape_ref(shape_a), before, ()))
             hunks.append(_container_hunk(_shape_ref(shape_b), (), after))
             continue
-        reference = shape_b or shape_a
+        reference = shape_b if after else shape_a
         hunks.append(_container_hunk(_shape_ref(reference), before, after))
     return tuple(hunks)
 

--- a/src/pptx/diff.py
+++ b/src/pptx/diff.py
@@ -1,10 +1,10 @@
 """Deck diff - the verification mirror (paper-pptx addition).
 
-PPTX carries no revision markup: a deck is amnesiac about its own history, so "what
-changed between v3 and v4?" has no programmable answer anywhere in the ecosystem. This
-provides it as a typed report beside the file - the deck-format analogue of a
-redline - assembled from the permanent slide ids, the visibility-complete text layer,
-the effective-value resolver, and the kernel's semantic XML comparison.
+PPTX carries no revision markup: a deck is amnesiac about its own history. This module
+therefore reports deterministic differences between two snapshots rather than claiming
+to recover the edits that produced them. The report is assembled from permanent slide
+ids, stable shape ids, the visibility-complete text layer, the effective-value resolver,
+and the kernel's semantic XML comparison.
 
 The matching contract, declared honestly: slides match by their PERMANENT slide id and
 top-level shapes within them match by slide-wide shape id, which serves lineage-derived
@@ -15,8 +15,13 @@ hazard: deleting the max-id slide then adding a new one recycles the id (upstrea
 max+1), which id-based matching reads as one edited slide - order add-before-delete when
 building lineage.
 
-Report-only: no annotated-copy rendering, no visual diffing, no similarity scoring -
-those are harness products built ON this report.
+Within a stable text container, schema v5 reports at most one changed region after
+consuming the longest exact prefix and then the longest non-overlapping exact suffix.
+Repeated content can make the resulting hunk location differ from the historical edit
+location; the report describes endpoints, never paragraph identity or chronology.
+
+Report-only: no annotated-copy rendering, visual diffing, similarity scoring, or
+paragraph move inference - those are harness products built ON this report.
 """
 
 from __future__ import annotations
@@ -29,7 +34,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 SCHEMA_NAME = "paper-deck-diff"
-SCHEMA_VERSION = 5  # -- was 4: exact paragraph alignment and table structure
+SCHEMA_VERSION = 5  # -- was 4: canonical text hunks and factual table dimensions
 
 _DETAIL_LEVELS = ("structure", "text", "full")
 
@@ -42,15 +47,16 @@ class BulletShift:
     field marker: `text_changes` stays empty while the slide visibly loses every glyph.
     This is the facet that reports it.
 
-    Paragraphs use the same exact container-scoped alignment as text and effective-font
-    reporting. Repeated ambiguity is skipped rather than settled by paragraph order.
+    Paragraphs qualify only when their exact text-and-field value is unique on both sides
+    and lies in the canonical unchanged prefix or suffix. Repeated or changed-region
+    paragraphs are skipped rather than paired by position.
 
     Fields:
 
     * ``part`` -- partname of the slide the paragraph lives on.
     * ``shape`` -- stable shape identity plus current display name.
     * ``before_location`` / ``after_location`` -- container-local paragraph locations.
-    * ``text`` -- the paragraph's text, which is also half its identity.
+    * ``text`` -- the unchanged paragraph's literal text.
     * ``before`` / ``after`` -- the resolved ``bullet``, ``bullet_font`` and ``bullet_size``
       payloads from :func:`pptx.inspect.effective_paragraph_format` on each side.
     """
@@ -102,7 +108,7 @@ class ShapeRef:
 
 @dataclass(frozen=True)
 class EffectiveShift:
-    """One exactly aligned run whose resolved font changed."""
+    """One uniquely matched run in a unique unchanged paragraph whose resolved font changed."""
 
     part: str
     shape: ShapeRef
@@ -281,11 +287,25 @@ def diff_decks(path_a, path_b, *, detail: str = "structure") -> DeckDiff:
     adding a new one RECYCLES the id, and this diff will read that delete-plus-add as one edited
     slide - order add-before-delete when producing lineage decks you intend to diff.
 
-    Paragraphs align by exact inspection fingerprints within their stable leaf-shape or table-
-    frame container. Insertions and deletions do not shift unchanged neighbors into replacements;
-    repeated content that exact context cannot associate is reported as ambiguous. Table grid
-    dimensions are structural changes, speaker notes remain one flat comparison, and table-cell
-    effective formatting and bullets remain outside the supported resolver domain.
+    Within each stable leaf-shape or table-frame container, paragraphs are ordered snapshot values
+    consisting of raw literal text plus positioned field markers. The longest exact prefix is
+    consumed first, followed by the longest non-overlapping exact suffix. The remaining middle is
+    one ``insertion``, ``deletion``, one-paragraph ``replacement``, or ``changed_region`` event.
+    Each event contains zero-based half-open ``before_range``/``after_range`` values and array-
+    valued ``before``/``after`` block evidence; every block carries its structured location, raw
+    text, and positioned fields. Duplicate values follow the prefix-first rule, which is a
+    deterministic endpoint representation rather than the historical edit location. Paragraph
+    moves and ambiguous identity are not inferred.
+
+    An unmatched text-bearing container produces one whole-container insertion or deletion event
+    and is never paired with another unmatched container.
+
+    Table dimensions are structural changes without inferred row/column insertion history.
+    At ``detail="full"``, effective-font and bullet shifts are limited to container-unique,
+    unchanged prefix/suffix paragraphs and exact unique run identities. Speaker notes remain one
+    flat comparison, while table-cell effective formatting and bullets remain outside the
+    supported resolver domain. ``package_changes`` remains the authoritative fallback for every
+    semantic package change not represented by a specialized facet.
     """
     if detail not in _DETAIL_LEVELS:
         raise ValueError(
@@ -624,12 +644,12 @@ def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
             chart_changes.extend(_diff_chart(shape_ref, shape_a.chart, shape_b.chart))
 
     table_structure_changes = _table_structure_changes(slide_a, slide_b)
-    alignments = ()
+    hunks = ()
     text_changes: "List[dict]" = []
     notes_change = None
     if detail in ("text", "full"):
-        alignments = _align_slide_text(slide_a, slide_b)
-        text_changes = _text_events(alignments, detail, slide_a, slide_b)
+        hunks = _slide_text_hunks(slide_a, slide_b)
+        text_changes = _text_events(hunks)
         notes_a = _notes_text(slide_a)
         notes_b = _notes_text(slide_b)
         if notes_a != notes_b:
@@ -638,8 +658,8 @@ def _diff_slide(slide_id, slide_a, slide_b, detail) -> SlideChange:
     effective_shifts: tuple = ()
     bullet_shifts: tuple = ()
     if detail == "full":
-        effective_shifts = _effective_shifts(alignments)
-        bullet_shifts = _bullet_shifts(slide_a, slide_b, alignments)
+        effective_shifts = _effective_shifts(hunks)
+        bullet_shifts = _bullet_shifts(slide_a, slide_b, hunks)
 
     return SlideChange(
         slide_id=slide_id,
@@ -766,15 +786,14 @@ def _chart_data(chart):
 
 
 @dataclass(frozen=True)
-class _ContainerAlignment:
-    """Exact paragraph evidence for one stable leaf shape or table frame."""
+class _ContainerHunk:
+    """Canonical snapshot evidence for one stable leaf shape or table frame."""
 
     shape: ShapeRef
     before: tuple
     after: tuple
-    pairs: tuple
-    ordered_pairs: tuple
-    move_pairs: tuple
+    before_range: tuple
+    after_range: tuple
 
 
 def _block_location(block) -> dict:
@@ -807,166 +826,114 @@ def _container_blocks(slide) -> dict:
     return {key: tuple(blocks) for key, blocks in result.items()}
 
 
-def _invariant_lcs_pairs(sequence_a, sequence_b) -> tuple:
-    """Return exact pairs present in every optimal LCS, without choosing a tie."""
-    rows, cols = len(sequence_a), len(sequence_b)
-    next_lengths = [0] * (cols + 1)
-    next_forced = [frozenset() for _ in range(cols + 1)]
-    for i in range(rows - 1, -1, -1):
-        lengths = [0] * (cols + 1)
-        forced = [frozenset() for _ in range(cols + 1)]
-        for j in range(cols - 1, -1, -1):
-            choices = []
-            if sequence_a[i] == sequence_b[j]:
-                choices.append((1 + next_lengths[j + 1], next_forced[j + 1] | {(i, j)}))
-            choices.append((next_lengths[j], next_forced[j]))
-            choices.append((lengths[j + 1], forced[j + 1]))
-            best = max(length for length, _ in choices)
-            winners = [pairs for length, pairs in choices if length == best]
-            lengths[j] = best
-            forced[j] = frozenset.intersection(*winners)
-        next_lengths = lengths
-        next_forced = forced
-    return tuple(sorted(next_forced[0]))
+def _paragraph_value(block) -> tuple:
+    """Return exact observable text evidence, with no formatting or normalization."""
+    return block.text, _field_markers(block)
 
 
-def _align_slide_text(slide_a, slide_b) -> tuple:
-    """Return one exact alignment result shared by all paragraph diff facets."""
+def _common_boundary_ranges(before, after) -> tuple:
+    """Return prefix-first, non-overlapping changed ranges in linear time."""
+    prefix_end = 0
+    shared_length = min(len(before), len(after))
+    while prefix_end < shared_length and _paragraph_value(before[prefix_end]) == _paragraph_value(
+        after[prefix_end]
+    ):
+        prefix_end += 1
+
+    suffix_length = 0
+    remaining_a = len(before) - prefix_end
+    remaining_b = len(after) - prefix_end
+    while (
+        suffix_length < min(remaining_a, remaining_b)
+        and _paragraph_value(before[len(before) - suffix_length - 1])
+        == _paragraph_value(after[len(after) - suffix_length - 1])
+    ):
+        suffix_length += 1
+
+    return (
+        (prefix_end, len(before) - suffix_length),
+        (prefix_end, len(after) - suffix_length),
+    )
+
+
+def _container_hunk(shape, before, after) -> _ContainerHunk:
+    """Return the sole canonical changed region for one stable container."""
+    before_range, after_range = _common_boundary_ranges(before, after)
+    return _ContainerHunk(
+        shape=shape,
+        before=before,
+        after=after,
+        before_range=before_range,
+        after_range=after_range,
+    )
+
+
+def _slide_text_hunks(slide_a, slide_b) -> tuple:
+    """Return canonical hunks for compatible leaf-shape and table containers."""
     containers_a = _container_blocks(slide_a)
     containers_b = _container_blocks(slide_b)
     shapes_a = {shape.shape_id: shape for shape in _iter_shape_tree(slide_a.shapes)}
     shapes_b = {shape.shape_id: shape for shape in _iter_shape_tree(slide_b.shapes)}
-    alignments = []
-    for key in sorted(set(containers_a) | set(containers_b)):
+    hunks = []
+    for key in sorted(set(containers_a) | set(containers_b), key=lambda item: (item[1], item[0])):
         before = containers_a.get(key, ())
         after = containers_b.get(key, ())
-        fingerprints_a = tuple(block.anchor.content_hash for block in before)
-        fingerprints_b = tuple(block.anchor.content_hash for block in after)
-        ordered = _invariant_lcs_pairs(fingerprints_a, fingerprints_b)
-        counts_a = Counter(fingerprints_a)
-        counts_b = Counter(fingerprints_b)
-        unique_a = {
-            value: i for i, value in enumerate(fingerprints_a) if counts_a[value] == 1
-        }
-        unique_b = {
-            value: i for i, value in enumerate(fingerprints_b) if counts_b[value] == 1
-        }
-        global_unique = {
-            (index_a, unique_b[value]) for value, index_a in unique_a.items() if value in unique_b
-        }
-        pairs = tuple(sorted(set(ordered) | global_unique))
-        move_pairs = tuple(
-            (index_a, index_b)
-            for index_a, index_b in sorted(global_unique - set(ordered))
-            if _block_location(before[index_a]) != _block_location(after[index_b])
-        )
-        reference = shapes_b.get(key[1]) or shapes_a[key[1]]
-        alignments.append(
-            _ContainerAlignment(
-                _shape_ref(reference),
-                before,
-                after,
-                pairs,
-                ordered,
-                move_pairs,
-            )
-        )
-    return tuple(alignments)
+        shape_a, shape_b = shapes_a.get(key[1]), shapes_b.get(key[1])
+        if (
+            before
+            and after
+            and shape_a is not None
+            and shape_b is not None
+            and _shape_kind(shape_a) != _shape_kind(shape_b)
+        ):
+            hunks.append(_container_hunk(_shape_ref(shape_a), before, ()))
+            hunks.append(_container_hunk(_shape_ref(shape_b), (), after))
+            continue
+        reference = shape_b or shape_a
+        hunks.append(_container_hunk(_shape_ref(reference), before, after))
+    return tuple(hunks)
 
 
-def _single_text_event(kind, alignment, block_a, block_b) -> dict:
-    event = {
-        "kind": kind,
-        "shape": alignment.shape,
-        "before_location": _block_location(block_a) if block_a is not None else None,
-        "after_location": _block_location(block_b) if block_b is not None else None,
-        "before": block_a.text if block_a is not None else None,
-        "after": block_b.text if block_b is not None else None,
-    }
-    fields_a, fields_b = _field_markers(block_a), _field_markers(block_b)
-    if fields_a != fields_b:
-        event["field_types_before"] = [field_type for _, field_type in fields_a]
-        event["field_types_after"] = [field_type for _, field_type in fields_b]
-        event["fields_before"] = [
-            {"offset": offset, "type": field_type} for offset, field_type in fields_a
-        ]
-        event["fields_after"] = [
-            {"offset": offset, "type": field_type} for offset, field_type in fields_b
-        ]
-    return event
-
-
-def _ambiguity_event(alignment, before, after) -> dict:
-    def candidates(blocks):
-        return [{"location": _block_location(block), "text": block.text} for block in blocks]
-
+def _text_block_payload(block) -> dict:
+    """Return one exact block as regular v5 snapshot evidence."""
     return {
-        "kind": "ambiguity",
-        "shape": alignment.shape,
-        "before_location": None,
-        "after_location": None,
-        "before_candidates": candidates(before),
-        "after_candidates": candidates(after),
-        "reason": "repeated exact paragraph fingerprints do not establish correspondence",
+        "location": _block_location(block),
+        "text": block.text,
+        "fields": [
+            {"offset": offset, "type": field_type}
+            for offset, field_type in _field_markers(block)
+        ],
     }
 
 
-def _observable_sequence(blocks, detail, slide) -> tuple:
-    values = []
-    for block in blocks:
-        item = [block.text, _field_markers(block)]
-        if detail == "full" and block.container != "table-cell":
-            item.append(tuple((run.text, run.field_type, run.font.to_dict()) for run in block.runs))
-            bullet = _bullet_payload(_paragraph_by_block(slide, block))
-            item.append(bullet[1] if bullet is not None else None)
-        values.append(tuple(item))
-    return tuple(values)
-
-
-def _text_events(alignments, detail, slide_a, slide_b) -> "List[dict]":
-    """Classify exact pairs and conservative unmatched regions into v5 text events."""
+def _text_events(hunks) -> "List[dict]":
+    """Emit at most one canonical endpoint hunk for each stable text container."""
     events = []
-    for alignment in alignments:
-        paired_a = {i for i, _ in alignment.pairs}
-        paired_b = {j for _, j in alignment.pairs}
-        for index_a, index_b in alignment.move_pairs:
-            events.append(
-                _single_text_event(
-                    "move", alignment, alignment.before[index_a], alignment.after[index_b]
-                )
-            )
-        anchors = (
-            ((-1, -1),) + alignment.ordered_pairs + ((len(alignment.before), len(alignment.after)),)
+    for hunk in hunks:
+        start_a, end_a = hunk.before_range
+        start_b, end_b = hunk.after_range
+        before = hunk.before[start_a:end_a]
+        after = hunk.after[start_b:end_b]
+        if not before and not after:
+            continue
+        if not before:
+            kind = "insertion"
+        elif not after:
+            kind = "deletion"
+        elif len(before) == len(after) == 1:
+            kind = "replacement"
+        else:
+            kind = "changed_region"
+        events.append(
+            {
+                "kind": kind,
+                "shape": hunk.shape,
+                "before_range": {"start": start_a, "end": end_a},
+                "after_range": {"start": start_b, "end": end_b},
+                "before": [_text_block_payload(block) for block in before],
+                "after": [_text_block_payload(block) for block in after],
+            }
         )
-        for (left_a, left_b), (right_a, right_b) in zip(anchors, anchors[1:]):
-            before = tuple(
-                alignment.before[i] for i in range(left_a + 1, right_a) if i not in paired_a
-            )
-            after = tuple(
-                alignment.after[j] for j in range(left_b + 1, right_b) if j not in paired_b
-            )
-            if not before and not after:
-                continue
-            if not after:
-                events.extend(
-                    _single_text_event("deletion", alignment, block, None) for block in before
-                )
-            elif not before:
-                events.extend(
-                    _single_text_event("insertion", alignment, None, block) for block in after
-                )
-            elif len(before) == len(after) == 1:
-                events.append(_single_text_event("replacement", alignment, before[0], after[0]))
-            elif _observable_sequence(before, detail, slide_a) != _observable_sequence(
-                after, detail, slide_b
-            ):
-                events.append(_ambiguity_event(alignment, before, after))
-        for index_a, index_b in alignment.pairs:
-            if (index_a, index_b) in alignment.move_pairs:
-                continue
-            block_a, block_b = alignment.before[index_a], alignment.after[index_b]
-            if block_a.text != block_b.text or _field_markers(block_a) != _field_markers(block_b):
-                events.append(_single_text_event("replacement", alignment, block_a, block_b))
     return events
 
 
@@ -999,12 +966,30 @@ def _font_values(font) -> tuple:
     )
 
 
-def _effective_shifts(alignments) -> "Tuple[EffectiveShift, ...]":
-    """Formatting changes for uniquely identified runs in exactly aligned paragraphs."""
+def _unique_unchanged_pairs(hunk):
+    """Boundary pairs whose exact paragraph value is unique on both sides."""
+    values_a = tuple(_paragraph_value(block) for block in hunk.before)
+    values_b = tuple(_paragraph_value(block) for block in hunk.after)
+    counts_a = Counter(values_a)
+    counts_b = Counter(values_b)
+    start_a, end_a = hunk.before_range
+    start_b, end_b = hunk.after_range
+    boundaries = (
+        (range(start_a), range(start_b)),
+        (range(end_a, len(hunk.before)), range(end_b, len(hunk.after))),
+    )
+    for indexes_a, indexes_b in boundaries:
+        for index_a, index_b in zip(indexes_a, indexes_b):
+            if counts_a[values_a[index_a]] == counts_b[values_b[index_b]] == 1:
+                yield index_a, index_b
+
+
+def _effective_shifts(hunks) -> "Tuple[EffectiveShift, ...]":
+    """Formatting changes for unique unchanged boundary paragraphs and runs."""
     shifts = []
-    for alignment in alignments:
-        for index_a, index_b in alignment.pairs:
-            block_a, block_b = alignment.before[index_a], alignment.after[index_b]
+    for hunk in hunks:
+        for index_a, index_b in _unique_unchanged_pairs(hunk):
+            block_a, block_b = hunk.before[index_a], hunk.after[index_b]
             if block_a.container == "table-cell" or block_b.container == "table-cell":
                 continue
             runs_a = [(i, run) for i, run in enumerate(block_a.runs) if run.text != "\v"]
@@ -1029,7 +1014,7 @@ def _effective_shifts(alignments) -> "Tuple[EffectiveShift, ...]":
                 shifts.append(
                     EffectiveShift(
                         part=block_a.anchor.part,
-                        shape=alignment.shape,
+                        shape=hunk.shape,
                         before_location=_block_location(block_a),
                         after_location=_block_location(block_b),
                         before_run_index=run_index_a,
@@ -1075,12 +1060,12 @@ def _bullet_payload(paragraph):
     return values, payload
 
 
-def _bullet_shifts(slide_a, slide_b, alignments) -> "Tuple[BulletShift, ...]":
-    """Bullet changes driven by the same exact paragraph pairs as text and fonts."""
+def _bullet_shifts(slide_a, slide_b, hunks) -> "Tuple[BulletShift, ...]":
+    """Bullet changes for unique unchanged boundary paragraphs."""
     shifts = []
-    for alignment in alignments:
-        for index_a, index_b in alignment.pairs:
-            block_a, block_b = alignment.before[index_a], alignment.after[index_b]
+    for hunk in hunks:
+        for index_a, index_b in _unique_unchanged_pairs(hunk):
+            block_a, block_b = hunk.before[index_a], hunk.after[index_b]
             if block_a.container == "table-cell" or block_b.container == "table-cell":
                 continue
             before = _bullet_payload(_paragraph_by_block(slide_a, block_a))
@@ -1090,7 +1075,7 @@ def _bullet_shifts(slide_a, slide_b, alignments) -> "Tuple[BulletShift, ...]":
             shifts.append(
                 BulletShift(
                     part=block_a.anchor.part,
-                    shape=alignment.shape,
+                    shape=hunk.shape,
                     before_location=_block_location(block_a),
                     after_location=_block_location(block_b),
                     text=block_b.text,
@@ -1101,48 +1086,8 @@ def _bullet_shifts(slide_a, slide_b, alignments) -> "Tuple[BulletShift, ...]":
     return tuple(shifts)
 
 
-def _table_signature(table) -> tuple:
-    """Exact cell paragraph fingerprints arranged as a stable row/column grid."""
-    from pptx.inspect import _paragraph_fingerprint
-
-    return tuple(
-        tuple(
-            tuple(_paragraph_fingerprint(paragraph._p) for paragraph in cell.text_frame.paragraphs)
-            for cell in row.cells
-        )
-        for row in table.rows
-    )
-
-
-def _insertion_candidates(before, after, count) -> list:
-    return [
-        index
-        for index in range(len(after) - count + 1)
-        if after[:index] + after[index + count :] == before
-    ]
-
-
-def _dimension_change(before, after, axis) -> dict:
-    delta = len(after) - len(before)
-    kind = "insertion" if delta > 0 else "deletion"
-    count = abs(delta)
-    candidates = (
-        _insertion_candidates(before, after, count)
-        if delta > 0
-        else _insertion_candidates(after, before, count)
-    )
-    result = {"kind": kind, "count": count}
-    if len(candidates) == 1:
-        result["index"] = candidates[0]
-    else:
-        result["ambiguous"] = True
-        result["candidate_indexes"] = candidates
-        result["axis"] = axis
-    return result
-
-
 def _table_structure_changes(slide_a, slide_b) -> tuple:
-    """Return exact table-grid evidence for stable table-frame IDs."""
+    """Return factual dimensions for stable table-frame IDs."""
     shapes_a = {shape.shape_id: shape for shape in _iter_shape_tree(slide_a.shapes)}
     shapes_b = {shape.shape_id: shape for shape in _iter_shape_tree(slide_b.shapes)}
     changes = []
@@ -1160,13 +1105,6 @@ def _table_structure_changes(slide_a, slide_b) -> tuple:
             "before": {"rows": rows_a, "columns": cols_a},
             "after": {"rows": rows_b, "columns": cols_b},
         }
-        grid_a, grid_b = _table_signature(table_a), _table_signature(table_b)
-        if cols_a == cols_b and rows_a != rows_b:
-            change["row_change"] = _dimension_change(grid_a, grid_b, "row")
-        elif rows_a == rows_b and cols_a != cols_b:
-            columns_a = tuple(tuple(row[column] for row in grid_a) for column in range(cols_a))
-            columns_b = tuple(tuple(row[column] for row in grid_b) for column in range(cols_b))
-            change["column_change"] = _dimension_change(columns_a, columns_b, "column")
         changes.append(change)
     return tuple(changes)
 

--- a/tests/paper/goldens/lineage_v1_v2.diff.json
+++ b/tests/paper/goldens/lineage_v1_v2.diff.json
@@ -40,16 +40,34 @@
             "shape_id": 2,
             "name": "Title 1"
           },
-          "before_location": {
-            "container": "shape",
-            "paragraph_index": 0
+          "before_range": {
+            "start": 0,
+            "end": 1
           },
-          "after_location": {
-            "container": "shape",
-            "paragraph_index": 0
+          "after_range": {
+            "start": 0,
+            "end": 1
           },
-          "before": "Lineage slide one",
-          "after": "Lineage slide one, retitled"
+          "before": [
+            {
+              "location": {
+                "container": "shape",
+                "paragraph_index": 0
+              },
+              "text": "Lineage slide one",
+              "fields": []
+            }
+          ],
+          "after": [
+            {
+              "location": {
+                "container": "shape",
+                "paragraph_index": 0
+              },
+              "text": "Lineage slide one, retitled",
+              "fields": []
+            }
+          ]
         }
       ]
     },

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -616,7 +616,7 @@ def test_incompatible_shape_kind_reuse_is_removal_plus_addition():
     before = Presentation()
     slide = before.slides.add_slide(before.slide_layouts[6])
     box = slide.shapes.add_textbox(0, 0, 914400, 914400)
-    box.name = "Reused"
+    box.name = "Before text box"
     shape_id = box.shape_id
     before_bytes = _serialized(before)
 
@@ -626,19 +626,25 @@ def test_incompatible_shape_kind_reuse_is_removal_plus_addition():
     image = io.BytesIO()
     PILImage.new("RGB", (2, 2), (10, 20, 30)).save(image, format="PNG")
     picture = after_slide.shapes.add_picture(io.BytesIO(image.getvalue()), 0, 0)
-    picture.name = "Reused"
+    picture.name = "After picture"
     assert picture.shape_id == shape_id
 
     report = diff_decks(io.BytesIO(before_bytes), after, detail="text")
     change = report.slide_changes[0]
-    expected = (ShapeRef(shape_id=shape_id, name="Reused"),)
-    assert change.shapes_removed == expected
-    assert change.shapes_added == expected
+    assert change.shapes_removed == (
+        ShapeRef(shape_id=shape_id, name="Before text box"),
+    )
+    assert change.shapes_added == (
+        ShapeRef(shape_id=shape_id, name="After picture"),
+    )
     assert change.geometry_changes == ()
     assert change.images_replaced == ()
     assert change.chart_data_changes == ()
     assert len(change.text_changes) == 1
     assert change.text_changes[0]["kind"] == "deletion"
+    assert change.text_changes[0]["shape"] == ShapeRef(
+        shape_id=shape_id, name="Before text box"
+    )
     assert _event_texts(change.text_changes[0], "before") == [""]
     assert change.text_changes[0]["after"] == []
 

--- a/tests/paper/test_diff.py
+++ b/tests/paper/test_diff.py
@@ -16,7 +16,7 @@ import pytest
 from lxml import etree
 
 from pptx import Presentation
-from pptx.diff import ShapeRef, diff_decks
+from pptx.diff import ShapeRef, _common_boundary_ranges, diff_decks
 from pptx.errors import UnsupportedStructureError
 from pptx.oxml.ns import qn
 from pptx.util import Inches
@@ -81,13 +81,16 @@ def test_lineage_pair_reports_the_exact_edit_list():
     assert len(report.slides_moved) == 1  # -- one displacement (256<->257 tie, declared)
 
     changes = {change.slide_id: change for change in report.slide_changes}
-    assert changes[256].text_changes[0]["kind"] == "replacement"
-    assert changes[256].text_changes[0]["shape"] == ShapeRef(2, "Title 1")
-    assert changes[256].text_changes[0]["before_location"] == {
+    event = changes[256].text_changes[0]
+    assert event["kind"] == "replacement"
+    assert event["shape"] == ShapeRef(2, "Title 1")
+    assert event["before"][0]["location"] == {
         "container": "shape",
         "paragraph_index": 0,
     }
-    assert changes[256].text_changes[0]["after"] == "Lineage slide one, retitled"
+    assert event["before_range"] == {"start": 0, "end": 1}
+    assert event["after_range"] == {"start": 0, "end": 1}
+    assert event["after"][0]["text"] == "Lineage slide one, retitled"
     assert changes[257].notes_change == {
         "before": "Original notes for slide two.",
         "after": "Updated notes for slide two.",
@@ -455,11 +458,11 @@ def test_id_matching_contract_on_rebuilt_and_re_idd_decks():
     assert report.slides_added == ()
     assert report.slides_removed == ()
     changed_texts = [
-        (c["before"], c["after"])
+        ([block["text"] for block in c["before"]], [block["text"] for block in c["after"]])
         for change in report_text.slide_changes
         for c in change.text_changes
     ]
-    assert ("Minimal clean fixture", "Rebuilt title") in changed_texts
+    assert (["Minimal clean fixture"], ["Rebuilt title"]) in changed_texts
 
     # -- distinct ids: full replacement, never a spurious match
     rebuilt._element.sldIdLst.sldId_lst[0].set("id", "300")
@@ -634,6 +637,10 @@ def test_incompatible_shape_kind_reuse_is_removal_plus_addition():
     assert change.geometry_changes == ()
     assert change.images_replaced == ()
     assert change.chart_data_changes == ()
+    assert len(change.text_changes) == 1
+    assert change.text_changes[0]["kind"] == "deletion"
+    assert _event_texts(change.text_changes[0], "before") == [""]
+    assert change.text_changes[0]["after"] == []
 
 
 def test_incompatible_graphic_frame_payload_reuse_is_removal_plus_addition():
@@ -734,6 +741,10 @@ def _alignment_deck(paragraphs, rows=None):
     return prs
 
 
+def _event_texts(event, side):
+    return [block["text"] for block in event[side]]
+
+
 def _set_cell_paragraphs(cell, paragraphs):
     text_frame = cell.text_frame
     text_frame.paragraphs[0].text = paragraphs[0]
@@ -770,9 +781,33 @@ def _nest_alignment_text(prs, group_names):
 def test_paragraph_insertion_reports_only_the_inserted_block(before, after, location):
     report = diff_decks(_alignment_deck(before), _alignment_deck(after), detail="text")
     events = report.slide_changes[0].text_changes
-    assert [(event["kind"], event["after"]) for event in events] == [("insertion", "X")]
-    assert events[0]["before_location"] is None
-    assert events[0]["after_location"]["paragraph_index"] == location
+    assert [(event["kind"], _event_texts(event, "after")) for event in events] == [
+        ("insertion", ["X"])
+    ]
+    assert events[0]["before"] == []
+    assert events[0]["before_range"] == {"start": location, "end": location}
+    assert events[0]["after_range"] == {"start": location, "end": location + 1}
+    assert events[0]["after"][0]["location"]["paragraph_index"] == location
+    assert events[0]["after"][0]["fields"] == []
+
+
+@pytest.mark.parametrize(
+    ("before", "after", "location"),
+    [
+        (("X", "A", "B"), ("A", "B"), 0),
+        (("A", "X", "B"), ("A", "B"), 1),
+        (("A", "B", "X"), ("A", "B"), 2),
+    ],
+)
+def test_paragraph_deletion_reports_only_the_deleted_block(before, after, location):
+    event = diff_decks(
+        _alignment_deck(before), _alignment_deck(after), detail="text"
+    ).slide_changes[0].text_changes[0]
+    assert event["kind"] == "deletion"
+    assert _event_texts(event, "before") == ["X"]
+    assert event["after"] == []
+    assert event["before_range"] == {"start": location, "end": location + 1}
+    assert event["after_range"] == {"start": location, "end": location}
 
 
 def test_paragraph_deletion_and_bounded_replacement_do_not_cascade():
@@ -790,13 +825,18 @@ def test_paragraph_deletion_and_bounded_replacement_do_not_cascade():
         .slide_changes[0]
         .text_changes
     )
-    assert [(event["kind"], event["before"]) for event in deletion] == [("deletion", "drop")]
-    assert [(event["kind"], event["before"], event["after"]) for event in replacement] == [
-        ("replacement", "old", "new")
+    assert [(event["kind"], _event_texts(event, "before")) for event in deletion] == [
+        ("deletion", ["drop"])
+    ]
+    assert [
+        (event["kind"], _event_texts(event, "before"), _event_texts(event, "after"))
+        for event in replacement
+    ] == [
+        ("replacement", ["old"], ["new"])
     ]
 
 
-def test_unique_paragraph_reorder_is_exact_move_evidence():
+def test_paragraph_reorder_is_one_changed_region_without_move_claims():
     events = (
         diff_decks(
             _alignment_deck(("A", "B", "C")),
@@ -806,26 +846,28 @@ def test_unique_paragraph_reorder_is_exact_move_evidence():
         .slide_changes[0]
         .text_changes
     )
-    assert {event["kind"] for event in events} == {"move"}
-    assert {event["before"] for event in events} == {"A", "B"}
+    assert len(events) == 1
+    assert events[0]["kind"] == "changed_region"
+    assert _event_texts(events[0], "before") == ["A", "B"]
+    assert _event_texts(events[0], "after") == ["B", "A"]
 
 
-def test_unique_paragraph_at_same_location_is_not_reported_as_moved():
+def test_multiple_disjoint_changes_are_one_canonical_changed_region():
     events = (
         diff_decks(
-            _alignment_deck(("A", "B", "C")),
-            _alignment_deck(("C", "B", "A")),
+            _alignment_deck(("edge", "old one", "same", "old two", "tail")),
+            _alignment_deck(("edge", "new one", "same", "new two", "tail")),
             detail="text",
         )
         .slide_changes[0]
         .text_changes
     )
-
-    assert {(event["kind"], event["before"]) for event in events} == {
-        ("move", "A"),
-        ("move", "C"),
-    }
-    assert all(event["before_location"] != event["after_location"] for event in events)
+    assert len(events) == 1
+    assert events[0]["kind"] == "changed_region"
+    assert events[0]["before_range"] == {"start": 1, "end": 4}
+    assert events[0]["after_range"] == {"start": 1, "end": 4}
+    assert _event_texts(events[0], "before") == ["old one", "same", "old two"]
+    assert _event_texts(events[0], "after") == ["new one", "same", "new two"]
 
 
 def test_nested_group_text_alignment_uses_leaf_id_not_group_path():
@@ -838,18 +880,34 @@ def test_nested_group_text_alignment_uses_leaf_id_not_group_path():
     assert len(events) == 1
     assert events[0]["kind"] == "insertion"
     assert events[0]["shape"] == ShapeRef(2, "alignment_text")
-    assert events[0]["after_location"] == {"container": "group", "paragraph_index": 0}
+    assert events[0]["after"][0]["location"] == {
+        "container": "group",
+        "paragraph_index": 0,
+    }
 
 
-def test_repeated_region_is_ambiguous_only_when_observably_changed():
+def test_repeated_region_uses_prefix_first_canonical_replacement():
     before = _alignment_deck(("A", "same", "same", "B"))
     unchanged = _alignment_deck(("A", "same", "same", "B"))
     changed = _alignment_deck(("A", "same", "changed", "B"))
     assert diff_decks(before, unchanged, detail="text").slide_changes == ()
     events = diff_decks(before, changed, detail="text").slide_changes[0].text_changes
     assert len(events) == 1
-    assert events[0]["kind"] == "ambiguity"
-    assert events[0]["before_location"] is None
+    assert events[0]["kind"] == "replacement"
+    assert events[0]["before_range"] == {"start": 2, "end": 3}
+    assert _event_texts(events[0], "before") == ["same"]
+    assert _event_texts(events[0], "after") == ["changed"]
+
+
+def test_repeated_insertion_uses_longest_prefix_before_suffix():
+    events = diff_decks(
+        _alignment_deck(("same", "same")),
+        _alignment_deck(("same", "same", "same")),
+        detail="text",
+    ).slide_changes[0].text_changes
+    assert len(events) == 1
+    assert events[0]["kind"] == "insertion"
+    assert events[0]["after_range"] == {"start": 2, "end": 3}
 
 
 def test_repeated_exact_boundaries_can_establish_a_replacement():
@@ -862,23 +920,27 @@ def test_repeated_exact_boundaries_can_establish_a_replacement():
         .slide_changes[0]
         .text_changes
     )
-    assert [(event["kind"], event["before"], event["after"]) for event in events] == [
-        ("replacement", "old", "new")
+    assert [
+        (event["kind"], _event_texts(event, "before"), _event_texts(event, "after"))
+        for event in events
+    ] == [
+        ("replacement", ["old"], ["new"])
     ]
 
 
-def test_nfc_equivalent_text_aligns_but_whitespace_remains_content():
+def test_nfc_representation_and_whitespace_remain_content():
     nfc = diff_decks(
         _alignment_deck(("caf\N{LATIN SMALL LETTER E WITH ACUTE}",)),
         _alignment_deck(("cafe\N{COMBINING ACUTE ACCENT}",)),
         detail="text",
     )
-    assert nfc.slide_changes[0].text_changes[0]["kind"] == "replacement"
-    assert nfc.slide_changes[0].text_changes[0]["before_location"] == {
+    nfc_event = nfc.slide_changes[0].text_changes[0]
+    assert nfc_event["kind"] == "replacement"
+    assert nfc_event["before"][0]["location"] == {
         "container": "shape",
         "paragraph_index": 0,
     }
-    assert nfc.slide_changes[0].text_changes[0]["after_location"] == {
+    assert nfc_event["after"][0]["location"] == {
         "container": "shape",
         "paragraph_index": 0,
     }
@@ -890,29 +952,27 @@ def test_table_row_insertion_reports_grid_and_only_real_text_insertions():
     before = _alignment_deck(("stable",), (("Name", "Value"), ("Alpha", "10")))
     after = _alignment_deck(("stable",), (("Name", "Value"), ("New", "5"), ("Alpha", "10")))
     structure = diff_decks(before, after, detail="structure").slide_changes[0]
-    assert structure.table_structure_changes[0]["row_change"] == {
-        "kind": "insertion",
-        "count": 1,
-        "index": 1,
+    assert structure.table_structure_changes[0] == {
+        "table": ShapeRef(3, "alignment_table"),
+        "before": {"rows": 2, "columns": 2},
+        "after": {"rows": 3, "columns": 2},
     }
     assert structure.text_changes == ()
     text = diff_decks(before, after, detail="text").slide_changes[0]
-    assert {(event["kind"], event["after"]) for event in text.text_changes} == {
-        ("insertion", "New"),
-        ("insertion", "5"),
-    }
-    assert all(event["kind"] != "replacement" for event in text.text_changes)
+    assert len(text.text_changes) == 1
+    assert text.text_changes[0]["kind"] == "insertion"
+    assert _event_texts(text.text_changes[0], "after") == ["New", "5"]
+    assert [block["location"] for block in text.text_changes[0]["after"]] == [
+        {"container": "table-cell", "paragraph_index": 0, "row": 1, "column": 0},
+        {"container": "table-cell", "paragraph_index": 0, "row": 1, "column": 1},
+    ]
 
     deletion = diff_decks(after, before, detail="text").slide_changes[0]
-    assert deletion.table_structure_changes[0]["row_change"] == {
-        "kind": "deletion",
-        "count": 1,
-        "index": 1,
-    }
-    assert {(event["kind"], event["before"]) for event in deletion.text_changes} == {
-        ("deletion", "New"),
-        ("deletion", "5"),
-    }
+    assert deletion.table_structure_changes[0]["before"]["rows"] == 3
+    assert deletion.table_structure_changes[0]["after"]["rows"] == 2
+    assert len(deletion.text_changes) == 1
+    assert deletion.text_changes[0]["kind"] == "deletion"
+    assert _event_texts(deletion.text_changes[0], "before") == ["New", "5"]
 
 
 def test_table_column_insertion_and_deletion_keep_exact_cell_coordinates():
@@ -920,28 +980,27 @@ def test_table_column_insertion_and_deletion_keep_exact_cell_coordinates():
     wide = _alignment_deck(("stable",), (("A", "X", "B"), ("C", "Y", "D")))
 
     insertion = diff_decks(narrow, wide, detail="text").slide_changes[0]
-    assert insertion.table_structure_changes[0]["column_change"] == {
-        "kind": "insertion",
-        "count": 1,
-        "index": 1,
+    assert insertion.table_structure_changes[0] == {
+        "table": ShapeRef(3, "alignment_table"),
+        "before": {"rows": 2, "columns": 2},
+        "after": {"rows": 2, "columns": 3},
     }
-    assert {
-        (event["kind"], event["after"], event["after_location"]["row"],
-         event["after_location"]["column"])
-        for event in insertion.text_changes
-    } == {("insertion", "X", 0, 1), ("insertion", "Y", 1, 1)}
+    assert len(insertion.text_changes) == 1
+    assert insertion.text_changes[0]["kind"] == "changed_region"
+    assert _event_texts(insertion.text_changes[0], "before") == ["B", "C"]
+    assert _event_texts(insertion.text_changes[0], "after") == ["X", "B", "C", "Y"]
+    assert insertion.text_changes[0]["after"][0]["location"] == {
+        "container": "table-cell",
+        "paragraph_index": 0,
+        "row": 0,
+        "column": 1,
+    }
 
     deletion = diff_decks(wide, narrow, detail="text").slide_changes[0]
-    assert deletion.table_structure_changes[0]["column_change"] == {
-        "kind": "deletion",
-        "count": 1,
-        "index": 1,
-    }
-    assert {(event["kind"], event["before"]) for event in deletion.text_changes} == {
-        ("deletion", "X"),
-        ("deletion", "Y"),
-    }
-    assert all(event["kind"] != "replacement" for event in deletion.text_changes)
+    assert deletion.table_structure_changes[0]["before"]["columns"] == 3
+    assert deletion.table_structure_changes[0]["after"]["columns"] == 2
+    assert len(deletion.text_changes) == 1
+    assert deletion.text_changes[0]["kind"] == "changed_region"
 
 
 def test_multiple_paragraphs_in_one_table_cell_do_not_collide_with_other_cells_or_tables():
@@ -958,8 +1017,8 @@ def test_multiple_paragraphs_in_one_table_cell_do_not_collide_with_other_cells_o
     events = diff_decks(before, after, detail="text").slide_changes[0].text_changes
     assert len(events) == 1
     assert events[0]["kind"] == "insertion"
-    assert events[0]["after"] == "new"
-    assert events[0]["after_location"] == {
+    assert _event_texts(events[0], "after") == ["new"]
+    assert events[0]["after"][0]["location"] == {
         "container": "table-cell",
         "paragraph_index": 1,
         "row": 0,
@@ -976,9 +1035,10 @@ def test_grouped_table_uses_leaf_shape_identity_for_grid_and_text():
     change = diff_decks(before, after, detail="text").slide_changes[0]
     grid = change.table_structure_changes[0]
     assert grid["table"] == ShapeRef(3, "alignment_table")
-    assert grid["column_change"]["index"] == 1
-    assert [(event["kind"], event["after"]) for event in change.text_changes] == [
-        ("insertion", "X")
+    assert grid["before"] == {"rows": 1, "columns": 2}
+    assert grid["after"] == {"rows": 1, "columns": 3}
+    assert [(event["kind"], _event_texts(event, "after")) for event in change.text_changes] == [
+        ("insertion", ["X"])
     ]
     assert change.text_changes[0]["shape"] == ShapeRef(3, "alignment_table")
 
@@ -995,12 +1055,18 @@ def test_added_or_removed_table_has_no_matched_grid_change():
     assert removed.table_structure_changes == ()
 
 
-def test_ambiguous_blank_table_row_does_not_invent_an_index():
+def test_duplicate_blank_table_row_reports_only_factual_dimensions():
     before = _alignment_deck(("stable",), (("", ""), ("", "")))
     after = _alignment_deck(("stable",), (("", ""), ("", ""), ("", "")))
-    grid = diff_decks(before, after).slide_changes[0].table_structure_changes[0]
-    assert grid["row_change"]["ambiguous"] is True
-    assert grid["row_change"]["candidate_indexes"] == [0, 1, 2]
+    change = diff_decks(before, after, detail="text").slide_changes[0]
+    assert change.table_structure_changes[0] == {
+        "table": ShapeRef(3, "alignment_table"),
+        "before": {"rows": 2, "columns": 2},
+        "after": {"rows": 3, "columns": 2},
+    }
+    assert len(change.text_changes) == 1
+    assert change.text_changes[0]["kind"] == "insertion"
+    assert change.text_changes[0]["after_range"] == {"start": 4, "end": 6}
 
 
 def test_effective_and_bullet_shifts_follow_exact_alignment_after_insertion():
@@ -1021,6 +1087,75 @@ def test_effective_and_bullet_shifts_follow_exact_alignment_after_insertion():
     assert bullet.after_location["paragraph_index"] == 2
 
 
+def test_repeated_paragraphs_cannot_create_false_full_detail_shifts():
+    before = _alignment_deck(("same", "same"))
+    before_paragraph = before.slides[0].shapes[0].text_frame.paragraphs[1]
+    before_paragraph.runs[0].font.bold = True
+    before_paragraph.bullet.set_character("•")
+
+    after = _alignment_deck(("same", "same", "same"))
+    after_paragraph = after.slides[0].shapes[0].text_frame.paragraphs[2]
+    after_paragraph.runs[0].font.bold = True
+    after_paragraph.bullet.set_character("•")
+
+    change = diff_decks(before, after, detail="full").slide_changes[0]
+    assert change.text_changes[0]["kind"] == "insertion"
+    assert change.effective_shifts == ()
+    assert change.bullet_shifts == ()
+
+
+def test_changed_region_has_no_specialized_formatting_correspondence():
+    before = _alignment_deck(("old",))
+    after = _alignment_deck(("new",))
+    after.slides[0].shapes[0].text_frame.paragraphs[0].runs[0].font.bold = True
+
+    change = diff_decks(before, after, detail="full").slide_changes[0]
+    assert change.text_changes[0]["kind"] == "replacement"
+    assert change.effective_shifts == ()
+    assert change.bullet_shifts == ()
+
+
+def test_run_splitting_does_not_create_a_text_event():
+    before = _alignment_deck(("AB",))
+    after = _alignment_deck(("",))
+    paragraph = after.slides[0].shapes[0].text_frame.paragraphs[0]
+    paragraph.add_run().text = "A"
+    paragraph.add_run().text = "B"
+
+    report = diff_decks(before, after, detail="text")
+    assert report.slide_changes == ()
+
+
+def test_boundary_scan_uses_linear_equality_operations():
+    class ComparableText:
+        comparisons = 0
+
+        def __init__(self, value):
+            self.value = value
+
+        def __eq__(self, other):
+            type(self).comparisons += 1
+            return self.value == other.value
+
+    class Block:
+        def __init__(self, value):
+            self.text = ComparableText(value)
+            self.runs = ()
+
+    for size in (8, 64, 512):
+        identical_a = tuple(Block(index) for index in range(size))
+        identical_b = tuple(Block(index) for index in range(size))
+        ComparableText.comparisons = 0
+        assert _common_boundary_ranges(identical_a, identical_b) == ((size, size), (size, size))
+        assert ComparableText.comparisons <= size + 1
+
+        different_a = tuple(Block(("a", index)) for index in range(size))
+        different_b = tuple(Block(("b", index)) for index in range(size))
+        ComparableText.comparisons = 0
+        assert _common_boundary_ranges(different_a, different_b) == ((0, size), (0, size))
+        assert ComparableText.comparisons <= 2 * size + 2
+
+
 def test_table_effective_and_bullet_formatting_remain_out_of_scope():
     before = _alignment_deck(("stable",), (("cell",),))
     after = _alignment_deck(("stable",), (("cell",),))
@@ -1036,12 +1171,12 @@ def test_table_effective_and_bullet_formatting_remain_out_of_scope():
 def test_frozen_alignment_pair_preserves_real_changes_without_cascade():
     report = diff_decks(_path(ALIGN_V1), _path(ALIGN_V2), detail="text")
     change = report.slide_changes[0]
-    assert change.table_structure_changes[0]["row_change"]["index"] == 1
-    assert {(event["kind"], event["after"]) for event in change.text_changes} == {
-        ("insertion", "Inserted paragraph"),
-        ("insertion", "New"),
-        ("insertion", "5"),
-    }
+    assert change.table_structure_changes[0]["before"] == {"rows": 2, "columns": 2}
+    assert change.table_structure_changes[0]["after"] == {"rows": 3, "columns": 2}
+    assert [(event["kind"], _event_texts(event, "after")) for event in change.text_changes] == [
+        ("insertion", ["Inserted paragraph"]),
+        ("insertion", ["New", "5"]),
+    ]
 
 
 # ------------------------------------------------------------- regressions
@@ -1056,11 +1191,11 @@ def test_trailing_whitespace_edit_is_a_reported_text_change():
         detail="text",
     )
     deltas = [
-        (c["before"], c["after"])
+        (_event_texts(c, "before"), _event_texts(c, "after"))
         for change in report.slide_changes
         for c in change.text_changes
     ]
-    assert ("Trailing space ", "Trailing space") in deltas
+    assert (["Trailing space "], ["Trailing space"]) in deltas
 
 
 def test_field_type_change_is_reported_when_visible_text_is_unchanged():
@@ -1079,9 +1214,9 @@ def test_field_type_change_is_reported_when_visible_text_is_unchanged():
 
     report = diff_decks(io.BytesIO(before.getvalue()), changed, detail="text")
     change = report.slide_changes[0].text_changes[0]
-    assert change["before"] == change["after"] == ""
-    assert change["field_types_before"] == ["slidenum"]
-    assert change["field_types_after"] == ["datetime1"]
+    assert _event_texts(change, "before") == _event_texts(change, "after") == [""]
+    assert change["before"][0]["fields"] == [{"offset": 0, "type": "slidenum"}]
+    assert change["after"][0]["fields"] == [{"offset": 0, "type": "datetime1"}]
 
 
 def test_field_movement_is_reported_without_false_formatting_shifts():
@@ -1105,8 +1240,8 @@ def test_field_movement_is_reported_without_false_formatting_shifts():
     report = diff_decks(before, after, detail="full")
     change = report.slide_changes[0].text_changes[0]
 
-    assert change["fields_before"] == [{"offset": 5, "type": "slidenum"}]
-    assert change["fields_after"] == [{"offset": 0, "type": "slidenum"}]
+    assert change["before"][0]["fields"] == [{"offset": 5, "type": "slidenum"}]
+    assert change["after"][0]["fields"] == [{"offset": 0, "type": "slidenum"}]
     assert report.slide_changes[0].effective_shifts == ()
 
 
@@ -1162,9 +1297,9 @@ def test_shape_removal_does_not_misattribute_later_blocks():
     diff = diff_decks(_path("self_generated/gauntlet.pptx"), prs_b, detail="full")
     change = next(c for c in diff.slide_changes)
     assert ShapeRef(shape_id=2, name="Title 1") in change.shapes_removed
-    # -- the title's block reads as removed (after=None); the body blocks are untouched
+    # -- the title's block reads as removed (after=[]); the body blocks are untouched
     for delta in change.text_changes:
-        assert delta["after"] is None, delta
+        assert delta["after"] == [], delta
     assert change.effective_shifts == ()  # -- no phantom shifts from index slippage
 
 

--- a/tests/paper/test_walkthrough_pitchbook.py
+++ b/tests/paper/test_walkthrough_pitchbook.py
@@ -156,11 +156,12 @@ def test_pitchbook_self_consistency_against_deck_diff(tmp_path):
     # -- the footer pass shows on every ORIGINAL slide as added text blocks
     for slide_id, change in changes.items():
         if change.text_changes:
-            assert all(c["before"] is None for c in change.text_changes), (
+            assert all(c["before"] == [] for c in change.text_changes), (
                 "unexpected edits to library content on slide %d" % slide_id
             )
             assert any(
-                c["after"] == "Paper Pitch Book" for c in change.text_changes
+                any(block["text"] == "Paper Pitch Book" for block in c["after"])
+                for c in change.text_changes
             ), "footer text missing on slide %d" % slide_id
 
 

--- a/tests/paper/test_walkthrough_qbr.py
+++ b/tests/paper/test_walkthrough_qbr.py
@@ -256,10 +256,10 @@ def test_walkthrough_self_consistency_against_deck_diff(tmp_path):
     assert any(
         c["kind"] == "replacement"
         and c["shape"]["shape_id"] == 2
-        and c["before_location"] == {"container": "shape", "paragraph_index": 0}
-        and c["after_location"] == {"container": "shape", "paragraph_index": 0}
-        and c["before"] == "Gauntlet: branded"
-        and c["after"] == "Q4 Business Review"
+        and c["before"][0]["location"] == {"container": "shape", "paragraph_index": 0}
+        and c["after"][0]["location"] == {"container": "shape", "paragraph_index": 0}
+        and c["before"][0]["text"] == "Gauntlet: branded"
+        and c["after"][0]["text"] == "Q4 Business Review"
         for c in retitled.to_dict()["text_changes"]
     )
     # -- the chart update replace_data_safe performed, per series/category


### PR DESCRIPTION
## Summary

- replace PR #45 paragraph every-optimal-LCS, global move inference, and ambiguity reconstruction with one deterministic prefix/suffix-bounded snapshot hunk per stable container
- report exact regular v5 arrays, half-open ranges, block locations, raw text, and field markers without claiming paragraph history
- report factual table dimensions without guessing row or column insertion indexes
- limit full-detail formatting and bullet pairing to unique unchanged boundary paragraphs
- update the public contract, regression coverage, golden output, and superseded planning/review guidance

## Why

PR #45 fixes the real ordinal-cascade bug, but its current implementation also attempts to reconstruct paragraph identity and table edit history that ordinary PPTX does not preserve. This stacked PR is the deliberately simpler alternative: it keeps stable slide/shape/container identity, fixes insertion and deletion cascades, and reports only endpoint facts that can be proven from the two snapshots.

This PR is based directly on PR #45 so reviewers can compare the two implementations in isolation.

## Verification

- 3,864 pytest cases passed; 1 skipped
- 54 Behave features / 974 scenarios passed
- 61 LibreOffice smoke cases passed
- Sphinx documentation build passed with warnings as errors
- Ruff and git diff checks passed
- paper-pptx 0.2.0 distribution build and strict Twine checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking schema-v5 payload change for `diff_decks` consumers (text events, table structure, full-detail pairing). Matching still uses lineage IDs; the risk is contract/consumer breakage rather than security.
> 
> **Overview**
> **`diff_decks` now reports deterministic snapshot hunks, not reconstructed edit history.** Within each stable text container it consumes the longest exact prefix then suffix and emits at most one `insertion`, `deletion`, one-paragraph `replacement`, or `changed_region`. Paragraph `move`/`ambiguity` events are gone.
> 
> Schema v5 text events use half-open `before_range`/`after_range` plus array `before`/`after` blocks (`location`, raw `text`, positioned `fields`). Absent sides are `[]`. Duplicate content uses a prefix-first location; it does not claim historical identity.
> 
> Tables report only before/after row and column counts. Full-detail font and bullet shifts apply only to unique unchanged prefix/suffix paragraphs (and unique runs). Docs, goldens, and tests follow the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cff0f478f9a2a908193b2c7fa3570e6eb0d6ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies paragraph and table comparison in `pptx.diff.diff_decks()` to one deterministic snapshot hunk per stable container, bounded by the longest equal prefix and suffix. Replaces LCS pairing, paragraph move/ambiguity events, and inferred table indexes with factual ranges and per-block evidence; incompatible shape-kind ID reuse now yields separate text deletion and insertion hunks that each preserve their side’s `shape` reference.

- Updates schema v5: replace `before_location`/`after_location` with half-open `before_range`/`after_range`; `before`/`after` are arrays of blocks, each with `location`, `text`, and `fields`; an absent side is `[]`.
- Emits only `insertion`, `deletion`, one-paragraph `replacement`, or `changed_region`; paragraph reorders are `changed_region`. Duplicate text uses a prefix-first tie rule; no paragraph identity is inferred.
- Unmatched text containers emit a whole-container `insertion`/`deletion` and are never paired; incompatible shape-kind reuse of an ID produces separate deletion and insertion hunks, each with its side’s `shape`.
- Table structure changes report only before/after row and column counts; no inferred row/column indexes. Row-major text hunks use snapshot coordinates; column growth can produce one broader `changed_region`.
- Limits `detail="full"` to unique unchanged boundary paragraphs and uniquely identified runs; changed regions, repeats, and table cells do not produce specialized shifts.
- Refreshes docs, tests, and goldens to the new contract; `notes_change` and `package_changes` behavior is unchanged.

<sup>Written for commit 5cff0f478f9a2a908193b2c7fa3570e6eb0d6ef1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

