### PR TITLE
Add strict slide-layout name lookup

### DIFF
--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -298,6 +298,11 @@ slide still uses::
             if not layout.used_by_slides:
                 master.slide_layouts.remove(layout)
 
+When a layout name will drive an edit, use
+:meth:`~pptx.slide.SlideLayouts.get_unique_by_name`. Layout names can repeat; the strict lookup
+refuses missing or duplicate matches and lets the agent choose explicitly. The inherited
+:meth:`~pptx.slide.SlideLayouts.get_by_name` remains first-match for upstream compatibility.
+
 Verify what changed
 -------------------
 

--- a/docs/user/paper-additions.rst
+++ b/docs/user/paper-additions.rst
@@ -300,8 +300,9 @@ slide still uses::
 
 When a layout name will drive an edit, use
 :meth:`~pptx.slide.SlideLayouts.get_unique_by_name`. Layout names can repeat; the strict lookup
-refuses missing or duplicate matches and lets the agent choose explicitly. The inherited
-:meth:`~pptx.slide.SlideLayouts.get_by_name` remains first-match for upstream compatibility.
+refuses missing or duplicate matches and lets the agent choose explicitly.
+:meth:`~pptx.slide.SlideLayouts.get_by_name` remains available when intentionally selecting the
+first matching layout is acceptable.
 
 Verify what changed
 -------------------

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -843,11 +843,41 @@ class SlideLayouts(ParentedElementProxy):
         return len(self._sldLayoutIdLst)
 
     def get_by_name(self, name: str, default: SlideLayout | None = None) -> SlideLayout | None:
-        """Return SlideLayout object having `name`, or `default` if not found."""
+        """Return the first layout named `name`, or `default` when none is found.
+
+        This preserves the upstream first-match contract. Use :meth:`get_unique_by_name` when the
+        result will drive an edit and duplicate layout names must be surfaced rather than guessed.
+        """
         for slide_layout in self:
             if slide_layout.name == name:
                 return slide_layout
         return default
+
+    def get_unique_by_name(self, name: str) -> SlideLayout:
+        """Return the only layout named `name`; refuse when zero or multiple layouts match.
+
+        Use this for mutation targeting because layout names are not required to be unique. A
+        missing name raises |TargetNotFoundError| and duplicates raise |AmbiguousTargetError|;
+        resolve ambiguity by selecting a layout explicitly by index or partname.
+        """
+        from pptx.errors import AmbiguousTargetError, TargetNotFoundError
+
+        matches = [
+            (idx, slide_layout)
+            for idx, slide_layout in enumerate(self)
+            if slide_layout.name == name
+        ]
+        if not matches:
+            raise TargetNotFoundError("no slide layout in this master is named %r" % name)
+        if len(matches) > 1:
+            candidates = ", ".join(
+                "%d (%s)" % (idx, slide_layout.part.partname) for idx, slide_layout in matches
+            )
+            raise AmbiguousTargetError(
+                "%d slide layouts in this master are named %r; candidates: %s; select the "
+                "intended layout explicitly by index or partname" % (len(matches), name, candidates)
+            )
+        return matches[0][1]
 
     def index(self, slide_layout: SlideLayout) -> int:
         """Return zero-based index of `slide_layout` in this collection.

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -845,8 +845,8 @@ class SlideLayouts(ParentedElementProxy):
     def get_by_name(self, name: str, default: SlideLayout | None = None) -> SlideLayout | None:
         """Return the first layout named `name`, or `default` when none is found.
 
-        This preserves the upstream first-match contract. Use :meth:`get_unique_by_name` when the
-        result will drive an edit and duplicate layout names must be surfaced rather than guessed.
+        Layout names need not be unique, and this method does not detect duplicates. Use
+        :meth:`get_unique_by_name` when selecting a layout for an edit.
         """
         for slide_layout in self:
             if slide_layout.name == name:
@@ -856,9 +856,10 @@ class SlideLayouts(ParentedElementProxy):
     def get_unique_by_name(self, name: str) -> SlideLayout:
         """Return the only layout named `name`; refuse when zero or multiple layouts match.
 
-        Use this for mutation targeting because layout names are not required to be unique. A
-        missing name raises |TargetNotFoundError| and duplicates raise |AmbiguousTargetError|;
-        resolve ambiguity by selecting a layout explicitly by index or partname.
+        Use this when a name selects the layout for creating, importing, or rebinding a slide. A
+        missing name raises |TargetNotFoundError| and duplicate names raise
+        |AmbiguousTargetError|; resolve ambiguity by selecting a layout explicitly by index or
+        partname.
         """
         from pptx.errors import AmbiguousTargetError, TargetNotFoundError
 

--- a/tests/paper/test_import.py
+++ b/tests/paper/test_import.py
@@ -437,7 +437,7 @@ def test_bake_uses_unique_blank_only_after_name_and_type_are_absent():
 # ----------------------------------------------------------- unique layout selection
 
 
-def test_strict_layout_name_lookup_refuses_duplicates_without_changing_upstream_lookup():
+def test_strict_layout_name_lookup_refuses_duplicates_without_changing_first_match_lookup():
     dest = _open(ALPHA)
     first = dest.slide_layouts[0]
     duplicate = dest.slide_layouts[1]

--- a/tests/paper/test_import.py
+++ b/tests/paper/test_import.py
@@ -437,6 +437,22 @@ def test_bake_uses_unique_blank_only_after_name_and_type_are_absent():
 # ----------------------------------------------------------- unique layout selection
 
 
+def test_strict_layout_name_lookup_refuses_duplicates_without_changing_upstream_lookup():
+    dest = _open(ALPHA)
+    first = dest.slide_layouts[0]
+    duplicate = dest.slide_layouts[1]
+    duplicate.name = first.name
+
+    assert dest.slide_layouts.get_by_name(first.name) is first
+    with pytest.raises(AmbiguousTargetError) as exc_info:
+        dest.slide_layouts.get_unique_by_name(first.name)
+
+    message = str(exc_info.value)
+    assert "0 (%s)" % first.part.partname in message
+    assert "1 (%s)" % duplicate.part.partname in message
+    assert "explicitly by index or partname" in message
+
+
 def test_duplicate_layout_name_on_one_master_refuses_and_explicit_target_recovers():
     dest = _open(ALPHA)
     source = _open(BETA)

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -8,6 +8,7 @@ import pytest
 
 from pptx.dml.fill import FillFormat
 from pptx.enum.shapes import PP_PLACEHOLDER
+from pptx.errors import AmbiguousTargetError, TargetNotFoundError
 from pptx.package import Package
 from pptx.parts.presentation import PresentationPart
 from pptx.parts.slide import SlideLayoutPart, SlideMasterPart, SlidePart
@@ -804,6 +805,45 @@ class DescribeSlideLayouts(object):
         # ---but default can be specified---
         slide_layout = slide_layouts.get_by_name("pick me!", "default-value")
         assert slide_layout == "default-value"
+
+    def it_can_find_the_unique_slide_layout_by_name(self, _iter_, slide_layout_, slide_layout_2_):
+        _iter_.return_value = iter((slide_layout_, slide_layout_2_))
+        slide_layout_.name = "not this one"
+        slide_layout_2_.name = "pick me!"
+        slide_layouts = SlideLayouts(None, None)
+
+        slide_layout = slide_layouts.get_unique_by_name("pick me!")
+
+        assert slide_layout is slide_layout_2_
+
+    def but_it_refuses_when_no_slide_layout_has_that_name(
+        self, _iter_, slide_layout_, slide_layout_2_
+    ):
+        _iter_.return_value = iter((slide_layout_, slide_layout_2_))
+        slide_layout_.name = "one"
+        slide_layout_2_.name = "two"
+        slide_layouts = SlideLayouts(None, None)
+
+        with pytest.raises(TargetNotFoundError, match="no slide layout.*pick me!"):
+            slide_layouts.get_unique_by_name("pick me!")
+
+    def but_it_refuses_duplicate_slide_layout_names_with_actionable_candidates(
+        self, _iter_, slide_layout_, slide_layout_2_
+    ):
+        _iter_.return_value = iter((slide_layout_, slide_layout_2_))
+        slide_layout_.name = slide_layout_2_.name = "Duplicate"
+        slide_layout_.part.partname = "/ppt/slideLayouts/slideLayout1.xml"
+        slide_layout_2_.part.partname = "/ppt/slideLayouts/slideLayout2.xml"
+        slide_layouts = SlideLayouts(None, None)
+
+        with pytest.raises(AmbiguousTargetError) as exc_info:
+            slide_layouts.get_unique_by_name("Duplicate")
+
+        message = str(exc_info.value)
+        assert "2 slide layouts" in message
+        assert "0 (/ppt/slideLayouts/slideLayout1.xml)" in message
+        assert "1 (/ppt/slideLayouts/slideLayout2.xml)" in message
+        assert "explicitly by index or partname" in message
 
     def it_knows_the_index_of_each_of_its_slide_layouts(
         self, _iter_, slide_layout_, slide_layout_2_


### PR DESCRIPTION
## Summary

- add `SlideLayouts.get_unique_by_name()` for mutation-safe exact-name lookup
- raise typed not-found and ambiguity refusals, with candidate indices and partnames for explicit recovery
- preserve upstream `get_by_name()` first-match/default behavior and point its docstring to the strict alternative
- document the choice and cover both unit and real-package duplicate-layout behavior

## Verification

- `3870 passed, 1 skipped` (full pytest suite)
- `974 scenarios passed` (full Behave suite)
- `151 passed` (focused slide/import suites)
- Sphinx HTML build passed with warnings as errors
- Ruff checks passed for changed source and tests (excluding pre-existing lint findings in touched legacy test files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API with unchanged first-match lookup; typed errors improve safety for layout-driven edits without touching import/auth paths in this diff.
> 
> **Overview**
> Adds **`SlideLayouts.get_unique_by_name()`** for mutation-safe layout selection when a name must identify exactly one layout. It raises **`TargetNotFoundError`** if nothing matches and **`AmbiguousTargetError`** if several share the name, listing candidate **indices and partnames** so callers can pick by index or partname instead of guessing.
> 
> **`get_by_name()`** behavior is unchanged (first match or default); its docstring now warns that names need not be unique and points to the strict helper. User docs in **paper-additions** describe when to use each lookup. Unit and import contract tests cover missing names, duplicates, and that **`get_by_name`** still returns the first match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05f2eef0de81503e08bc7a9f0b65e5c858e9efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict slide-layout name lookup to `pptx.slide.SlideLayouts` to prevent accidental edits when layout names repeat. Old behavior: `get_by_name` returned the first match or a default; new behavior keeps that and adds `get_unique_by_name` that enforces a single match.

- `get_unique_by_name` raises `TargetNotFoundError` when none match and `AmbiguousTargetError` when multiple match; messages list candidate indices and partnames for explicit selection.
- Updates `get_by_name` docstring and user docs to steer edit scenarios to the strict lookup; tests cover duplicate-name cases and confirm `get_by_name` remains first-match.

<sup>Written for commit d05f2eef0de81503e08bc7a9f0b65e5c858e9efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/paper-instruments/paper-pptx/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

